### PR TITLE
fix some harmless compiler warnings

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -96,7 +96,7 @@ namespace Opm {
 
     void EclipseState::initFaults(DeckConstPtr deck) {
         EclipseGridConstPtr grid = getEclipseGrid();
-        m_faults = std::make_shared<FaultCollection>( grid->getNX() , grid->getNY() , grid->getNZ());
+        m_faults = std::make_shared<FaultCollection>();
         std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
 
         for (size_t index=0; index < gridSection->count("FAULTS"); index++) {

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -23,10 +23,7 @@
 
 namespace Opm {
 
-    FaultCollection::FaultCollection(size_t nx , size_t ny , size_t nz) :
-        m_nx(nx),
-        m_ny(ny),
-        m_nz(nz)
+    FaultCollection::FaultCollection()
     {
         
     }

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -36,7 +36,7 @@ namespace Opm {
 
 class FaultCollection {
 public:
-    FaultCollection(size_t nx , size_t ny , size_t nz);
+    FaultCollection();
     size_t size() const;
     bool hasFault(const std::string& faultName) const;
     std::shared_ptr<Fault>  getFault(const std::string& faultName) const;
@@ -45,8 +45,6 @@ public:
     void setTransMult(const std::string& faultName , double transMult);
 
 private:
-
-    size_t m_nx, m_ny, m_nz;
     OrderedMap<std::shared_ptr<Fault > > m_faults;
 };
 }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(AddFaceToFaults) {
 
 
 BOOST_AUTO_TEST_CASE(CreateFaultCollection) {
-    Opm::FaultCollection faults(100,10,6);
+    Opm::FaultCollection faults;
     BOOST_CHECK_EQUAL( faults.size() , 0 );
     BOOST_CHECK(! faults.hasFault("NO-NotThisOne"));
     BOOST_CHECK_THROW( faults.getFault("NO") , std::invalid_argument );
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE(CreateFaultCollection) {
 
 
 BOOST_AUTO_TEST_CASE(AddFaultsToCollection) {
-    Opm::FaultCollection faults(10,10,10);
+    Opm::FaultCollection faults;
     std::shared_ptr<Opm::Fault> fault = std::make_shared<Opm::Fault>("FAULT");
     
     faults.addFault(fault);


### PR DESCRIPTION
this comes with a minor API change as well, as the FaultCollection
class did not use the Cartesian size of the grid at all, so I decided
to remove the attributes and the arguments to the constructor...
