### PR TITLE
grid properties: add support for the NTG keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -287,6 +287,19 @@ namespace Opm {
             // porosity
             SupportedDoubleKeywordInfo( "PORO"  , 0.0, "1" ),
 
+            // the permeability keywords
+            SupportedDoubleKeywordInfo( "PERMX" , 0.0, "Permeability" ),
+            SupportedDoubleKeywordInfo( "PERMY" , 0.0, "Permeability" ),
+            SupportedDoubleKeywordInfo( "PERMZ" , 0.0, "Permeability" ),
+            SupportedDoubleKeywordInfo( "PERMXY", 0.0, "Permeability" ), // E300 only
+            SupportedDoubleKeywordInfo( "PERMXZ", 0.0, "Permeability" ), // E300 only
+            SupportedDoubleKeywordInfo( "PERMYZ", 0.0, "Permeability" ), // E300 only
+
+            // gross-to-net thickness (acts as a multiplier for PORO
+            // and the permeabilities in the X-Y plane as well as for
+            // the well rates.)
+            SupportedDoubleKeywordInfo( "NTG"   , 1.0, "1" ),
+
             // transmissibility multipliers
             SupportedDoubleKeywordInfo( "MULTX" , 1.0, "1" ),
             SupportedDoubleKeywordInfo( "MULTY" , 1.0, "1" ),
@@ -297,14 +310,6 @@ namespace Opm {
 
             // pore volume multipliers
             SupportedDoubleKeywordInfo( "MULTPV", 1.0, "1" ),
-
-            // the permeability keywords
-            SupportedDoubleKeywordInfo( "PERMX" , 0.0, "Permeability" ),
-            SupportedDoubleKeywordInfo( "PERMY" , 0.0, "Permeability" ),
-            SupportedDoubleKeywordInfo( "PERMZ" , 0.0, "Permeability" ),
-            SupportedDoubleKeywordInfo( "PERMXY", 0.0, "Permeability" ), // E300 only
-            SupportedDoubleKeywordInfo( "PERMXZ", 0.0, "Permeability" ), // E300 only
-            SupportedDoubleKeywordInfo( "PERMYZ", 0.0, "Permeability" ), // E300 only
         };
 
         m_intGridProperties = std::make_shared<GridProperties<int> >(m_eclipseGrid->getNX() , m_eclipseGrid->getNY() , m_eclipseGrid->getNZ() , supportedIntKeywords); 

--- a/opm/parser/share/keywords/N/NTG
+++ b/opm/parser/share/keywords/N/NTG
@@ -1,1 +1,1 @@
-{"name" : "NTG" , "data" : {"value_type" : "DOUBLE"}}
+{"name" : "NTG" , "data" : {"value_type" : "DOUBLE", "dimension" : "1"}}


### PR DESCRIPTION
Whoever came up with that keyword deserves a spanking because its
semantics are adapting thickness of the grid layers using the rock
properties without modifying the grid (and thus the output is not
showing what is actually used). As I understood that whole affair,
this is also done incorrectly, because the flow is not distorted in
depth direction but this the permeability should be divided by the NTG
values as the fluids seep through the thinner layers more quickly...

Anyway, we have to implement it, so here we go.
