### PR TITLE
Added missing files from the Utility folder to the CMakeLists file.

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -144,6 +144,12 @@ Utility/GruptreeWrapper.hpp
 Utility/WelspecsWrapper.hpp
 Utility/PvtgOuterTable.hpp
 Utility/EquilWrapper.hpp
+Utility/EndscaleWrapper.hpp
+Utility/ScalecrsWrapper.hpp
+Utility/EnptvdTable.hpp
+Utility/EnkrvdTable.hpp
+Utility/RocktabTable.hpp
+Utility/RockTable.hpp
 )
 
 add_library(buildParser ${rawdeck_source} ${build_parser_source} ${deck_source} ${unit_source})


### PR DESCRIPTION
Currently opm-core's opm-parser-integrate branch does not build if you install files.
