### PR TITLE
Uniform parser 'prereqs' file

### DIFF
--- a/cmake/Modules/opm-parser-prereqs.cmake
+++ b/cmake/Modules/opm-parser-prereqs.cmake
@@ -14,6 +14,6 @@ set (opm-parser_DEPS
 	"CXX10Features REQUIRED"
 	# various runtime library enhancements
 	"Boost 1.44.0
-		COMPONENTS date_time filesystem system unit_test_framework REQUIRED"
+		COMPONENTS date_time filesystem system iostream unit_test_framework REQUIRED"
 	"cJSON"
 	)


### PR DESCRIPTION
This change-set applies a few white-space adjustments to `cmake/Modules/opm-parser-prereqs.cmake` in order to blend in with the conventions of other `*-prereqs.cmake` files under the OPM umbrella.

Furthermore, we also install a component search for Boost.Iostreams.  Although superfluous for the purpose of opm-parser, this enables using the same `opm-parser-prereqs.cmake` file in all modules.  The requirement for Boost.Iostreams comes from the (far removed) downstream module opm-benchmarks which uses Boost.Iostreams to handle (GZip) compressed input streams.

I appreciate that this is contentious.

Tested on (Debug and Release modes):
- Ubuntu 12.04 LTS x86_64 (CMake 2.8.7, GCC 4.6.3, Boost 1.46.1)
- CentOS 5.10 x86_64 (CMake 2.8.10.1, GCC 4.4.7, Boost 1.48)
