### PR TITLE
add the FGIT keyword to the FIELD_PROBE

### DIFF
--- a/opm/parser/share/keywords/F/FIELD_PROBE
+++ b/opm/parser/share/keywords/F/FIELD_PROBE
@@ -48,6 +48,7 @@
       "FGIR",
       "FGIRH",
       "FGIRT",
+      "FGIT",
       "FGITH",
       "FGPP",
       "FGPP2",


### PR DESCRIPTION
Mea Culpa: For some reason it was not included in the deck_names list. The patch is very simple and after it, the reduced Norne deck from the deck loads without the parser blowing up.
