### PR TITLE
configure: also set the CMAKE_C*_FLAGS_DEBUG and CMAKE_C*_FLAGS_RELEASE ...

### DIFF
--- a/cmake/Scripts/configure
+++ b/cmake/Scripts/configure
@@ -494,11 +494,13 @@ for a in "${VARS[@]}"; do
       ;;
     CFLAGS=*)
       a=${a#CFLAGS=}
-      c_opts=" -DCMAKE_C_FLAGS=\"${a/\"/\\\"}\""
+      a="${a/\"/\\\"}"
+      c_opts=" -DCMAKE_C_FLAGS=\"$a\"  -DCMAKE_C_FLAGS_DEBUG=\"$a\" -DCMAKE_C_FLAGS_RELEASE=\"$a\" "
       ;;
     CXXFLAGS=*)
       a=${a#CXXFLAGS=}
-      cxx_opts=" -DCMAKE_CXX_FLAGS=\"${a/\"/\\\"}\""
+      a="${a/\"/\\\"}"
+      cxx_opts=" -DCMAKE_CXX_FLAGS=\"$a\"  -DCMAKE_CXX_FLAGS_DEBUG=\"$a\" -DCMAKE_CXX_FLAGS_RELEASE=\"$a\" "
       ;;
     FC=*)
       a=${a#FC=}


### PR DESCRIPTION
...of CXX_FLAGS is specified

for me, setting only CMAKE_CXX_FLAGS did not do the trick when I was
trying to compile everyting with libstdc++'s debug mode enabled. (it
caused linker errors because opm-parser was not linked against
std::debug in this case.) Maybe I got something wrong, though...
