### PR TITLE
use extended regular expressions if using std::regex

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -133,7 +133,7 @@ CHECK_CXX_SOURCE_RUNS("
     #include <regex>
     int main(void)
     {
-      std::regex r(\"AB.*|BC+\");
+      std::regex r(\"AB.*|BC+\", std::regex::extended);
       if (!std::regex_match(\"AB\", r))
            return 1;
       if (!std::regex_match(\"ABC\", r))

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -509,7 +509,7 @@ namespace Opm {
     void ParserKeyword::setMatchRegex(const std::string& deckNameRegexp) {
         try {
 #if HAVE_REGEX
-            m_matchRegex = std::regex(deckNameRegexp);
+            m_matchRegex = std::regex(deckNameRegexp, std::regex::extended);
 #else
             m_matchRegex = boost::regex(deckNameRegexp);
 #endif


### PR DESCRIPTION
some compilers (e.g., GCC < 4.9) seem to need it...

thanks to [at]bska for digging this up!
