### PR TITLE
Eclipse grid reset actnum

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -30,6 +30,18 @@
 #include <ert/ecl/ecl_grid.h>
 namespace Opm {
 
+    /**
+       Will create an EclipseGrid instance based on an existing
+       GRID/EGRID file.
+    */
+    EclipseGrid::EclipseGrid(const std::string& filename ) {
+        ecl_grid_type * c_ptr = ecl_grid_load_case( filename.c_str() );
+        if (c_ptr)
+            m_grid.reset( c_ptr , ecl_grid_free );
+        else
+            throw std::invalid_argument("Could not load grid from binary file: " + filename);
+    }
+
     
     EclipseGrid::EclipseGrid(std::shared_ptr<const RUNSPECSection> runspecSection, std::shared_ptr<const GRIDSection> gridSection) {
         if (runspecSection->hasKeyword("DIMENS")) {
@@ -376,6 +388,11 @@ namespace Opm {
     
     void EclipseGrid::resetACTNUM( const int * actnum) {
         ecl_grid_reset_actnum( m_grid.get() , actnum );
+    }
+
+
+    void EclipseGrid::fwriteEGRID( const std::string& filename ) {
+        ecl_grid_fwrite_EGRID( m_grid.get() , filename.c_str() );
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -31,6 +31,7 @@ namespace Opm {
 
     class EclipseGrid {
     public:
+        EclipseGrid(const std::string& filename);
         EclipseGrid(std::shared_ptr<const RUNSPECSection> runspecSection, std::shared_ptr<const GRIDSection> gridSection);
         
         static bool hasCornerPointKeywords(std::shared_ptr<const GRIDSection> gridSection);
@@ -56,6 +57,7 @@ namespace Opm {
         void exportACTNUM( std::vector<int>& actnum) const;
         void resetACTNUM( const int * actnum);
         bool equal(const EclipseGrid& other) const;
+        void fwriteEGRID( const std::string& filename );
     private:
         std::shared_ptr<ecl_grid_type> m_grid;
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -20,6 +20,7 @@
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
+#include <cstdio>
 
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
@@ -534,3 +535,39 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
     grid.resetACTNUM( NULL );
     BOOST_CHECK_EQUAL( 1000U , grid.getNumActive() );
 }
+
+
+BOOST_AUTO_TEST_CASE(LoadFromBinary) {
+    BOOST_CHECK_THROW(Opm::EclipseGrid( "No/does/not/exist" ) , std::invalid_argument);
+}
+
+
+
+BOOST_AUTO_TEST_CASE(Fwrite) {
+    const char *deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " 10 10 10 /\n"
+        "GRID\n"
+        "COORD\n"
+        "  726*1 / \n"
+        "ZCORN \n"
+        "  8000*1 / \n"
+        "EDIT\n"
+        "\n";
+ 
+    Opm::ParserPtr parser(new Opm::Parser());
+    Opm::DeckConstPtr deck = parser->parseString(deckData) ;
+    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
+    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
+    Opm::EclipseGrid grid1(runspecSection , gridSection );
+
+    grid1.fwriteEGRID( "TEST.EGRID" );
+
+    Opm::EclipseGrid grid2( "TEST.EGRID" );
+
+    BOOST_CHECK( grid1.equal( grid2 ));
+    remove("TEST.EGRID");
+}
+


### PR DESCRIPTION
Implement function to reset the actnum map of an existing EclipseGrid instance. Observe that this requires ert commit: https://github.com/Ensembles/ert/commit/93aedb2d4f536b4371a1484b2289e369d18edad1
