### PR TITLE
Deleted unneeded default constructor.

### DIFF
--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -28,9 +28,6 @@ using namespace std;
 
 namespace Opm {
 
-    RawRecord::RawRecord() : m_fileName(""), m_keywordName("") {
-    }
-
     /*
      * It is assumed that after a record is terminated, there is no quote marks
      * in the subsequent comment. This is in accordance with the Eclipse user

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -32,7 +32,6 @@ namespace Opm {
 
     class RawRecord {
     public:
-        RawRecord();
         RawRecord(const std::string& singleRecordString, const std::string& fileName = "", const std::string& keywordName = "");
         
         std::string pop_front();


### PR DESCRIPTION
Its implementation was buggy, initialising references to temporary objects.

This also silences the warning clang produces for this.
