### PR TITLE
enable CDash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required (VERSION 2.6)
 project (OPMParser CXX)
 enable_testing()
 enable_language(C)
+include(CTest)
 
 
 SET(CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/Modules")

--- a/CTestConfig.cmake
+++ b/CTestConfig.cmake
@@ -1,0 +1,13 @@
+# this file tells CTest where it should upload its results. To run
+# CTest manually, run
+#
+#  ctest -D Experimental
+#
+
+set(CTEST_PROJECT_NAME "opm-parser")
+set(CTEST_NIGHTLY_START_TIME "00:01:00 UTC")
+
+set(CTEST_DROP_METHOD "http")
+set(CTEST_DROP_SITE "opm-project.org")
+set(CTEST_DROP_LOCATION "/CDash/submit.php?project=opm-parser")
+set(CTEST_DROP_SITE_CDASH TRUE)


### PR DESCRIPTION
Next try, this time it should be okay. (famous last words.) the most fun part of this was to find out that `include(CTest)` was missing in CMakeLists.txt. The dropsite is

http://www.opm-project.org/CDash/index.php?project=opm-parser
