### PR TITLE
Provide find module for OPM Parser library

### DIFF
--- a/cmake/Modules/Findopm-parser.cmake
+++ b/cmake/Modules/Findopm-parser.cmake
@@ -9,6 +9,8 @@
 #	OPM_PARSER_INCLUDE_DIRS      Header file directories
 #	OPM_PARSER_LIBRARIES         Archives and shared objects
 
+include (FindPackageHandleStandardArgs)
+
 # variables to pass on to other packages
 if (FIND_QUIETLY)
   set (OPM_PARSER_QUIET "QUIET")


### PR DESCRIPTION
Searches for headers and objects of the library as well as finding the prerequisites (Boost and CJSON) necessary to link a program.

This find module is intended to use in _client_ programs/libraries of opm-parser. Note that this requires the find modules from #34 to work correctly.
