### PR TITLE
add WELTARG keyword

### DIFF
--- a/opm/parser/share/keywords/W/WELTARG
+++ b/opm/parser/share/keywords/W/WELTARG
@@ -1,0 +1,5 @@
+{"name" : "WELTARG" , "items" : [
+    {"name" : "WELL"         , "value_type" : "STRING" },
+    {"name" : "CMODE"        , "value_type" : "STRING" },
+    {"name" : "NEW_VALUE" , "value_type" : "DOUBLE" , "dimension" : "ContextDependent"},
+]}


### PR DESCRIPTION
this one is used deep inside opm-porsol and features one of these nasty context
dependent parameters...

For a change, merging this PR shouldn't break anything for anyone...
