### PR TITLE
export possibility to parse an arbitrary std::istream

### DIFF
--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -55,6 +55,36 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseFile(singleKeywordFile.string()));
 }
 
+BOOST_AUTO_TEST_CASE(parse_stringWithWWCTKeyword_deckReturned) {
+    const char *wwctString =
+        "SUMMARY\n"
+        "\n"
+        "-- Kommentar\n"
+        "WWCT\n"
+        "  'WELL-1' 'WELL-2' / -- Ehne mehne muh\n"
+        "/\n";
+    ParserPtr parser = createWWCTParser();
+    BOOST_CHECK( parser->canParseKeyword("WWCT"));
+    BOOST_CHECK( parser->canParseKeyword("SUMMARY"));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseString(wwctString));
+}
+
+BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
+    const char *wwctString =
+        "SUMMARY\n"
+        "\n"
+        "-- Kommentar\n"
+        "WWCT\n"
+        "  'WELL-1' 'WELL-2' / -- Rumpelstilzchen\n"
+        "/\n";
+    std::shared_ptr<std::istringstream> wwctStream(new std::istringstream(wwctString));
+
+    ParserPtr parser = createWWCTParser();
+    BOOST_CHECK( parser->canParseKeyword("WWCT"));
+    BOOST_CHECK( parser->canParseKeyword("SUMMARY"));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseStream(wwctStream));
+}
+
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/wwct.data");
     ParserPtr parser = createWWCTParser();

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -64,6 +64,14 @@ namespace Opm {
             deck = deckToFill;
             inputstream.reset(new std::istringstream(inputData));
         }
+
+        ParserState(std::shared_ptr<std::istream> inputStream, DeckPtr deckToFill, bool useStrictParsing) {
+            lineNR = 0;
+            strictParsing = useStrictParsing;
+            dataFile = "";
+            deck = deckToFill;
+            inputstream = inputStream;
+        }
     };
 
     Parser::Parser(bool addDefault) {
@@ -91,6 +99,15 @@ namespace Opm {
     DeckPtr Parser::parseString(const std::string &data, bool strictParsing) const {
 
         std::shared_ptr<ParserState> parserState(new ParserState(data, DeckPtr(new Deck()), strictParsing));
+
+        parseStream(parserState);
+        applyUnitsToDeck(parserState->deck);
+        return parserState->deck;
+    }
+
+    DeckPtr Parser::parseStream(std::shared_ptr<std::istream> inputStream, bool strictParsing) const {
+
+        std::shared_ptr<ParserState> parserState(new ParserState(inputStream, DeckPtr(new Deck()), strictParsing));
 
         parseStream(parserState);
         applyUnitsToDeck(parserState->deck);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -48,6 +48,7 @@ namespace Opm {
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
         DeckPtr parseFile(const std::string &dataFile, bool strictParsing=true) const;
         DeckPtr parseString(const std::string &data, bool strictParsing=true) const;
+        DeckPtr parseStream(std::shared_ptr<std::istream> inputStream, bool strictParsing=true) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addKeyword(ParserKeywordConstPtr parserKeyword);


### PR DESCRIPTION
this has the potential to reduce the memory requirements of the parser
for opm-benchmarks considerably and is quite easy to add since
internally all parsing happend on istreams anyway...

The parser integration test has been extended to test the new method
as well as `parseString()` which was omitted previously. (I wonder who
introduced this without changing the test. ;)
