### PR TITLE
fixed: linking due to several specializations being generated

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -73,6 +73,7 @@ EclipseState/Schedule/CompletionSet.cpp
 EclipseState/Schedule/ScheduleEnums.cpp 
 EclipseState/Schedule/GroupTreeNode.cpp
 EclipseState/Schedule/GroupTree.cpp
+EclipseState/Grid/GridProperty.cpp
 #
 EclipseState/Grid/EclipseGrid.cpp)
 

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -1,0 +1,33 @@
+/*
+  Copyright 2014 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include "GridProperty.hpp"
+
+namespace Opm {
+
+template<>  
+void GridProperty<int>::loadFromDeckKeyword(Opm::DeckKeywordConstPtr deckKeyword) {
+    if (deckKeyword->isDataKeyword()) {
+        const std::vector<int>& data = deckKeyword->getIntData();
+        setFromVector(data);
+    } else
+        throw std::invalid_argument("Can only load from DATA keywords");
+}
+
+}

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -23,6 +23,7 @@
 #include <string>
 #include <vector>
 #include <unordered_map>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 /*
   This class implemenents a class representing properties which are
@@ -81,20 +82,6 @@ private:
     std::string m_keyword;
     std::vector<T> m_data;
 };
-
-
-template<>  
-void GridProperty<int>::loadFromDeckKeyword(DeckKeywordConstPtr deckKeyword) {
-    if (deckKeyword->isDataKeyword()) {
-        const std::vector<int>& data = deckKeyword->getIntData();
-        setFromVector(data);
-    } else
-        throw std::invalid_argument("Can only load from DATA keywords");
-}
-    
-    
-
-
 
 }
 #endif


### PR DESCRIPTION
due to the separate build steps for the library and the test binary, the current setup results in two copies of the specialization being generated, with the corresponding linker failure (below).

../../../../../lib/x86_64-linux-gnu/libParser.a(EclipseState.cpp.o): In function `Opm::GridProperty<int>::loadFromDeckKeyword(std::shared_ptr<Opm::DeckKeyword const>)':
EclipseState.cpp:(.text+0x0): multiple definition of`Opm::GridProperty<int>::loadFromDeckKeyword(std::shared_ptr<Opm::DeckKeyword const>)'
CMakeFiles/runEclipseStateTests.dir/EclipseStateTests.cpp.o:EclipseStateTests.cpp:(.text+0x220): first defined here
collect2: error: ld returned 1 exit status

i guess the msft linker have other rules here. this is perhaps not how you want it fixed, though it is a proper fix.
