### PR TITLE
Fix find module for cjson library

### DIFF
--- a/cmake/Modules/Findcjson.cmake
+++ b/cmake/Modules/Findcjson.cmake
@@ -4,6 +4,8 @@
 #       CJSON_INCLUDE_DIRS      Header file directories
 #       CJSON_LIBRARIES         Archive/shared objects
 
+include (FindPackageHandleStandardArgs)
+
 if (CJSON_ROOT)
   set (_no_default_path "NO_DEFAULT_PATH")
 else (CJSON_ROOT)


### PR DESCRIPTION
Some small issues prevented the cjson library from being found if located in an out-of-tree build.
