### PR TITLE
fixed: keep a copy instead of a reference

### DIFF
--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -50,8 +50,8 @@ namespace Opm {
     private:
         std::string m_sanitizedRecordString;
         std::deque<std::string> m_recordItems;
-        const std::string& m_fileName;
-        const std::string& m_keywordName;
+        const std::string m_fileName;
+        const std::string m_keywordName;
         
         void setRecordString(const std::string& singleRecordString);
         void splitSingleRecordString();


### PR DESCRIPTION
storing string references are not a good idea, since temporaries are
often used. fixes RawRecordTest on my box
