### PR TITLE
fix some "#if without expression" errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,9 @@ if (NOT Boost_USE_STATIC_LIBS)
 endif ()
 
 find_package(CXX11Features)
-add_definitions(-DHAVE_REGEX=${HAVE_REGEX})
+if (HAVE_REGEX)
+  add_definitions(-DHAVE_REGEX=${HAVE_REGEX})
+endif()
 
 set(EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 find_package(cjson)


### PR DESCRIPTION
That was caused because the command line flag to define HAVE_REGEX
should only be added if HAVE_REGEX is set to true...
