### PR TITLE
Bumped boost to filesystem version 3, and changed a single usage of file...

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,9 @@ set(Boost_USE_STATIC_LIBS        ON)
 set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
 
-# The boost version is not tested, but should be OK according to documentation. Tested with 1.45.0
-find_package(Boost 1.36.0 COMPONENTS filesystem date_time system unit_test_framework REQUIRED)
-
+# Requires BOOST filesystem version 3, thus 1.44 is necessary.
+add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
+find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_framework REQUIRED)
 
 include_directories(${PROJECT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -45,26 +45,23 @@ namespace Opm {
         return deck;
     }
 
-
     size_t Parser::size() const {
         return m_parserKeywords.size();
     }
-    
-    
+
     void Parser::addKeyword(ParserKeywordConstPtr parserKeyword) {
         m_parserKeywords.insert(std::make_pair(parserKeyword->getName(), parserKeyword));
     }
-    
+
     bool Parser::hasKeyword(const std::string& keyword) const {
         return m_parserKeywords.find(keyword) != m_parserKeywords.end();
     }
 
-   ParserKeywordConstPtr Parser::getKeyword(const std::string& keyword) const {
-       if (hasKeyword(keyword)) {
-           return m_parserKeywords.at(keyword);
-       }
-   }
-
+    ParserKeywordConstPtr Parser::getKeyword(const std::string& keyword) const {
+        if (hasKeyword(keyword)) {
+            return m_parserKeywords.at(keyword);
+        }
+    }
 
     void Parser::parseFile(DeckPtr deck, const std::string &file, bool parseStrict) const {
         std::ifstream inputstream;
@@ -121,8 +118,6 @@ namespace Opm {
             throw std::invalid_argument("Input JSON object is not an array");
     }
 
-
-            
     RawKeywordPtr Parser::createRawKeyword(const DeckConstPtr deck, const std::string& keywordString, bool strictParsing) const {
         if (hasKeyword(keywordString)) {
             ParserKeywordConstPtr parserKeyword = m_parserKeywords.find(keywordString)->second;
@@ -191,8 +186,8 @@ namespace Opm {
 
         try {
             Json::JsonObject jsonKeyword(configFile);
-            ParserKeywordConstPtr parserKeyword( new ParserKeyword( jsonKeyword ));
-            addKeyword( parserKeyword );
+            ParserKeywordConstPtr parserKeyword(new ParserKeyword(jsonKeyword));
+            addKeyword(parserKeyword);
             return true;
         } catch (...) {
             return false;
@@ -200,18 +195,17 @@ namespace Opm {
 
     }
 
-
     void Parser::loadKeywordsFromDirectory(const boost::filesystem::path& directory, bool recursive, bool onlyALLCAPS8) {
         if (!boost::filesystem::exists(directory))
             throw std::invalid_argument("Directory: " + directory.string() + " does not exist.");
         else {
             boost::filesystem::directory_iterator end;
-            for (boost::filesystem::directory_iterator iter(directory) ; iter != end; iter++) {
-                if (is_directory(*iter)) {
+            for (boost::filesystem::directory_iterator iter(directory); iter != end; iter++) {
+                if (boost::filesystem::is_directory(*iter)) {
                     if (recursive)
-                        loadKeywordsFromDirectory(*iter , recursive , onlyALLCAPS8);
+                        loadKeywordsFromDirectory(*iter, recursive, onlyALLCAPS8);
                 } else {
-                    if (ParserKeyword::validName( iter->path().filename()) || !onlyALLCAPS8 ) {
+                    if (ParserKeyword::validName(iter->path().filename().string()) || !onlyALLCAPS8) {
                         if (!loadKeywordFromFile(*iter))
                             std::cerr << "** Warning: failed to load keyword from file:" << iter->path() << std::endl;
                     }
@@ -219,7 +213,6 @@ namespace Opm {
             }
         }
     }
-    
 
     void Parser::populateDefaultKeywords() {
         addKeyword(ParserKeywordConstPtr(new ParserKeyword("GRIDUNIT", 1)));


### PR DESCRIPTION
...name(), which has changed from string to path in filesystem v 3

... and some free ( :-( ) formatting changes
