### PR TITLE
Grid properties: get rid of the dimension string for integer properties

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -138,10 +138,10 @@ namespace Opm {
         BoxManager boxManager(m_eclipseGrid->getNX( ) , m_eclipseGrid->getNY() , m_eclipseGrid->getNZ());
         typedef GridProperties<int>::SupportedKeywordInfo SupportedIntKeywordInfo;
         static std::vector<SupportedIntKeywordInfo> supportedIntKeywords =
-            {SupportedIntKeywordInfo( "SATNUM" , 0.0, "1" ),
-             SupportedIntKeywordInfo( "PVTNUM" , 0.0, "1" ),
-             SupportedIntKeywordInfo( "EQLNUM" , 0.0, "1" ),
-             SupportedIntKeywordInfo( "FIPNUM" , 0.0, "1" )};
+            {SupportedIntKeywordInfo( "SATNUM" , 0.0 ),
+             SupportedIntKeywordInfo( "PVTNUM" , 0.0 ),
+             SupportedIntKeywordInfo( "EQLNUM" , 0.0 ),
+             SupportedIntKeywordInfo( "FIPNUM" , 0.0 )};
 
         typedef GridProperties<double>::SupportedKeywordInfo SupportedDoubleKeywordInfo;
         static std::vector<SupportedDoubleKeywordInfo> supportedDoubleKeywords =
@@ -283,7 +283,7 @@ namespace Opm {
             } else if (m_doubleGridProperties->hasKeyword( field )) {
                 std::shared_ptr<GridProperty<double> > property = m_doubleGridProperties->getKeyword( field );
 
-                double siShiftValue = shiftValue * getSIScaling(property->getDimensionString());
+                double siShiftValue = shiftValue * getSIScaling(property->getKeywordInfo().getDimensionString());
                 property->add(siShiftValue , boxManager.getActiveBox() );
             } else
                 throw std::invalid_argument("Fatal error processing ADD keyword. Tried to shift not defined keyword " + field);
@@ -308,7 +308,7 @@ namespace Opm {
             } else if (m_doubleGridProperties->supportsKeyword( field )) {
                 std::shared_ptr<GridProperty<double> > property = m_doubleGridProperties->getKeyword( field );
 
-                double siValue = value * getSIScaling(property->getDimensionString());
+                double siValue = value * getSIScaling(property->getKeywordInfo().getDimensionString());
                 property->setScalar( siValue , boxManager.getActiveBox() );
             } else
                 throw std::invalid_argument("Fatal error processing EQUALS keyword. Tried to set not defined keyword " + field);

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
@@ -58,7 +58,7 @@ public:
         m_nz = nz;
         
         for (auto iter = supportedKeywords.begin(); iter != supportedKeywords.end(); ++iter) 
-            m_supportedKeywords[std::get<0>(*iter)] = *iter;
+            m_supportedKeywords[iter->getKeywordName()] = *iter;
     }
 
     

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -43,10 +43,83 @@
 
 namespace Opm {
 
+template <class DataType>
+class GridPropertySupportedKeywordInfo;
+
+template <>
+class GridPropertySupportedKeywordInfo<int>
+{
+public:
+    GridPropertySupportedKeywordInfo()
+    {}
+
+    GridPropertySupportedKeywordInfo(const std::string& name,
+                                     int defaultValue)
+        : m_keywordName(name)
+        , m_defaultValue(defaultValue)
+    {}
+
+    GridPropertySupportedKeywordInfo(const GridPropertySupportedKeywordInfo &other)
+        : m_keywordName(other.m_keywordName)
+        , m_defaultValue(other.m_defaultValue)
+    {}
+
+    const std::string& getKeywordName() const {
+        return m_keywordName;
+    }
+
+    int getDefaultValue() const {
+        return m_defaultValue;
+    }
+
+private:
+    std::string m_keywordName;
+    int m_defaultValue;
+};
+
+template <>
+class GridPropertySupportedKeywordInfo<double>
+{
+public:
+    GridPropertySupportedKeywordInfo()
+    {}
+
+    GridPropertySupportedKeywordInfo(const std::string& name,
+                                     double defaultValue,
+                                     const std::string& dimensionString)
+        : m_keywordName(name)
+        , m_defaultValue(defaultValue)
+        , m_dimensionString(dimensionString)
+    {}
+
+    GridPropertySupportedKeywordInfo(const GridPropertySupportedKeywordInfo &other)
+        : m_keywordName(other.m_keywordName)
+        , m_defaultValue(other.m_defaultValue)
+        , m_dimensionString(other.m_dimensionString)
+    {}
+
+    const std::string& getKeywordName() const {
+        return m_keywordName;
+    }
+
+    double getDefaultValue() const {
+        return m_defaultValue;
+    }
+
+    const std::string& getDimensionString() const {
+        return m_dimensionString;
+    }
+
+private:
+    std::string m_keywordName;
+    double m_defaultValue;
+    std::string m_dimensionString;
+};
+
 template <typename T>
 class GridProperty {
 public:
-    typedef std::tuple</*name=*/std::string, /*dataType=*/T, /*unit=*/std::string> SupportedKeywordInfo;
+    typedef GridPropertySupportedKeywordInfo<T> SupportedKeywordInfo;
 
     GridProperty(size_t nx , size_t ny , size_t nz , const SupportedKeywordInfo& kwInfo) {
         m_nx = nx;
@@ -54,7 +127,7 @@ public:
         m_nz = nz;
         m_kwInfo = kwInfo;
         m_data.resize( nx * ny * nz );
-        std::fill( m_data.begin() , m_data.end() ,  std::get<1>(m_kwInfo));
+        std::fill( m_data.begin() , m_data.end() ,  m_kwInfo.getDefaultValue());
     }
 
     size_t size() const {
@@ -140,16 +213,13 @@ public:
             }
         }
     }
-    
 
-    const std::string& getKeywordName() const
-    {
-        return std::get<0>(m_kwInfo);
+    const std::string& getKeywordName() const {
+        return m_kwInfo.getKeywordName();
     }
 
-    const std::string& getDimensionString() const
-    {
-        return std::get<2>(m_kwInfo);
+    const SupportedKeywordInfo& getKeywordInfo() const {
+        return m_kwInfo;
     }
 
 private:

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
@@ -38,8 +38,8 @@
 BOOST_AUTO_TEST_CASE(Empty) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::vector<SupportedKeywordInfo> supportedKeywords =
-        { SupportedKeywordInfo("SATNUM" , 0, "1"),
-          SupportedKeywordInfo("FIPNUM" , 2, "1") };
+        { SupportedKeywordInfo("SATNUM" , 0),
+          SupportedKeywordInfo("FIPNUM" , 2) };
     Opm::GridProperties<int> gridProperties( 10, 10, 100 , supportedKeywords);
     
     BOOST_CHECK( gridProperties.supportsKeyword("SATNUM") );
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(Empty) {
 BOOST_AUTO_TEST_CASE(addKeyword) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::vector<SupportedKeywordInfo> supportedKeywords =
-        { SupportedKeywordInfo("SATNUM" , 0, "1") };
+        { SupportedKeywordInfo("SATNUM" , 0) };
     Opm::GridProperties<int> gridProperties( 100, 10 , 10 , supportedKeywords);
     
     BOOST_CHECK_THROW( gridProperties.addKeyword("NOT-SUPPORTED") , std::invalid_argument);
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(addKeyword) {
 BOOST_AUTO_TEST_CASE(getKeyword) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::vector<SupportedKeywordInfo> supportedKeywords =
-        { SupportedKeywordInfo("SATNUM" , 0, "1") };
+        { SupportedKeywordInfo("SATNUM" , 0) };
     Opm::GridProperties<int> gridProperties( 100,25,4 , supportedKeywords);
     std::shared_ptr<Opm::GridProperty<int> > satnum1 = gridProperties.getKeyword("SATNUM");
     std::shared_ptr<Opm::GridProperty<int> > satnum2 = gridProperties.getKeyword("SATNUM");

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -39,7 +39,7 @@ Opm::DeckKeywordConstPtr createTABDIMSKeyword( );
 
 BOOST_AUTO_TEST_CASE(Empty) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo("SATNUM" , 77, "1");
+    SupportedKeywordInfo keywordInfo("SATNUM" , 77);
     Opm::GridProperty<int> gridProperty( 5 , 5 , 4 , keywordInfo);
     const std::vector<int>& data = gridProperty.getData();
     BOOST_CHECK_EQUAL( 100U , data.size());
@@ -59,7 +59,7 @@ BOOST_AUTO_TEST_CASE(Empty) {
 
 BOOST_AUTO_TEST_CASE(EmptyDefault) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo("SATNUM" , 0, "1");
+    SupportedKeywordInfo keywordInfo("SATNUM" , 0);
     Opm::GridProperty<int> gridProperty( /*nx=*/10,
                                          /*ny=*/10,
                                          /*nz=*/1 ,
@@ -97,7 +97,7 @@ Opm::DeckKeywordConstPtr createTABDIMSKeyword( ) {
 BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_notData_Throws) {
     Opm::DeckKeywordConstPtr tabdimsKw = createTABDIMSKeyword(); 
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo("TABDIMS" , 100, "1");
+    SupportedKeywordInfo keywordInfo("TABDIMS" , 100);
     Opm::GridProperty<int> gridProperty( 6 ,1,1 , keywordInfo);
     BOOST_CHECK_THROW( gridProperty.loadFromDeckKeyword( tabdimsKw ) , std::invalid_argument );
 }
@@ -106,7 +106,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_notData_Throws) {
 BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_wrong_size_throws) {
     Opm::DeckKeywordConstPtr satnumKw = createSATNUMKeyword(); 
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo("SATNUM" , 66, "1");
+    SupportedKeywordInfo keywordInfo("SATNUM" , 66);
     Opm::GridProperty<int> gridProperty( 15 ,1,1, keywordInfo);
     BOOST_CHECK_THROW( gridProperty.loadFromDeckKeyword( satnumKw ) , std::invalid_argument );
 }
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_wrong_size_throws) {
 BOOST_AUTO_TEST_CASE(SetFromDeckKeyword) {
     Opm::DeckKeywordConstPtr satnumKw = createSATNUMKeyword(); 
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo("SATNUM" , 99, "1");
+    SupportedKeywordInfo keywordInfo("SATNUM" , 99);
     Opm::GridProperty<int> gridProperty( 4 , 4 , 2 , keywordInfo);
     gridProperty.loadFromDeckKeyword( satnumKw );
     const std::vector<int>& data = gridProperty.getData();
@@ -137,8 +137,8 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword) {
 
 BOOST_AUTO_TEST_CASE(copy) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo1("P1" , 0, "1");
-    SupportedKeywordInfo keywordInfo2("P2" , 9, "1");
+    SupportedKeywordInfo keywordInfo1("P1" , 0);
+    SupportedKeywordInfo keywordInfo2("P2" , 9);
     Opm::GridProperty<int> prop1( 4 , 4 , 2 , keywordInfo1);
     Opm::GridProperty<int> prop2( 4 , 4 , 2 , keywordInfo2);
 
@@ -159,8 +159,8 @@ BOOST_AUTO_TEST_CASE(copy) {
 
 BOOST_AUTO_TEST_CASE(SCALE) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo1("P1" , 1, "1");
-    SupportedKeywordInfo keywordInfo2("P2" , 9, "1");
+    SupportedKeywordInfo keywordInfo1("P1" , 1);
+    SupportedKeywordInfo keywordInfo2("P2" , 9);
 
     Opm::GridProperty<int> prop1( 4 , 4 , 2 , keywordInfo1);
     Opm::GridProperty<int> prop2( 4 , 4 , 2 , keywordInfo2);
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(SCALE) {
 
 BOOST_AUTO_TEST_CASE(SET) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo("P1" , 1, "1");
+    SupportedKeywordInfo keywordInfo("P1" , 1);
     Opm::GridProperty<int> prop( 4 , 4 , 2 , keywordInfo);
 
     std::shared_ptr<Opm::Box> global = std::make_shared<Opm::Box>(4,4,2);
@@ -205,8 +205,8 @@ BOOST_AUTO_TEST_CASE(SET) {
 
 BOOST_AUTO_TEST_CASE(ADD) {
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    SupportedKeywordInfo keywordInfo1("P1" , 1, "1");
-    SupportedKeywordInfo keywordInfo2("P2" , 9, "1");
+    SupportedKeywordInfo keywordInfo1("P1" , 1);
+    SupportedKeywordInfo keywordInfo2("P2" , 9);
     Opm::GridProperty<int> prop1( 4 , 4 , 2 , keywordInfo1);
     Opm::GridProperty<int> prop2( 4 , 4 , 2 , keywordInfo2);
 


### PR DESCRIPTION
this uses a small amount of template magic, to automatically change
the API of the GridProperty class depending on wheter it is
instantiated for double or for int.

Note: This feature may not be worth the additional complexity, so I'm not offended in any way if you just close the PR without merging...
