### PR TITLE
add a cmake test to check if the used file system is case sensitive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,13 +49,14 @@ else()
     include_directories( "${CMAKE_CURRENT_SOURCE_DIR}/opm/json" )   
 endif()
 
+include("cmake/Modules/CheckCaseSensitiveFileSystem.cmake")
+add_definitions("-DHAVE_CASE_SENSITIVE_FILESYSTEM=${HAVE_CASE_SENSITIVE_FILESYSTEM}")
+
 find_package(ERT)
 include_directories( ${ERT_INCLUDE_DIRS} )   
 
-
 set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
-
 
 add_subdirectory(opm/json)
 add_subdirectory(opm/parser)

--- a/cmake/Modules/CheckCaseSensitiveFileSystem.cmake
+++ b/cmake/Modules/CheckCaseSensitiveFileSystem.cmake
@@ -1,0 +1,29 @@
+#
+# Module to check whether the file system is case sensitive or not
+#
+# Sets the following variable:
+#
+# HAVE_CASE_SENSITIVE_FILESYSTEM   True if the file system honors the case of files
+
+message(STATUS "Checking whether the file system is case-sensitive")
+# create a file containing uppercase characters
+file(WRITE "${CMAKE_BINARY_DIR}/UPPER" "Foo")
+
+# check if the all-lowercase file with the same name can be opened
+set(FooContents "")
+if (EXISTS "${CMAKE_BINARY_DIR}/upper")
+    file(READ "${CMAKE_BINARY_DIR}/upper" FooContents)
+endif()
+
+# remove the file again in order not to have it dangling around...
+file(REMOVE "${CMAKE_BINARY_DIR}/UPPER")
+
+# check the contents of the file opened with lower-case. If it is
+# empty, the file system is case sensitive.
+if ("${FooContents}" STREQUAL "Foo")
+  message(STATUS "File system is not case-sensitive")
+  set(HAVE_CASE_SENSITIVE_FILESYSTEM 0)
+else()
+  message(STATUS "File system is case-sensitive")
+  set(HAVE_CASE_SENSITIVE_FILESYSTEM 1)
+endif()

--- a/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
@@ -48,6 +48,7 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeWrongCase) {
 
     Opm::ParserPtr parser(new Opm::Parser());
 
+#if HAVE_CASE_SENSITIVE_FILESYSTEM
     // so far, we expect the files which are included to exhibit
     // exactly the same spelling as their names on disk. Eclipse seems
     // to be a bit more relaxed when it comes to this, so we might
@@ -55,5 +56,16 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeWrongCase) {
     BOOST_CHECK_THROW(parser->parseFile(inputFile1Path.string()), std::runtime_error);
     BOOST_CHECK_THROW(parser->parseFile(inputFile2Path.string()), std::runtime_error);
     BOOST_CHECK_THROW(parser->parseFile(inputFile3Path.string()), std::runtime_error);
+#else
+    // for case-insensitive filesystems, the include statement will
+    // always work regardless of how the capitalization of the
+    // included files is wrong...
+    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile1Path.string())->hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile1Path.string())->hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile2Path.string())->hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile2Path.string())->hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile3Path.string())->hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile3Path.string())->hasKeyword("WATER"));
+#endif
 }
 


### PR DESCRIPTION
And fix the unit test for INCLUDE. This should make the test pass on
case insensitive file systems like the one of MacOS X. (Who uses that
anyway? ;))
