### PR TITLE
fixed: don't mix member names and function parameters

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -35,8 +35,8 @@ namespace Opm {
         m_isDataKeyword = false;
     }
 
-    void DeckKeyword::setDataKeyword(bool isDataKeyword) {
-        m_isDataKeyword = isDataKeyword;
+    void DeckKeyword::setDataKeyword(bool isDataKeyword_) {
+        m_isDataKeyword = isDataKeyword_;
     }
     
     bool DeckKeyword::isDataKeyword() const {


### PR DESCRIPTION
Sure didn't take long for another one of these to be reintroduced :)
