### PR TITLE
fix spurious GCC warnings

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -33,7 +33,9 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 
-
+// forward declarations
+Opm::DeckKeywordConstPtr createSATNUMKeyword();
+Opm::DeckKeywordConstPtr createTABDIMSKeyword();
 
 BOOST_AUTO_TEST_CASE(Empty) {
     Opm::GridProperty<int> gridProperties( 100 , "SATNUM" , 77);
@@ -54,8 +56,6 @@ BOOST_AUTO_TEST_CASE(EmptyDefault) {
     for (size_t i=0; i < data.size(); i++)
         BOOST_CHECK_EQUAL( 0 , data[i] );
 }
-
-
 
 Opm::DeckKeywordConstPtr createSATNUMKeyword( ) {
     const char *deckData =

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -202,7 +202,7 @@ namespace Opm {
 
     double TimeMap::getTimeStepLength(size_t tStepIdx) const
     {
-        assert(0 <= tStepIdx && tStepIdx < numTimesteps());
+        assert(tStepIdx < numTimesteps());
         const boost::posix_time::ptime &t1
             = m_timeList[tStepIdx];
         const boost::posix_time::ptime &t2
@@ -214,7 +214,7 @@ namespace Opm {
 
     double TimeMap::getTimePassedUntil(size_t tLevelIdx) const
     {
-        assert(0 <= tLevelIdx && tLevelIdx < m_timeList.size());
+        assert(tLevelIdx < m_timeList.size());
         const boost::posix_time::ptime &t1
             = m_timeList.front();
         const boost::posix_time::ptime &t2

--- a/opm/parser/eclipse/Utility/FullTable.hpp
+++ b/opm/parser/eclipse/Utility/FullTable.hpp
@@ -97,7 +97,7 @@ namespace Opm {
 
         std::shared_ptr<const InnerTable> getInnerTable(size_t rowIdx) const
         {
-            assert(0 <= rowIdx && rowIdx < static_cast<size_t>(m_innerTables.size()));
+            assert(rowIdx < m_innerTables.size());
             return m_innerTables[rowIdx];
         }
 


### PR DESCRIPTION
The root cause are pretty (too?) strict flags w.r.t. compiler
warnings. In this case, the offenders are "-Wmissing-declarations" and
"-Wtype-limits".
