### PR TITLE
Allow static ert

### DIFF
--- a/cmake/Modules/FindERT.cmake
+++ b/cmake/Modules/FindERT.cmake
@@ -182,6 +182,13 @@ if (UNIX)
   list (APPEND ERT_LIBRARIES ${MATH_LIBRARY})
 endif (UNIX)
 
+# if shared libraries are disabled on linux, explcitly linking to the
+# pthreads library is required by ERT
+find_package(Threads ${ERT_QUIET})
+if (CMAKE_THREAD_LIBS_INIT)
+  list (APPEND ERT_LIBRARIES ${CMAKE_THREAD_LIBS_INIT})
+endif()
+
 # Platform specific library where dlopen with friends lives
 list (APPEND ERT_LIBRARIES ${CMAKE_DL_LIBS})
 


### PR DESCRIPTION
this is required if no shared  ERT libraries are build...
