### PR TITLE
Explicitly set the output path for bin/ and lib/ output from the build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,10 @@ else()
 endif()
 
 
+set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
+set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
+
+
 add_subdirectory(opm/json)
 add_subdirectory(opm/parser)
 


### PR DESCRIPTION
This PR should facilitate finding opm-parser as a sibling directory.
