### PR TITLE
add PVCDO keyword and fix typo pvdco -> pvcdo

### DIFF
--- a/opm/parser/eclipse/Utility/PvcdoTable.hpp
+++ b/opm/parser/eclipse/Utility/PvcdoTable.hpp
@@ -16,21 +16,21 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef OPM_PARSER_PVDCO_TABLE_HPP
-#define	OPM_PARSER_PVDCO_TABLE_HPP
+#ifndef OPM_PARSER_PVCDO_TABLE_HPP
+#define	OPM_PARSER_PVCDO_TABLE_HPP
 
 #include "SimpleTable.hpp"
 
 namespace Opm {
-    class PvdcoTable : protected SimpleTable {
+    class PvcdoTable : protected SimpleTable {
         typedef SimpleTable ParentType;
 
     public:
         /*!
-         * \brief Read the PVDCO keyword and provide some convenience
+         * \brief Read the PVCDO keyword and provide some convenience
          *        methods for it.
          */
-        PvdcoTable(Opm::DeckKeywordConstPtr keyword,
+        PvcdoTable(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx = 0,
                   int firstEntityOffset = 0)
             : SimpleTable(keyword,
@@ -61,5 +61,5 @@ namespace Opm {
     };
 }
 
-#endif	// OPM_PARSER_PVDCO_TABLE_HPP
+#endif	// OPM_PARSER_PVCDO_TABLE_HPP
 

--- a/opm/parser/share/keywords/P/PVCDO
+++ b/opm/parser/share/keywords/P/PVCDO
@@ -1,0 +1,8 @@
+{"name" : "PVTW" , "size" : {"keyword":"TABDIMS" , "item":"NTPVT"}, "items":
+    [   {"name":"P_BUBB", "value_type" : "DOUBLE", "dimension":"Pressure" },
+        {"name":"RS_BUBB", "value_type" : "DOUBLE","dimension":"OilDissolutionFactor"},
+        {"name":"OIL_VOL_FACTOR", "value_type" : "DOUBLE","dimension":"1"},
+        {"name":"OIL_VISCOSITY", "value_type" : "DOUBLE","dimension":"Viscosity"},
+        {"name":"OIL_COMPRESSIBILITY", "value_type" : "DOUBLE","dimension":"1"},
+        {"name":"OIL_VISCOSIBILITY", "value_type" : "DOUBLE","dimension":"1"}
+]}


### PR DESCRIPTION
this is used in opm-core but I doubt that these code paths have
actually been tested recently because the parser would have thrown up
as soon as it had encountered PVCDO...
