### PR TITLE
rename Parser::parse to Parser::parseFile and add Parser::parseData

### DIFF
--- a/opm/parser/eclipse/Applications/Schedule.cpp
+++ b/opm/parser/eclipse/Applications/Schedule.cpp
@@ -14,7 +14,7 @@
 int main(int argc, char** argv) {
     Opm::ParserPtr parser(new Opm::Parser());
     std::string file = argv[1];
-    Opm::DeckConstPtr deck = parser->parse(file, false);
+    Opm::DeckConstPtr deck = parser->parseFile(file, false);
     Opm::Schedule sched( deck );
     
     std::cout << "Wells: " << sched.numWells() << std::endl;

--- a/opm/parser/eclipse/Applications/opm-eclkwtest.cpp
+++ b/opm/parser/eclipse/Applications/opm-eclkwtest.cpp
@@ -68,7 +68,7 @@ int main(int argc, char** argv) {
 
     Opm::ParserPtr parser(new Opm::Parser());
     std::string file = argv[1];
-    Opm::DeckConstPtr deck = parser->parse(file, true);
+    Opm::DeckConstPtr deck = parser->parseFile(file, true);
     
     printDeckDiagnostics(deck, printKeywords);
 

--- a/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromRecord ) {
 
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMPDAT1");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     DeckKeywordConstPtr COMPDAT1 = deck->getKeyword("COMPDAT" , 0);
     DeckRecordConstPtr line0 = COMPDAT1->getRecord(0);
     DeckRecordConstPtr line1 = COMPDAT1->getRecord(1);
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromKeyword ) {
 
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMPDAT1");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     DeckKeywordConstPtr COMPDAT1 = deck->getKeyword("COMPDAT" , 1);
     
     std::map< std::string , std::vector<CompletionConstPtr> > completions = Completion::completionsFromCOMPDATKeyword( COMPDAT1 );

--- a/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
@@ -107,7 +107,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     path datafile;
     ParserPtr parser(new Parser());
     createDeckWithInclude (datafile);
-    DeckConstPtr deck = parser->parse(datafile.string());
+    DeckConstPtr deck =  parser->parseFile(datafile.string());
 
     BOOST_CHECK( deck->hasKeyword("DIMENS"));
     BOOST_CHECK( deck->hasKeyword("START"));

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -52,13 +52,13 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     ParserPtr parser = createWWCTParser();
     BOOST_CHECK( parser->canParseKeyword("WWCT"));
     BOOST_CHECK( parser->canParseKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(DeckPtr deck = parser->parse(singleKeywordFile.string()));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseFile(singleKeywordFile.string()));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/wwct.data");
     ParserPtr parser = createWWCTParser();
-    DeckPtr deck = parser->parse(singleKeywordFile.string());
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string());
     BOOST_CHECK(deck->hasKeyword("SUMMARY"));
     BOOST_CHECK(deck->hasKeyword("WWCT"));
 }
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_dataIsCorrect) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/wwct.data");
     ParserPtr parser = createWWCTParser();
-    DeckPtr deck = parser->parse(singleKeywordFile.string());
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string());
     BOOST_CHECK_EQUAL("WELL-1", deck->getKeyword("WWCT" , 0)->getRecord(0)->getItem(0)->getString(0));
     BOOST_CHECK_EQUAL("WELL-2", deck->getKeyword("WWCT" , 0)->getRecord(0)->getItem(0)->getString(1));
 }
@@ -90,14 +90,14 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_deckReturned) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/bpr.data");
     ParserPtr parser = createBPRParser();
 
-    BOOST_CHECK_NO_THROW(DeckPtr deck = parser->parse(singleKeywordFile.string()));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseFile(singleKeywordFile.string()));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_DeckhasBRP) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/bpr.data");
 
     ParserPtr parser = createBPRParser();
-    DeckPtr deck = parser->parse(singleKeywordFile.string());
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string());
 
     BOOST_CHECK_EQUAL(true, deck->hasKeyword("BPR"));
 }
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/bpr.data");
 
     ParserPtr parser = createBPRParser();
-    DeckPtr deck = parser->parse(singleKeywordFile.string());
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string());
 
     DeckKeywordConstPtr keyword = deck->getKeyword("BPR" , 0);
     BOOST_CHECK_EQUAL(2U, keyword->size());
@@ -155,7 +155,7 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
 /***************** Testing non-recognized keywords ********************/
 BOOST_AUTO_TEST_CASE(parse_unknownkeywordWithnonstrictparsing_keywordmarked) {
     ParserPtr parser(new Parser());
-    DeckPtr deck = parser->parse("testdata/integration_tests/someobscureelements.data", false);
+    DeckPtr deck =  parser->parseFile("testdata/integration_tests/someobscureelements.data", false);
     BOOST_CHECK_EQUAL(4U, deck->size());
     DeckKeywordConstPtr unknown = deck->getKeyword("GRUDINT");
     BOOST_CHECK(!unknown->isKnown());
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(parse_unknownkeywordWithnonstrictparsing_keywordmarked) {
 
 BOOST_AUTO_TEST_CASE(parse_unknownkeywordWithstrictparsing_exceptionthrown) {
     ParserPtr parser(new Parser());
-    BOOST_CHECK_THROW(parser->parse("testdata/integration_tests/someobscureelements.data", true), std::invalid_argument);
+    BOOST_CHECK_THROW( parser->parseFile("testdata/integration_tests/someobscureelements.data", true), std::invalid_argument);
 }
 
 /*********************Testing truncated (default) records ***************************/
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(parse_unknownkeywordWithstrictparsing_exceptionthrown) {
 // Datafile contains 3 RADFIN4 keywords. One fully specified, one with 2 out of 11 items, and one with no items.
 BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {
     ParserPtr parser(new Parser());
-    DeckPtr deck = parser->parse("testdata/integration_tests/truncated_records.data");
+    DeckPtr deck =  parser->parseFile("testdata/integration_tests/truncated_records.data");
     BOOST_CHECK_EQUAL(4U, deck->size());
     DeckKeywordConstPtr radfin4_0_full= deck->getKeyword("RADFIN4", 0);
     DeckKeywordConstPtr radfin4_1_partial= deck->getKeyword("RADFIN4", 1);

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTestsInternalData.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTestsInternalData.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(ParseFileWithManyKeywords) {
     boost::filesystem::path multipleKeywordFile("testdata/statoil/gurbat_trimmed.DATA");
 
     ParserPtr parser(new Parser());
-    DeckPtr deck = parser->parse(multipleKeywordFile.string() , false);
+    DeckPtr deck =  parser->parseFile(multipleKeywordFile.string() , false);
     SchedulePtr schedule(new Schedule(deck));
     
     GroupTreePtr treeAtStart = schedule->getGroupTree(0);

--- a/opm/parser/eclipse/IntegrationTests/ParseACTION.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseACTION.cpp
@@ -50,10 +50,10 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
     BOOST_REQUIRE( parser->canParseKeyword( "WCONHIST" ));
     BOOST_REQUIRE( parser->canParseKeyword( "THROW" ));
     
-    BOOST_REQUIRE_THROW( parser->parse( actionFile2.string() , false) , std::invalid_argument );
+    BOOST_REQUIRE_THROW(  parser->parseFile( actionFile2.string() , false) , std::invalid_argument );
     
                        
-    DeckPtr deck = parser->parse(actionFile.string() , false);
+    DeckPtr deck =  parser->parseFile(actionFile.string() , false);
     DeckKeywordConstPtr kw1 = deck->getKeyword("WCONHIST" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1->size() );
 

--- a/opm/parser/eclipse/IntegrationTests/ParseDENSITY.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseDENSITY.cpp
@@ -40,7 +40,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(ParseDENSITY) {
     ParserPtr parser(new Parser());
     boost::filesystem::path file("testdata/integration_tests/DENSITY/DENSITY1");
-    DeckPtr deck = parser->parse(file.string());
+    DeckPtr deck =  parser->parseFile(file.string());
     DeckKeywordPtr densityKw = deck->getKeyword("DENSITY" , 0);
 
     

--- a/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
@@ -38,7 +38,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_EQUIL_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path pvtgFile("testdata/integration_tests/EQUIL/EQUIL1");
-    DeckPtr deck = parser->parse(pvtgFile.string());
+    DeckPtr deck =  parser->parseFile(pvtgFile.string());
     DeckKeywordConstPtr kw0 = deck->getKeyword("EQLDIMS" , 0);
     DeckKeywordConstPtr kw1 = deck->getKeyword("EQUIL" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1->size() );

--- a/opm/parser/eclipse/IntegrationTests/ParsePORO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePORO.cpp
@@ -38,7 +38,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(ParsePOROandPERMX) {
     ParserPtr parser(new Parser());
     boost::filesystem::path poroFile("testdata/integration_tests/PORO/PORO1");
-    DeckPtr deck = parser->parse(poroFile.string());
+    DeckPtr deck =  parser->parseFile(poroFile.string());
     DeckKeywordConstPtr kw1 = deck->getKeyword("PORO" , 0);
     DeckKeywordPtr kw2 = deck->getKeyword("PERMX" , 0);
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
@@ -22,7 +22,7 @@ using namespace Opm;
 void check_parser(ParserPtr parser) {
 
     boost::filesystem::path pvtgFile("testdata/integration_tests/PVTG/PVTG.txt");
-    DeckPtr deck = parser->parse(pvtgFile.string());
+    DeckPtr deck =  parser->parseFile(pvtgFile.string());
     DeckKeywordConstPtr kw1 = deck->getKeyword("PVTG" , 0);
     BOOST_CHECK_EQUAL(5U , kw1->size());
 

--- a/opm/parser/eclipse/IntegrationTests/ParseRSVD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseRSVD.cpp
@@ -38,7 +38,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_EQUIL_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path pvtgFile("testdata/integration_tests/RSVD/RSVD.txt");
-    DeckPtr deck = parser->parse(pvtgFile.string());
+    DeckPtr deck =  parser->parseFile(pvtgFile.string());
     DeckKeywordConstPtr kw1 = deck->getKeyword("RSVD" , 0);
     BOOST_CHECK_EQUAL( 6U , kw1->size() );
 

--- a/opm/parser/eclipse/IntegrationTests/ParseTVDP.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTVDP.cpp
@@ -37,7 +37,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(ParseTVDP) {
     ParserPtr parser(new Parser());
     boost::filesystem::path poroFile("testdata/integration_tests/TVDP/TVDP1");
-    DeckPtr deck = parser->parse(poroFile.string());
+    DeckPtr deck =  parser->parseFile(poroFile.string());
 
     BOOST_CHECK_EQUAL( false , deck->hasKeyword("TVDP*"));
     BOOST_CHECK( deck->hasKeyword("TVDPA"));

--- a/opm/parser/eclipse/IntegrationTests/ParseTVPD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTVPD.cpp
@@ -37,7 +37,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(AddDataKeywordFromJson_correctlyConfigured) {
     ParserPtr parser(new Parser());
     boost::filesystem::path poroFile("testdata/integration_tests/TVPD/TVPD1");
-    DeckPtr deck = parser->parse(poroFile.string());
+    DeckPtr deck =  parser->parseFile(poroFile.string());
 
     BOOST_CHECK( deck->hasKeyword("TVDPA"));
     BOOST_CHECK( deck->hasKeyword("TVDP1"));

--- a/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE( parse_VFPPROD_OK ) {
     boost::filesystem::path file("testdata/integration_tests/VFPPROD/VFPPROD1");
     BOOST_CHECK( parser->canParseKeyword("VFPPROD"));
 
-    DeckPtr deck = parser->parse(file.string());
+    DeckPtr deck =  parser->parseFile(file.string());
 
     DeckKeywordConstPtr VFPPROD1 = deck->getKeyword("VFPPROD" , 0);
     DeckKeywordConstPtr BPR = deck->getKeyword("BPR" , 0);

--- a/opm/parser/eclipse/IntegrationTests/ParseWCONHIST.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWCONHIST.cpp
@@ -38,7 +38,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_WCHONHIST_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path wconhistFile("testdata/integration_tests/WCONHIST/WCONHIST1");
-    DeckPtr deck = parser->parse(wconhistFile.string());
+    DeckPtr deck =  parser->parseFile(wconhistFile.string());
     DeckKeywordConstPtr kw1 = deck->getKeyword("WCONHIST" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1->size() );
 

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
 
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE1");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
     TimeMapConstPtr timeMap = sched->getTimeMap();
     BOOST_CHECK_EQUAL(boost::gregorian::date(2007, boost::gregorian::May, 10), sched->getStartDate());
@@ -49,7 +49,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
 
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMMENTS_AFTER_KEYWORDS");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
     TimeMapConstPtr timeMap = sched->getTimeMap();
     BOOST_CHECK_EQUAL(boost::gregorian::date(2007, boost::gregorian::May, 10), sched->getStartDate());
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
 BOOST_AUTO_TEST_CASE(WellTesting) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS2");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
 
     BOOST_CHECK_EQUAL(3U, sched->numWells());
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS2");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
 
     BOOST_CHECK_EQUAL(3U, sched->numWells());
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_with_explicit_L0_parenting) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GRUPTREE_EXPLICIT_PARENTING");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
 
     GroupTreeNodePtr rootNode = sched->getGroupTree(0)->getNode("FIELD");
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_with_explicit_L0_parenting) {
 BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr schedule(new Schedule(deck));
 
     // Time 0, only from WELSPECS
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
 BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GROUPS_REPARENT");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr schedule(new Schedule(deck));
 
     schedule->getGroupTree(0)->printTree();
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
 BOOST_AUTO_TEST_CASE(GroupTreeTest_PrintGrouptree) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
 
     GroupTreePtr rootNode = sched->getGroupTree(0);
@@ -254,7 +254,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_PrintGrouptree) {
 BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GROUPS");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched( new Schedule(deck));
     
     BOOST_CHECK_EQUAL( 3U , sched->numGroups() );
@@ -290,7 +290,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
 BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS_AND_GROUPS");
-    DeckPtr deck = parser->parse(scheduleFile.string());
+    DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched( new Schedule(deck));
 
     GroupPtr group1 = sched->getGroup("GROUP1");

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -46,8 +46,8 @@ namespace Opm {
         Parser(bool addDefault = true);
 
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
-        DeckPtr parse(const std::string &dataFile) const;
-        DeckPtr parse(const std::string &dataFile, bool strictParsing) const;
+        DeckPtr parseFile(const std::string &dataFile, bool strictParsing=true) const;
+        DeckPtr parseString(const std::string &data, bool strictParsing=true) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addKeyword(ParserKeywordConstPtr parserKeyword);
@@ -71,7 +71,7 @@ namespace Opm {
         ParserKeywordConstPtr matchingKeyword(const std::string& keyword) const;
 
         bool tryParseKeyword(std::shared_ptr<ParserState> parserState) const;
-        void parseFile(std::shared_ptr<ParserState> parserState) const;
+        void parseStream(std::shared_ptr<ParserState> parserState) const;
         RawKeywordPtr createRawKeyword(const std::string& keywordString, std::shared_ptr<ParserState> parserState) const;
         void addDefaultKeywords();
 


### PR DESCRIPTION
Parser::parseData is quite useful for unit tests to prevent them
spilling files to everything. Also, what was formerly
Parser::parseFile has been renamed to Parser::parseStream and slightly
modified to not be specific for std::ifstream.

finally, the "strict" argument of this method is now defaulting to "true" instead
of doing the same thing using a separate method.
