### PR TITLE
Handle INCLUDE keywords

### DIFF
--- a/opm/parser/eclipse/IntegrationTests/CMakeLists.txt
+++ b/opm/parser/eclipse/IntegrationTests/CMakeLists.txt
@@ -12,6 +12,11 @@ target_link_libraries(runParseWCONHIST Parser ${Boost_LIBRARIES})
 add_test(NAME runParseWCONHIST WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH} COMMAND runParseWCONHIST)
 
 
+add_executable(runIncludeTest IncludeTest.cpp)
+target_link_libraries(runIncludeTest Parser ${Boost_LIBRARIES})
+add_test(NAME runIncludeTest WORKING_DIRECTORY ${EXECUTABLE_OUTPUT_PATH} COMMAND runIncludeTest)
+
+
 add_executable(runParseEQUIL ParseEQUIL.cpp)
 target_link_libraries(runParseEQUIL Parser ${Boost_LIBRARIES})
 add_test(NAME runParseEQUIL 

--- a/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
@@ -1,0 +1,117 @@
+/*
+ Copyright 2013 Statoil ASA.
+
+ This file is part of the Open Porous Media project (OPM).
+
+ OPM is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OPM is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE ParserIntegrationTests
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+#include <boost/filesystem.hpp>
+#include <ostream>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParserRecord.hpp>
+#include <opm/parser/eclipse/Parser/ParserIntItem.hpp>
+#include <opm/parser/eclipse/Parser/ParserStringItem.hpp>
+
+#include <opm/parser/eclipse/Parser/ParserEnums.hpp>
+
+using namespace Opm;
+using namespace boost::filesystem;
+
+void
+createDeckWithInclude(path& datafile)
+{
+    path root = unique_path("/tmp/%%%%-%%%%");
+    path absoluteInclude = root / "absolute.include";
+    path includePath = root / "include";
+
+    create_directories(root);
+    create_directories(includePath);
+
+        {
+            datafile = root / "TEST.DATA";
+
+            std::ofstream of(datafile.string().c_str());
+
+            of << "INCLUDE" << std::endl;
+            of << "   \'relative.include\' /" << std::endl;
+
+            of << std::endl;
+
+            of << "INCLUDE" << std::endl;
+            of << "   \'" << absoluteInclude.string() << "\' /" << std::endl;
+
+            of << std::endl;
+
+            of << "INCLUDE" << std::endl;
+            of << "  \'include/nested.include\'   /" << std::endl;
+
+            of.close();
+        }
+        {
+            std::ofstream of(absoluteInclude.string().c_str());
+
+            of << "DIMENS" << std::endl;
+            of << "   10 20 30 /" << std::endl;
+            of.close();
+        }
+
+        {
+            path relativeInclude = root / "relative.include";
+            std::ofstream of(relativeInclude.string().c_str());
+
+            of << "START" << std::endl;
+            of << "   10 'FEB' 2012 /" << std::endl;
+            of.close();
+        }
+
+        {
+            path nestedInclude = includePath / "nested.include";
+            path gridInclude = includePath / "grid.include";
+            std::ofstream of(nestedInclude.string().c_str());
+
+            of << "INCLUDE" << std::endl;
+            of << "   \'include/grid.include\'  /" << std::endl;
+            of.close();
+
+            std::ofstream of2(gridInclude.string().c_str());
+            of2 << "GRIDUNIT" << std::endl;
+            of2 << "/" << std::endl;
+            of2.close();
+        }
+
+
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
+    path datafile;
+    ParserPtr parser(new Parser());
+    parser->loadKeywordsFromDirectory(KEYWORD_DIRECTORY);
+    createDeckWithInclude (datafile);
+    DeckConstPtr deck = parser->parse(datafile.string());
+
+    BOOST_CHECK( deck->hasKeyword("DIMENS"));
+    BOOST_CHECK( deck->hasKeyword("START"));
+    BOOST_CHECK( deck->hasKeyword("GRIDUNIT"));
+}
+

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -60,8 +60,7 @@ namespace Opm {
     private:
         std::map<std::string, ParserKeywordConstPtr> m_parserKeywords;
         bool tryParseKeyword(const DeckConstPtr deck ,  std::ifstream& inputstream , RawKeywordPtr& rawKeyword, bool strictParsing) const;
-        void parseFile(DeckPtr deck , const std::string &file, bool strictParsing) const;
-        boost::filesystem::path verifyValidInputPath(const std::string& inputPath) const;
+        void parseFile(DeckPtr deck , const boost::filesystem::path& file, const boost::filesystem::path& rootPath, bool strictParsing) const;
         void populateDefaultKeywords();
         RawKeywordPtr createRawKeyword(const DeckConstPtr deck , const std::string& keywordString, bool strictParsing) const;
 


### PR DESCRIPTION
This PR has changed INCLUDE behaviour:
1. Will work correctly with absolute include paths.
2. Handles nested includes as ECLIPSE - i.e. everything is relative to the location of the input .DATA file.
