### PR TITLE
make Deck::hasKeyword() throw if the used parser doesn't know about the queried keyword

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -49,6 +49,8 @@ ${PROJECT_BINARY_DIR}/generated-source/DefaultKeywordList.cpp
 SET_SOURCE_FILES_PROPERTIES(${PROJECT_BINARY_DIR}/generated-source/DefaultKeywordList.cpp PROPERTIES GENERATED TRUE)
 
 set( build_parser_source 
+Parser/ParserEmptyKeywordList.cpp
+Parser/Parser.cpp
 Parser/ParserEnums.cpp
 Parser/ParserKeyword.cpp 
 Parser/ParserRecord.cpp

--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -20,16 +20,25 @@
 #include <vector>
 #include <iostream>
 
+#include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 namespace Opm {
-
     Deck::Deck() {
+        m_parser = 0;
         m_keywords = KeywordContainerPtr(new KeywordContainer());
     }
 
-    bool Deck::hasKeyword(const std::string& keyword) const {
-        return m_keywords->hasKeyword(keyword);
+    Deck::Deck(const Parser* parser) {
+        m_parser = parser;
+        m_keywords = KeywordContainerPtr(new KeywordContainer());
+    }
+
+    bool Deck::hasKeyword(const std::string& keywordName) const {
+        if (m_parser && !m_parser->canParseKeyword(keywordName))
+            throw std::logic_error("Queried for unrecognized keyword '" + keywordName + "'");
+
+        return m_keywords->hasKeyword(keywordName);
     }
     
     void Deck::addKeyword( DeckKeywordPtr keyword) {

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -27,10 +27,14 @@
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
+    class Parser;
+    typedef std::shared_ptr<Parser> ParserPtr;
+    typedef std::shared_ptr<const Parser> ParserConstPtr;
 
     class Deck {
     public:
         Deck();
+        Deck(const Parser *parser);
         bool hasKeyword( const std::string& keyword ) const;
         void addKeyword( DeckKeywordPtr keyword);
         DeckKeywordPtr getKeyword(const std::string& keyword , size_t index) const;
@@ -49,6 +53,7 @@ namespace Opm {
         std::shared_ptr<UnitSystem> getActiveUnitSystem()  const;
 
     private:
+        const Parser* m_parser;
         KeywordContainerPtr m_keywords;
         std::shared_ptr<UnitSystem> m_defaultUnits;
         std::shared_ptr<UnitSystem> m_activeUnits;

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -89,7 +89,7 @@ namespace Opm {
 
     DeckPtr Parser::parseFile(const std::string &dataFileName, bool strictParsing) const {
 
-        std::shared_ptr<ParserState> parserState(new ParserState(dataFileName, DeckPtr(new Deck()), getRootPathFromFile(dataFileName), strictParsing));
+        std::shared_ptr<ParserState> parserState(new ParserState(dataFileName, DeckPtr(new Deck(this)), getRootPathFromFile(dataFileName), strictParsing));
 
         parseStream(parserState);
         applyUnitsToDeck(parserState->deck);
@@ -98,7 +98,7 @@ namespace Opm {
 
     DeckPtr Parser::parseString(const std::string &data, bool strictParsing) const {
 
-        std::shared_ptr<ParserState> parserState(new ParserState(data, DeckPtr(new Deck()), strictParsing));
+        std::shared_ptr<ParserState> parserState(new ParserState(data, DeckPtr(new Deck(this)), strictParsing));
 
         parseStream(parserState);
         applyUnitsToDeck(parserState->deck);
@@ -107,7 +107,7 @@ namespace Opm {
 
     DeckPtr Parser::parseStream(std::shared_ptr<std::istream> inputStream, bool strictParsing) const {
 
-        std::shared_ptr<ParserState> parserState(new ParserState(inputStream, DeckPtr(new Deck()), strictParsing));
+        std::shared_ptr<ParserState> parserState(new ParserState(inputStream, DeckPtr(new Deck(this)), strictParsing));
 
         parseStream(parserState);
         applyUnitsToDeck(parserState->deck);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -63,11 +63,13 @@ namespace Opm {
         void loadKeywordsFromDirectory(const boost::filesystem::path& directory , bool recursive = true, bool onlyALLCAPS8Files = true);
         size_t size() const;
         void applyUnitsToDeck(DeckPtr deck) const;
+
+        bool hasKeyword(const std::string& keyword) const;
+
     private:
         std::map<std::string, ParserKeywordConstPtr> m_parserKeywords;
         std::map<std::string, ParserKeywordConstPtr> m_wildCardKeywords;
 
-        bool hasKeyword(const std::string& keyword) const;
         bool hasWildCardKeyword(const std::string& keyword) const;
         ParserKeywordConstPtr matchingKeyword(const std::string& keyword) const;
 


### PR DESCRIPTION
the problem is that the commonly used pattern

```
if (deck->hasKeyword("FOO"))
   auto kw = deck->getKeyword("FOO");
```

will succeed even if FOO is completely undefined (e.g. because it
contains a typo).

this lead to the discovery of a few bugs in opm-core and opm-autodiff as well as to the discovery that the ROCKTAB definition was missing in opm-parser.

This patch is more a RFC than a "real" PR because the parser needs to be passed to the deck via a raw pointer and the user needs to make sure that the parser object lives at least as long as the deck. std::shared_ptr cannot be used here as creating one in the parse*() methods would lead to the immediate deletion of the parser as soon as the pointer goes out of scope. One way to solve this is to add a static method Parser::create() which returns a shared pointer, but that would lead to cyclic dependencies (the parser object pointing to itself via a shared_ptr) and thus to resource leaks. That said, I'd like to have such a functionality because it uncovers quite a few non-trivial bugs...
