### PR TITLE
add get*Double() methods to the FloatItem

### DIFF
--- a/opm/parser/eclipse/Deck/DeckFloatItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckFloatItem.cpp
@@ -53,6 +53,17 @@ namespace Opm {
         return m_SIdata;
     }
 
+    double DeckFloatItem::getRawDouble(size_t index) const
+    {
+        return getRawFloat(index);
+    }
+
+    double DeckFloatItem::getSIDouble(size_t index) const
+    {
+        return getSIFloat(index);
+    }
+
+
     void DeckFloatItem::assertSIData() const {
         if (m_dimensions.size() > 0) {
             if (m_SIdata.size() > 0) {

--- a/opm/parser/eclipse/Deck/DeckFloatItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckFloatItem.hpp
@@ -38,6 +38,9 @@ namespace Opm {
         float getSIFloat(size_t index) const;
         const std::vector<float>& getSIFloatData() const;
 
+        double getRawDouble(size_t index) const;
+        double getSIDouble(size_t index) const;
+
         void push_back(std::deque<float> data , size_t items);
         void push_back(std::deque<float> data);
         void push_back(float value);


### PR DESCRIPTION
this is a bit of a hack since the precision of these methods is
obviously limited to single precision and there are no *Data()
variants because these would involve the creation of a std::vector
containing all elements, but it fixes my GridManager issue...
