### PR TITLE
avoid coverting the data of a deck item to SI multiple times

### DIFF
--- a/opm/parser/eclipse/Deck/DeckDoubleItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckDoubleItem.cpp
@@ -40,6 +40,10 @@ namespace Opm {
 
     void DeckDoubleItem::assertSIData() const {
         if (m_dimensions.size() > 0) {
+            if (m_SIdata.size() > 0) {
+                // we already converted this item to SI!
+                return;
+            }
             m_SIdata.resize( m_data.size() );
             if (m_dimensions.size() == 1) {
                 double SIfactor = m_dimensions[0]->getSIScaling();


### PR DESCRIPTION
This resulted in _quadratic_ complexity if data points where retrieved
one-by-one. For the Norne case, this had the consequence that
retrieving the data for ZCORN (-> about 1M data points) took hours...
