### PR TITLE
use extended regular expressions if using std::regex

### DIFF
--- a/cmake/Modules/FindCXX11Features.cmake
+++ b/cmake/Modules/FindCXX11Features.cmake
@@ -133,7 +133,7 @@ CHECK_CXX_SOURCE_RUNS("
     #include <regex>
     int main(void)
     {
-      std::regex r(\"AB.*|BC+\");
+      std::regex r(\"AB.*|BC+\", std::regex::extended);
       if (!std::regex_match(\"AB\", r))
            return 1;
       if (!std::regex_match(\"ABC\", r))


### PR DESCRIPTION
some compilers (e.g., GCC < 4.9) seem to need it...

thanks to [at]bska for digging this up!
