### PR TITLE
add numTables() method to the table classes

### DIFF
--- a/opm/parser/eclipse/Utility/FullTable.hpp
+++ b/opm/parser/eclipse/Utility/FullTable.hpp
@@ -59,6 +59,9 @@ namespace Opm {
         typedef std::shared_ptr<Self> Pointer;
         typedef std::shared_ptr<const Self> ConstPointer;
 
+        static size_t numTables(Opm::DeckKeywordConstPtr keyword)
+        { return OuterTable::numTables(keyword); }
+
         /*!
          * \brief Read full tables from keywords like PVTO
          *

--- a/opm/parser/eclipse/Utility/PvtgOuterTable.hpp
+++ b/opm/parser/eclipse/Utility/PvtgOuterTable.hpp
@@ -26,6 +26,8 @@ namespace Opm {
         typedef SimpleMultiRecordTable ParentType;
 
     public:
+        using ParentType::numTables;
+
         /*!
          * \brief Read the per record table of the PVTG keyword and
          *        provide some convenience methods for it.

--- a/opm/parser/eclipse/Utility/PvtoOuterTable.hpp
+++ b/opm/parser/eclipse/Utility/PvtoOuterTable.hpp
@@ -26,6 +26,8 @@ namespace Opm {
         typedef SimpleMultiRecordTable ParentType;
 
     public:
+        using ParentType::numTables;
+
         /*!
          * \brief Read the per record table of the PVTO keyword and
          *        provide some convenience methods for it.

--- a/opm/parser/eclipse/Utility/SimpleMultiRecordTable.cpp
+++ b/opm/parser/eclipse/Utility/SimpleMultiRecordTable.cpp
@@ -19,6 +19,28 @@
 #include <opm/parser/eclipse/Utility/SimpleMultiRecordTable.hpp>
 
 namespace Opm {
+/*!
+ * \brief Returns the number of tables which can be found in a
+ *        given keyword.
+ */
+size_t SimpleMultiRecordTable::numTables(Opm::DeckKeywordConstPtr keyword)
+{
+    size_t result = 0;
+
+    // first, go to the first record of the specified table. For this,
+    // we need to skip the right number of empty records...
+    for (size_t recordIdx = 0;
+         recordIdx < keyword->size();
+         ++ recordIdx)
+    {
+        if (getNumFlatItems_(keyword->getRecord(recordIdx)) == 0)
+            // each table ends with an empty record
+            ++ result;
+    }
+
+    return result;
+}
+
 // create table from first few items of multiple records (i.e. getSIDoubleData() throws an exception)
 SimpleMultiRecordTable::SimpleMultiRecordTable(Opm::DeckKeywordConstPtr keyword,
                                                const std::vector<std::string> &columnNames,
@@ -68,7 +90,7 @@ SimpleMultiRecordTable::SimpleMultiRecordTable(Opm::DeckKeywordConstPtr keyword,
     }
 }
 
-size_t SimpleMultiRecordTable::getNumFlatItems_(Opm::DeckRecordConstPtr deckRecord) const
+size_t SimpleMultiRecordTable::getNumFlatItems_(Opm::DeckRecordConstPtr deckRecord)
 {
     int result = 0;
     for (unsigned i = 0; i < deckRecord->size(); ++ i) {

--- a/opm/parser/eclipse/Utility/SimpleMultiRecordTable.hpp
+++ b/opm/parser/eclipse/Utility/SimpleMultiRecordTable.hpp
@@ -34,6 +34,12 @@ namespace Opm {
     class SimpleMultiRecordTable : public SimpleTable {
     public:
         /*!
+         * \brief Returns the number of tables which can be found in a
+         *        given keyword.
+         */
+        static size_t numTables(Opm::DeckKeywordConstPtr keyword);
+
+        /*!
          * \brief Read simple tables from multi-item keywords like PVTW
          *
          * This creates a table out of the first N items of each of
@@ -59,7 +65,7 @@ namespace Opm {
         { return m_numRecords; }
 
     private:
-        size_t getNumFlatItems_(Opm::DeckRecordConstPtr deckRecord) const;
+        static size_t getNumFlatItems_(Opm::DeckRecordConstPtr deckRecord);
         double getFlatSiDoubleData_(Opm::DeckRecordConstPtr deckRecord, unsigned flatItemIdx) const;
 
         size_t m_firstRecordIdx;


### PR DESCRIPTION
For SimpleTable, that is simply the number of records in a keyword, for
MultiRecordTables, it is the number of _empty_ records.

this patch makes supporting multi-PVT easier and cleaner.
