### PR TITLE
remove the "MATRIX_COMPRESSIBILITY" from ROCK

### DIFF
--- a/opm/parser/share/keywords/R/ROCK
+++ b/opm/parser/share/keywords/R/ROCK
@@ -1,4 +1,3 @@
 {"name" : "ROCK" , "size" : {"keyword":"TABDIMS" , "item":"NTPVT"}, "items" : [
         {"name" : "PREF"  , "value_type" : "FLOAT" , "default" : 1.0132 , "dimension" : "P"},
-        {"name" : "COMPRESSIBILITY" , "value_type" : "FLOAT" , "default" : 0 , "dimension" : "1/P"},
-        {"name" : "MATRIX_COMPRESSIBILITY" , "value_type" : "FLOAT" , "default" : 0 , "dimension" : "1/P"}]}
+        {"name" : "COMPRESSIBILITY" , "value_type" : "FLOAT" , "default" : 0 , "dimension" : "1/P"}]}


### PR DESCRIPTION
This field is specific to the Eclipse 300 geomechanics module. IMHO,
either all fields for the eclipse 300 geomechanics module should be
added or none. Adapting the table code to "partially defined" keywords
is a pain I'd rather avoid!
