### PR TITLE
Change unintended compile-time polymorphism to dynamic

### DIFF
--- a/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
@@ -96,9 +96,11 @@ namespace Opm
 //        return deckItem;
 //    }
 
-    bool ParserDoubleItem::equal(const ParserDoubleItem& other) const
+    bool ParserDoubleItem::equal(const ParserItem& other) const
     {
-        if (ParserItem::equal(other) && (getDefault() == other.getDefault()))
+        // cast to a pointer to avoid bad_cast exception
+        const ParserDoubleItem* rhs = dynamic_cast<const ParserDoubleItem*>(&other);
+        if (rhs && ParserItem::equal(other) && (getDefault() == rhs->getDefault()))
             return true;
         else
             return false;

--- a/opm/parser/eclipse/Parser/ParserDoubleItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserDoubleItem.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         ParserDoubleItem( const Json::JsonObject& jsonConfig);
 
         DeckItemConstPtr scan(RawRecordPtr rawRecord) const;
-        bool equal(const ParserDoubleItem& other) const;
+        bool equal(const ParserItem& other) const;
         void inlineNew(std::ostream& os) const;
         void setDefault(double defaultValue);
         double getDefault() const {

--- a/opm/parser/eclipse/Parser/ParserIntItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserIntItem.cpp
@@ -108,9 +108,11 @@ namespace Opm {
     }
 
 
-    bool ParserIntItem::equal(const ParserIntItem& other) const
+    bool ParserIntItem::equal(const ParserItem& other) const
     {
-        if (ParserItem::equal(other) && (getDefault() == other.getDefault()))
+        // cast to a pointer to avoid bad_cast exception
+        const ParserIntItem* rhs = dynamic_cast<const ParserIntItem*>(&other);
+        if (rhs && ParserItem::equal(other) && (getDefault() == rhs->getDefault()))
             return true;
         else
             return false;

--- a/opm/parser/eclipse/Parser/ParserIntItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserIntItem.hpp
@@ -40,7 +40,7 @@ namespace Opm {
         ParserIntItem(const Json::JsonObject& jsonConfig);
 
         DeckItemConstPtr scan(RawRecordPtr rawRecord) const;
-        bool equal(const ParserIntItem& other) const;
+        bool equal(const ParserItem& other) const;
         void inlineNew(std::ostream& os) const;
         
         void setDefault(int defaultValue);

--- a/opm/parser/eclipse/Parser/ParserStringItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserStringItem.cpp
@@ -110,9 +110,11 @@ namespace Opm {
     }
      
      
-    bool ParserStringItem::equal(const ParserStringItem& other) const
+    bool ParserStringItem::equal(const ParserItem& other) const
     {
-        if (ParserItem::equal(other) && (getDefault() == other.getDefault()))
+        // cast to a pointer to avoid bad_cast exception
+        const ParserStringItem* rhs = dynamic_cast<const ParserStringItem*>(&other);
+        if (rhs && ParserItem::equal(other) && (getDefault() == rhs->getDefault()))
             return true;
         else
             return false;

--- a/opm/parser/eclipse/Parser/ParserStringItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserStringItem.hpp
@@ -36,7 +36,7 @@ namespace Opm {
         ParserStringItem(const std::string& itemName, const std::string& defaultValue);
         ParserStringItem( const Json::JsonObject& jsonConfig);
 
-        bool equal(const ParserStringItem& other) const;
+        bool equal(const ParserItem& other) const;
         DeckItemConstPtr scan(RawRecordPtr rawRecord) const;
         void inlineNew(std::ostream& os) const;
         void setDefault(const std::string& defaultValue);


### PR DESCRIPTION
equals(ParserIntItem&) has a different signature than equals(ParserItem&),
thus the former method does _not_ overload the latter. Virtual just means
then only means that you have created a _new_ entry in the v-table. If
you call equals through a pointer/reference to the base class ParserItem,
the defined method in the derived class is not called, and we miss out the
test for the equal default value.

Instead, we should take an argument of the base type and use a dynamic
cast to the derived type. If this downcast fails, then they are not equal;
otherwise we have gotten ourselves a pointer to get the properly typed
default value.

We must use pointers instead of references; if we cast to a reference,
a bad_cast exception is thrown if the expression is not in the proper
type hierarchy.
