### PR TITLE
Trimming right side of each read line, to avoid line ending problems.

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
@@ -243,10 +244,11 @@ namespace Opm {
 
     bool Parser::tryParseKeyword(const DeckConstPtr deck, const std::string& filename , size_t& lineNR , std::ifstream& inputstream, RawKeywordPtr& rawKeyword, bool strictParsing) const {
         std::string line;
+
         while (std::getline(inputstream, line)) {
+            boost::algorithm::trim_right(line); // Removing garbage (eg. \r)
             std::string keywordString;
             lineNR++;
-            
             if (rawKeyword == NULL) {
                 if (RawKeyword::tryParseKeyword(line, keywordString)) {
                     rawKeyword = createRawKeyword(deck, filename , lineNR , keywordString, strictParsing);

--- a/opm/parser/eclipse/RawDeck/StarToken.cpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.cpp
@@ -20,7 +20,7 @@
 #include <string>
 #include <iostream>
 #include <stdexcept>
-
+#include <boost/lexical_cast.hpp>
 #include <opm/parser/eclipse/RawDeck/StarToken.hpp>
 
 
@@ -34,25 +34,26 @@ namespace Opm {
             return true;
     }
 
-
   
     template <>
     int readValueToken(const std::string& valueToken) {
-        char * error_ptr;
-        int value = strtol( valueToken.c_str() , &error_ptr , 10);
-        if (error_ptr[0] != C_EOS)
-            throw std::invalid_argument("Parsing integer value from: " + valueToken + " failed");
-        return value;
+        try {
+            return boost::lexical_cast<int>(valueToken);
+        }
+        catch (boost::bad_lexical_cast&) {
+            throw std::invalid_argument("Unable to parse string" + valueToken + " to an integer");
+        }
     }
     
 
     template <>
     double readValueToken(const std::string& valueToken) {
-        char * error_ptr;
-        double value = strtod( valueToken.c_str() , &error_ptr);
-        if (error_ptr[0] != C_EOS)
-            throw std::invalid_argument("Parsing double value from: " + valueToken + " failed");
-        return value;
+        try {
+            return boost::lexical_cast<double>(valueToken);
+        }
+        catch (boost::bad_lexical_cast&) {
+            throw std::invalid_argument("Unable to parse string " + valueToken + " to a double");
+        }
     }
 
 


### PR DESCRIPTION
Removed C style parsing of numbers, using boost::lexical_cast instead.
