### PR TITLE
Add preferred phase to Well class.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -504,7 +504,8 @@ namespace Opm {
         int headI = record->getItem("HEAD_I")->getInt(0) - 1;
         int headJ = record->getItem("HEAD_J")->getInt(0) - 1;
         double refDepth = record->getItem("REF_DEPTH")->getSIDouble(0);
-        WellPtr well(new Well(wellName, headI, headJ, refDepth, m_timeMap , timeStep));
+        Phase::PhaseEnum preferredPhase = Phase::PhaseEnumFromString(record->getItem("PHASE")->getTrimmedString(0));
+        WellPtr well(new Well(wellName, headI, headJ, refDepth, preferredPhase, m_timeMap , timeStep));
         m_wells[ wellName ] = well;
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -27,7 +27,8 @@
 
 namespace Opm {
 
-    Well::Well(const std::string& name, int headI, int headJ, double refDepth, TimeMapConstPtr timeMap , size_t creationTimeStep)
+    Well::Well(const std::string& name, int headI, int headJ, double refDepth, Phase::PhaseEnum preferredPhase,
+               TimeMapConstPtr timeMap, size_t creationTimeStep)
         : m_status(new DynamicState<WellCommon::StatusEnum>(timeMap, WellCommon::OPEN)),
           m_isAvailableForGroupControl(new DynamicState<bool>(timeMap, true)),
           m_guideRate(new DynamicState<double>(timeMap, -1.0)),
@@ -40,7 +41,8 @@ namespace Opm {
           m_groupName( new DynamicState<std::string>( timeMap , "" )),
           m_headI(headI),
           m_headJ(headJ),
-          m_refDepth(refDepth)      
+          m_refDepth(refDepth),
+          m_preferredPhase(preferredPhase)
     {
         m_name = name;
         m_creationTimeStep = creationTimeStep;
@@ -92,7 +94,6 @@ namespace Opm {
         m_status->add( timeStep , status );
     }
     
-
     bool Well::isProducer(size_t timeStep) const {
         return m_isProducer->get(timeStep);
     }
@@ -147,6 +148,10 @@ namespace Opm {
 
     double Well::getRefDepth() const {
         return m_refDepth;
+    }
+
+    Phase::PhaseEnum Well::getPreferredPhase() const {
+        return m_preferredPhase;
     }
 
     CompletionSetConstPtr Well::getCompletions(size_t timeStep) const {

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -124,7 +124,8 @@ namespace Opm {
 
     class Well {
     public:
-        Well(const std::string& name, int headI, int headJ, double refDepth, TimeMapConstPtr timeMap , size_t creationTimeStep);
+        Well(const std::string& name, int headI, int headJ, double refDepth, Phase::PhaseEnum preferredPhase,
+             TimeMapConstPtr timeMap, size_t creationTimeStep);
         const std::string& name() const;
 
         bool hasBeenDefined(size_t timeStep) const;
@@ -133,10 +134,11 @@ namespace Opm {
 
         WellCommon::StatusEnum getStatus(size_t timeStep) const;
         void                   setStatus(size_t timeStep, WellCommon::StatusEnum Status);
-        
+
         int    getHeadI() const;
         int    getHeadJ() const;
         double getRefDepth() const;
+        Phase::PhaseEnum getPreferredPhase() const;
         
         bool isAvailableForGroupControl(size_t timeStep) const;
         void setAvailableForGroupControl(size_t timeStep, bool isAvailableForGroupControl);
@@ -166,7 +168,7 @@ namespace Opm {
         std::string m_name;
         
         std::shared_ptr<DynamicState<WellCommon::StatusEnum> > m_status;
-        
+
         std::shared_ptr<DynamicState<bool> > m_isAvailableForGroupControl;
         std::shared_ptr<DynamicState<double> > m_guideRate;
         std::shared_ptr<DynamicState<GuideRate::GuideRatePhaseEnum> > m_guideRatePhase;
@@ -182,6 +184,7 @@ namespace Opm {
         int m_headI;
         int m_headJ;
         double m_refDepth;
+        Phase::PhaseEnum m_preferredPhase;
     };
     typedef std::shared_ptr<Well> WellPtr;
     typedef std::shared_ptr<const Well> WellConstPtr;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -148,8 +148,8 @@ BOOST_AUTO_TEST_CASE(GroupAddWell) {
 
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
-    Opm::WellPtr well1(new Opm::Well("WELL1" , 0, 0, 0.0, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, timeMap , 0));
+    Opm::WellPtr well1(new Opm::Well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap, 0));
+    Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, Opm::Phase::OIL, timeMap, 0));
     
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1 );
@@ -185,8 +185,8 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
 
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
-    Opm::WellPtr well1(new Opm::Well("WELL1" , 0, 0, 0.0, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, timeMap , 0));
+    Opm::WellPtr well1(new Opm::Well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap, 0));
+    Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, Opm::Phase::OIL, timeMap, 0));
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1 );

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
@@ -53,8 +53,8 @@ BOOST_AUTO_TEST_CASE(AddAndDeleteWell) {
     Opm::WellSet wellSet;
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
 
-    Opm::WellPtr well(new Opm::Well("WELL1" , 0, 0, 0.0, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, timeMap , 0));
+    Opm::WellPtr well(new Opm::Well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
+    Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
 
     wellSet.addWell( well ); 
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL1"));
@@ -78,8 +78,8 @@ BOOST_AUTO_TEST_CASE(AddWellSameName) {
     Opm::WellSet wellSet;
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
 
-    Opm::WellPtr well1(new Opm::Well("WELL" , 0, 0, 0.0, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL" , 0, 0, 0.0, timeMap , 0));
+    Opm::WellPtr well1(new Opm::Well("WELL" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
+    Opm::WellPtr well2(new Opm::Well("WELL" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
 
     wellSet.addWell( well1 ); 
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL"));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -43,14 +43,14 @@ Opm::TimeMapPtr createXDaysTimeMap(size_t numDays) {
 
 BOOST_AUTO_TEST_CASE(CreateWell_CorrectNameAndDefaultValues) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     BOOST_CHECK_EQUAL( "WELL1" , well.name() );
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).OilRate);
 }
 
 BOOST_AUTO_TEST_CASE(CreateWell_GetProductionPropertiesShouldReturnSameObject) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
 
     BOOST_CHECK_EQUAL(&(well.getProductionProperties(5)), &(well.getProductionProperties(5)));
     BOOST_CHECK_EQUAL(&(well.getProductionProperties(8)), &(well.getProductionProperties(8)));
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(CreateWell_GetProductionPropertiesShouldReturnSameObject) {
 
 BOOST_AUTO_TEST_CASE(CreateWell_GetInjectionPropertiesShouldReturnSameObject) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
 
     BOOST_CHECK_EQUAL(&(well.getInjectionProperties(5)), &(well.getInjectionProperties(5)));
     BOOST_CHECK_EQUAL(&(well.getInjectionProperties(8)), &(well.getInjectionProperties(8)));
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(CreateWell_GetInjectionPropertiesShouldReturnSameObject) {
 
 BOOST_AUTO_TEST_CASE(CreateWellCreateTimeStepOK) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 5);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 5);
     BOOST_CHECK_EQUAL( false , well.hasBeenDefined(0) );
     BOOST_CHECK_EQUAL( false , well.hasBeenDefined(4) );
     BOOST_CHECK_EQUAL( true , well.hasBeenDefined(5) );
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(CreateWellCreateTimeStepOK) {
 
 BOOST_AUTO_TEST_CASE(setWellProductionProperties_PropertiesSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
 
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy( 5 ).OilRate);
     Opm::WellProductionProperties props;
@@ -103,7 +103,7 @@ BOOST_AUTO_TEST_CASE(setWellProductionProperties_PropertiesSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setOilRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).OilRate);
     Opm::WellProductionProperties props;
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(setOilRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(seLiquidRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).LiquidRate);
     Opm::WellProductionProperties props;
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(seLiquidRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setPredictionModeProduction_ModeSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     
     BOOST_CHECK_EQUAL( true, well.getProductionPropertiesCopy(5).predictionMode);
     Opm::WellProductionProperties props;
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(setPredictionModeProduction_ModeSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setpredictionModeInjection_ModeSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
 
     BOOST_CHECK_EQUAL( true, well.getInjectionPropertiesCopy(5).predictionMode);
     Opm::WellInjectionProperties props;
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(setpredictionModeInjection_ModeSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(NewWellZeroCompletions) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     Opm::CompletionSetConstPtr completions = well.getCompletions( 0 );
     BOOST_CHECK_EQUAL( 0U , completions->size());
 }
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(NewWellZeroCompletions) {
 
 BOOST_AUTO_TEST_CASE(UpdateCompletions) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     Opm::CompletionSetConstPtr completions = well.getCompletions( 0 );
     BOOST_CHECK_EQUAL( 0U , completions->size());
     
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(UpdateCompletions) {
 
 BOOST_AUTO_TEST_CASE(setGasRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::GAS, timeMap , 0);
     
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).GasRate);
     Opm::WellProductionProperties properties;
@@ -216,7 +216,7 @@ BOOST_AUTO_TEST_CASE(setGasRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setWaterRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
     
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).WaterRate);
     Opm::WellProductionProperties properties;
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(setWaterRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setSurfaceInjectionRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
     
     BOOST_CHECK_EQUAL(0.0 , well.getInjectionPropertiesCopy(5).surfaceInjectionRate);
     Opm::WellInjectionProperties props(well.getInjectionPropertiesCopy(5));
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(setSurfaceInjectionRate_RateSetCorrect) {
 
 BOOST_AUTO_TEST_CASE(setReservoirInjectionRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap , 0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
     
     BOOST_CHECK_EQUAL(0.0 , well.getInjectionPropertiesCopy(5).reservoirInjectionRate);
     Opm::WellInjectionProperties properties(well.getInjectionPropertiesCopy(5));
@@ -257,7 +257,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     // HACK: This test checks correctly setting of isProducer/isInjector. This property depends on which of
     //       WellProductionProperties/WellInjectionProperties is set last, independent of actual values.
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap ,0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap ,0);
 
     /* 1: Well is created as producer */
     BOOST_CHECK_EQUAL( false , well.isInjector(0));
@@ -313,7 +313,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
 
 BOOST_AUTO_TEST_CASE(GroupnameCorretlySet) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1" , 0, 0, 0.0, timeMap ,0);
+    Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap ,0);
 
     BOOST_CHECK_EQUAL("" , well.getGroupName(2));
 
@@ -327,19 +327,20 @@ BOOST_AUTO_TEST_CASE(GroupnameCorretlySet) {
 
 BOOST_AUTO_TEST_CASE(addWELSPECS_setData_dataSet) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 23, 42, 2334.32, timeMap, 3);
+    Opm::Well well("WELL1", 23, 42, 2334.32, Opm::Phase::WATER, timeMap, 3);
 
     BOOST_CHECK(!well.hasBeenDefined(2));
     BOOST_CHECK(well.hasBeenDefined(3));
     BOOST_CHECK_EQUAL(23, well.getHeadI());
     BOOST_CHECK_EQUAL(42, well.getHeadJ());
     BOOST_CHECK_EQUAL(2334.32, well.getRefDepth());
+    BOOST_CHECK_EQUAL(Opm::Phase::WATER, well.getPreferredPhase());
 }
 
 
 BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
     
 
     Opm::WellProductionProperties productionProps(well.getProductionPropertiesCopy(1));
@@ -360,7 +361,7 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
 
 BOOST_AUTO_TEST_CASE(InjectorType) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
     
     Opm::WellInjectionProperties injectionProps(well.getInjectionPropertiesCopy(1));
     injectionProps.injectorType = Opm::WellInjector::WATER;
@@ -375,7 +376,7 @@ BOOST_AUTO_TEST_CASE(InjectorType) {
 
 BOOST_AUTO_TEST_CASE(WellStatus) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
     
     well.setStatus( 1 , Opm::WellCommon::OPEN );
     BOOST_CHECK_EQUAL( Opm::WellCommon::OPEN , well.getStatus( 5 ));
@@ -389,7 +390,7 @@ BOOST_AUTO_TEST_CASE(WellStatus) {
 BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
 
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::OIL, timeMap, 0);
 
     
     BOOST_CHECK( !well.getProductionPropertiesCopy(1).hasProductionControl( Opm::WellProducer::ORAT ));
@@ -439,7 +440,7 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
 BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
     
     BOOST_CHECK( !well.getInjectionPropertiesCopy(1).hasInjectionControl( Opm::WellInjector::RATE ));
     BOOST_CHECK( !well.getInjectionPropertiesCopy(1).hasInjectionControl( Opm::WellInjector::RESV ));
@@ -483,7 +484,7 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 
 BOOST_AUTO_TEST_CASE(WellSetAvailableForGroupControl_ControlSet) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
 
     BOOST_CHECK(well.isAvailableForGroupControl(10));
     well.setAvailableForGroupControl(12, false);
@@ -494,7 +495,7 @@ BOOST_AUTO_TEST_CASE(WellSetAvailableForGroupControl_ControlSet) {
 
 BOOST_AUTO_TEST_CASE(WellSetGuideRate_GuideRateSet) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
 
     BOOST_CHECK_LT(well.getGuideRate(0), 0);
     well.setGuideRate(1, 32.2);
@@ -504,7 +505,7 @@ BOOST_AUTO_TEST_CASE(WellSetGuideRate_GuideRateSet) {
 
 BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
     BOOST_CHECK_EQUAL(Opm::GuideRate::UNDEFINED, well.getGuideRatePhase(0));
     well.setGuideRatePhase(3, Opm::GuideRate::RAT);
     BOOST_CHECK_EQUAL(Opm::GuideRate::UNDEFINED, well.getGuideRatePhase(2));
@@ -514,7 +515,7 @@ BOOST_AUTO_TEST_CASE(WellGuideRatePhase_GuideRatePhaseSet) {
 
 BOOST_AUTO_TEST_CASE(WellSetScalingFactor_ScalingFactorSetSet) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
-    Opm::Well well("WELL1", 1, 2, 2334.32, timeMap, 0);
+    Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
     BOOST_CHECK_EQUAL(1.0, well.getGuideRateScalingFactor(0));
     well.setGuideRateScalingFactor(4, 0.6);
     BOOST_CHECK_EQUAL(1.0, well.getGuideRateScalingFactor(3));


### PR DESCRIPTION
This entails:
- Adding a new data member of type Opm::Phase::PhaseEnum.
- Adding method getPreferredPhase().
- Adding extra constructor argument.
- Modifying constructor call in Schedule::addWell().
- Adding unit test for the new preferredPhase property.
- Modifying constructor call in all the well unit tests.

This is needed because we want to use the preferred phase to set initial wellbore fluid composition for production wells.
