### PR TITLE
Suppress unused argument warnings.

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -38,35 +38,34 @@ namespace Opm {
 
         virtual size_t size() const = 0;
         
-        virtual int getInt(size_t index) const {
+        virtual int getInt(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support int");
         }
 
-        virtual float getSIFloat(size_t index) const {
+        virtual float getSIFloat(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support float");
         }
 
-        virtual float getRawFloat(size_t index) const {
+        virtual float getRawFloat(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support float");
         }
 
-        virtual double getSIDouble(size_t index) const {
+        virtual double getSIDouble(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support double");
         }
 
-        virtual double getRawDouble(size_t index) const {
+        virtual double getRawDouble(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support double");
         }
 
-        virtual bool getBool(size_t index) const {
+        virtual bool getBool(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support bool");
         }
 
-        virtual std::string getString(size_t index) const {
+        virtual std::string getString(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support string");
         }
 
-        
 
         virtual const std::vector<int>& getIntData( ) const {
             throw std::logic_error("This implementation of DeckItem does not support int");
@@ -84,7 +83,8 @@ namespace Opm {
             throw std::logic_error("This implementation of DeckItem does not support string");
         }
 
-        virtual void push_backDimension(std::shared_ptr<const Dimension> activeDimension , std::shared_ptr<const Dimension> defaultDimension) {
+        virtual void push_backDimension(std::shared_ptr<const Dimension> /* activeDimension */,
+                                        std::shared_ptr<const Dimension> /* defaultDimension */) {
             throw std::invalid_argument("Should not be here - internal error ...");
         }
 

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -58,7 +58,7 @@ namespace Opm {
         static double defaultDouble();
       
         virtual bool equal(const ParserItem& other) const;
-        virtual void inlineNew(std::ostream& os) const {}
+        virtual void inlineNew(std::ostream& /* os */) const {}
       
         virtual ~ParserItem() {
         }

--- a/opm/parser/eclipse/Utility/SimpleTable.hpp
+++ b/opm/parser/eclipse/Utility/SimpleTable.hpp
@@ -46,9 +46,9 @@ namespace Opm {
                     size_t firstEntityOffset = 0);
 
         // constructor to make the base class compatible with specialized table implementations
-        SimpleTable(Opm::DeckKeywordConstPtr keyword,
-                    size_t recordIdx = 0,
-                    size_t firstEntityOffset = 0)
+        SimpleTable(Opm::DeckKeywordConstPtr /* keyword */,
+                    size_t /* recordIdx = 0 */,
+                    size_t /* firstEntityOffset = 0 */)
         {
             throw std::logic_error("The base class of simple tables can't be "
                                    "instantiated without specifying columns!");


### PR DESCRIPTION
This suppression has been done in the way I feel is least intrusive, by using C-style comments around the argument names.
