### PR TITLE
Support 'SOIL' keyword

### DIFF
--- a/opm/parser/share/keywords/S/SOIL
+++ b/opm/parser/share/keywords/S/SOIL
@@ -1,0 +1,1 @@
+{"name" : "SOIL" , "data" : {"value_type" : "DOUBLE", "dimension" : "1"}}


### PR DESCRIPTION
This commit introduces support for the `SOIL` (initial oil saturation) keyword.  This is similar to existing keywords `SWAT` and `SGAS` and is needed to input some decks.
