### PR TITLE
fixed: install dune.module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,3 +70,5 @@ add_subdirectory(opm/parser)
 # handled.
 
 file(COPY ${PROJECT_SOURCE_DIR}/testdata DESTINATION ${EXECUTABLE_OUTPUT_PATH})
+
+install(FILES dune.module DESTINATION lib/dunecontrol/opm-parser)


### PR DESCRIPTION
Building with dune-control is broken since opm-core declares a dependency on opm-parser and this file is missing.
