### PR TITLE
attempt to fix a weird error on a jenkins test rig

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -508,7 +508,7 @@ namespace Opm {
 
     void ParserKeyword::setMatchRegex(const std::string& deckNameRegexp) {
         try {
-            m_matchRegex = boost::regex::basic_regex<std::string::value_type>(deckNameRegexp);
+            m_matchRegex = boost::regex(deckNameRegexp);
             m_matchRegexString = deckNameRegexp;
         }
         catch (const boost::bad_expression &e) {


### PR DESCRIPTION
http://opm-project.org/CDash/viewBuildError.php?type=0&buildid=21247

this _seems_ to be caused by an old boost version, but I'm not
sure. It can't be the compiler because for me it works on GCC 4.4, GCC
4.9 as well as clang 3.3.

It would be nice if somebody could check that this brings the build server is back to normal before this PR is merged...
