### PR TITLE
Add new EclipseGrid constructor taking a Deck.

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -154,10 +154,7 @@ namespace Opm {
 
 
     void EclipseState::initEclipseGrid(DeckConstPtr deck) {
-        std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-        std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-        
-        m_eclipseGrid = EclipseGridConstPtr( new EclipseGrid( runspecSection , gridSection ));
+        m_eclipseGrid = EclipseGridConstPtr( new EclipseGrid( deck ));
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -69,27 +69,6 @@ namespace Opm {
     } // anonymous namespace
 
     
-    EclipseGrid::EclipseGrid(std::shared_ptr<const RUNSPECSection> runspecSection, std::shared_ptr<const GRIDSection> gridSection)
-        : m_pinchActive(false),
-          m_pinchThresholdThickness(invalidThickness)
-    {
-        if (runspecSection->hasKeyword("DIMENS")) {
-            std::vector<int> dims = getDims(runspecSection->getKeyword("DIMENS"));
-            initGrid(dims, gridSection);
-        } else
-            throw std::invalid_argument("The RUNSPEC section must have the DIMENS keyword with grid dimensions");
-    }
-
-    
-    EclipseGrid::EclipseGrid(int nx, int ny , int nz , std::shared_ptr<const GRIDSection> gridSection)
-        : m_pinchActive(false),
-          m_pinchThresholdThickness(invalidThickness)
-    {
-        std::vector<int> dims = {nx , ny , nz};
-        initGrid( dims , gridSection );
-    }
-
-    
     EclipseGrid::EclipseGrid(std::shared_ptr<const Deck> deck)
         : m_pinchActive(false),
           m_pinchThresholdThickness(invalidThickness)
@@ -99,21 +78,19 @@ namespace Opm {
         if (hasRUNSPEC && hasGRID) {
             // Equivalent to first constructor.
             auto runspecSection = std::make_shared<const RUNSPECSection>(deck);
-            auto gridSection = std::make_shared<const GRIDSection>(deck);
             if (runspecSection->hasKeyword("DIMENS")) {
                 DeckKeywordConstPtr dimens = runspecSection->getKeyword("DIMENS");
                 std::vector<int> dims = getDims(dimens);
-                initGrid(dims, gridSection);
+                initGrid(dims, deck);
             } else {
                 throw std::invalid_argument("The RUNSPEC section must have the DIMENS keyword with grid dimensions.");
             }
         } else if (hasGRID) {
             // Look for SPECGRID instead of DIMENS.
-            auto gridSection = std::make_shared<const GRIDSection>(deck);
-            if (gridSection->hasKeyword("SPECGRID")) {
-                DeckKeywordConstPtr specgrid = gridSection->getKeyword("SPECGRID");
+            if (deck->hasKeyword("SPECGRID")) {
+                DeckKeywordConstPtr specgrid = deck->getKeyword("SPECGRID");
                 std::vector<int> dims = getDims(specgrid);
-                initGrid(dims, gridSection);
+                initGrid(dims, deck);
             } else {
                 throw std::invalid_argument("With no RUNSPEC section, the GRID section must have the SPECGRID keyword with grid dimensions.");
             }
@@ -134,18 +111,18 @@ namespace Opm {
         }
     }
 
-    template <typename DeckOrSectionConstPtr>
-    void EclipseGrid::initGrid( const std::vector<int>& dims , DeckOrSectionConstPtr gridSection ) {
-        if (hasCornerPointKeywordsGeneric(gridSection)) {
-            initCornerPointGrid(dims , gridSection);
-        } else if (hasCartesianKeywordsGeneric(gridSection)) {
-            initCartesianGrid(dims , gridSection);
+
+    void EclipseGrid::initGrid( const std::vector<int>& dims , DeckConstPtr deck ) {
+        if (hasCornerPointKeywords(deck)) {
+            initCornerPointGrid(dims , deck);
+        } else if (hasCartesianKeywords(deck)) {
+            initCartesianGrid(dims , deck);
         } else {
-            throw std::invalid_argument("The GRID section must have COORD / ZCORN or D?? + TOPS keywords");
+            throw std::invalid_argument("The deck must have COORD / ZCORN or D?? + TOPS keywords");
         }
-        if (gridSection->hasKeyword("PINCH")) {
+        if (deck->hasKeyword("PINCH")) {
             m_pinchActive = true;
-            m_pinchThresholdThickness = gridSection->getKeyword("PINCH")->getRecord(0)->getItem("THRESHOLD_THICKNESS")->getSIDouble(0);
+            m_pinchThresholdThickness = deck->getKeyword("PINCH")->getRecord(0)->getItem("THRESHOLD_THICKNESS")->getSIDouble(0);
         }
     }
     
@@ -231,42 +208,34 @@ namespace Opm {
         }
     }
 
-
-    bool EclipseGrid::hasCornerPointKeywords(std::shared_ptr<const GRIDSection> gridSection) {
-        return hasCornerPointKeywordsGeneric(gridSection);
-    }
-
-
-    template <class DeckOrSectionConstPtr>
-    bool EclipseGrid::hasCornerPointKeywordsGeneric(DeckOrSectionConstPtr gridSection) {
-        if (gridSection->hasKeyword("ZCORN") && gridSection->hasKeyword("COORD"))
+    bool EclipseGrid::hasCornerPointKeywords(DeckConstPtr deck) {
+        if (deck->hasKeyword("ZCORN") && deck->hasKeyword("COORD"))
             return true;
         else
             return false;
     }
 
 
-    template <class DeckOrSectionConstPtr>
-    void EclipseGrid::assertCornerPointKeywords( const std::vector<int>& dims , DeckOrSectionConstPtr gridSection ) const
+    void EclipseGrid::assertCornerPointKeywords( const std::vector<int>& dims , DeckConstPtr deck ) const
     {
         const int nx = dims[0];
         const int ny = dims[1];
         const int nz = dims[2];
         {
-            DeckKeywordConstPtr ZCORNKeyWord = gridSection->getKeyword("ZCORN");
+            DeckKeywordConstPtr ZCORNKeyWord = deck->getKeyword("ZCORN");
             
             if (ZCORNKeyWord->getDataSize() != static_cast<size_t>(8*nx*ny*nz))
                 throw std::invalid_argument("Wrong size in ZCORN keyword - expected 8*x*ny*nz = " + boost::lexical_cast<std::string>(8*nx*ny*nz));
         }
 
         {
-            DeckKeywordConstPtr COORDKeyWord = gridSection->getKeyword("COORD");
+            DeckKeywordConstPtr COORDKeyWord = deck->getKeyword("COORD");
             if (COORDKeyWord->getDataSize() != static_cast<size_t>(6*(nx + 1)*(ny + 1)))
                 throw std::invalid_argument("Wrong size in COORD keyword - expected 6*(nx + 1)*(ny + 1) = " + boost::lexical_cast<std::string>(6*(nx + 1)*(ny + 1)));
         }
 
-        if (gridSection->hasKeyword("ACTNUM")) {
-            DeckKeywordConstPtr ACTNUMKeyWord = gridSection->getKeyword("ACTNUM");
+        if (deck->hasKeyword("ACTNUM")) {
+            DeckKeywordConstPtr ACTNUMKeyWord = deck->getKeyword("ACTNUM");
             if (ACTNUMKeyWord->getDataSize() != static_cast<size_t>(nx*ny*nz))
                 throw std::invalid_argument("Wrong size in ACTNUM keyword - expected 8*x*ny*nz = " + boost::lexical_cast<std::string>(nx*ny*nz));
         }
@@ -275,26 +244,25 @@ namespace Opm {
 
 
 
-    template <class DeckOrSectionConstPtr>
-    void EclipseGrid::initCornerPointGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection) {
-        assertCornerPointKeywords( dims , gridSection );
+    void EclipseGrid::initCornerPointGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+        assertCornerPointKeywords( dims , deck );
         {
-            DeckKeywordConstPtr ZCORNKeyWord = gridSection->getKeyword("ZCORN");
-            DeckKeywordConstPtr COORDKeyWord = gridSection->getKeyword("COORD");
+            DeckKeywordConstPtr ZCORNKeyWord = deck->getKeyword("ZCORN");
+            DeckKeywordConstPtr COORDKeyWord = deck->getKeyword("COORD");
             const std::vector<double>& zcorn = ZCORNKeyWord->getSIDoubleData();
             const std::vector<double>& coord = COORDKeyWord->getSIDoubleData();
             const int * actnum = NULL;
             double    * mapaxes = NULL;
             
-            if (gridSection->hasKeyword("ACTNUM")) {
-                DeckKeywordConstPtr actnumKeyword = gridSection->getKeyword("ACTNUM");
+            if (deck->hasKeyword("ACTNUM")) {
+                DeckKeywordConstPtr actnumKeyword = deck->getKeyword("ACTNUM");
                 const std::vector<int>& actnumVector = actnumKeyword->getIntData();
                 actnum = actnumVector.data();
                 
             }
             
-            if (gridSection->hasKeyword("MAPAXES")) {
-                DeckKeywordConstPtr mapaxesKeyword = gridSection->getKeyword("MAPAXES");
+            if (deck->hasKeyword("MAPAXES")) {
+                DeckKeywordConstPtr mapaxesKeyword = deck->getKeyword("MAPAXES");
                 DeckRecordConstPtr record = mapaxesKeyword->getRecord(0);
                 mapaxes = new double[6];
                 for (size_t i = 0; i < 6; i++) {
@@ -324,51 +292,42 @@ namespace Opm {
             }
         }
     }
-    
-
-    bool EclipseGrid::hasCartesianKeywords(std::shared_ptr<const GRIDSection> gridSection) {
-        return hasCartesianKeywordsGeneric(gridSection);
-    }
 
 
-    template <class DeckOrSectionConstPtr>
-    bool EclipseGrid::hasCartesianKeywordsGeneric(DeckOrSectionConstPtr gridSection) {
-        if (hasDVDEPTHZKeywords( gridSection ))
+    bool EclipseGrid::hasCartesianKeywords(DeckConstPtr deck) {
+        if (hasDVDEPTHZKeywords( deck ))
             return true;
         else
-            return hasDTOPSKeywords(gridSection);
+            return hasDTOPSKeywords(deck);
     }
 
 
-    template <class DeckOrSectionConstPtr>
-    bool EclipseGrid::hasDVDEPTHZKeywords(DeckOrSectionConstPtr gridSection) {
-        if (gridSection->hasKeyword("DXV") &&
-            gridSection->hasKeyword("DYV") &&
-            gridSection->hasKeyword("DZV") &&
-            gridSection->hasKeyword("DEPTHZ"))
+    bool EclipseGrid::hasDVDEPTHZKeywords(DeckConstPtr deck) {
+        if (deck->hasKeyword("DXV") &&
+            deck->hasKeyword("DYV") &&
+            deck->hasKeyword("DZV") &&
+            deck->hasKeyword("DEPTHZ"))
             return true;
         else
             return false;
     }
 
-    template <class DeckOrSectionConstPtr>
-    bool EclipseGrid::hasDTOPSKeywords(DeckOrSectionConstPtr gridSection) {
-        if ((gridSection->hasKeyword("DX") || gridSection->hasKeyword("DXV")) &&
-            (gridSection->hasKeyword("DY") || gridSection->hasKeyword("DYV")) &&
-            (gridSection->hasKeyword("DZ") || gridSection->hasKeyword("DZV")) &&
-            gridSection->hasKeyword("TOPS"))
+    bool EclipseGrid::hasDTOPSKeywords(DeckConstPtr deck) {
+        if ((deck->hasKeyword("DX") || deck->hasKeyword("DXV")) &&
+            (deck->hasKeyword("DY") || deck->hasKeyword("DYV")) &&
+            (deck->hasKeyword("DZ") || deck->hasKeyword("DZV")) &&
+            deck->hasKeyword("TOPS"))
             return true;
         else
             return false;
     }
 
 
-    template <class DeckOrSectionConstPtr>
-    void EclipseGrid::initCartesianGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection) {
-        if (hasDVDEPTHZKeywords( gridSection ))
-            initDVDEPTHZGrid( dims , gridSection );
-        else if (hasDTOPSKeywords(gridSection))
-            initDTOPSGrid( dims ,gridSection );
+    void EclipseGrid::initCartesianGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+        if (hasDVDEPTHZKeywords( deck ))
+            initDVDEPTHZGrid( dims , deck );
+        else if (hasDTOPSKeywords(deck))
+            initDTOPSGrid( dims ,deck );
         else 
             throw std::invalid_argument("Tried to initialize cartesian grid without all required keywords");
     }
@@ -379,12 +338,11 @@ namespace Opm {
     }
 
     
-    template <class DeckOrSectionConstPtr>
-    void EclipseGrid::initDVDEPTHZGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection) {
-        const std::vector<double>& DXV = gridSection->getKeyword("DXV")->getSIDoubleData();
-        const std::vector<double>& DYV = gridSection->getKeyword("DYV")->getSIDoubleData();
-        const std::vector<double>& DZV = gridSection->getKeyword("DZV")->getSIDoubleData();
-        const std::vector<double>& DEPTHZ = gridSection->getKeyword("DEPTHZ")->getSIDoubleData();
+    void EclipseGrid::initDVDEPTHZGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+        const std::vector<double>& DXV = deck->getKeyword("DXV")->getSIDoubleData();
+        const std::vector<double>& DYV = deck->getKeyword("DYV")->getSIDoubleData();
+        const std::vector<double>& DZV = deck->getKeyword("DZV")->getSIDoubleData();
+        const std::vector<double>& DEPTHZ = deck->getKeyword("DEPTHZ")->getSIDoubleData();
 
         assertVectorSize( DEPTHZ , static_cast<size_t>( (dims[0] + 1)*(dims[1] +1 )) , "DEPTHZ");
         assertVectorSize( DXV    , static_cast<size_t>( dims[0] ) , "DXV");
@@ -395,22 +353,20 @@ namespace Opm {
     }
 
 
-    template <class DeckOrSectionConstPtr>
-    void EclipseGrid::initDTOPSGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection) {
-        std::vector<double> DX = createDVector( dims , 0 , "DX" , "DXV" , gridSection);
-        std::vector<double> DY = createDVector( dims , 1 , "DY" , "DYV" , gridSection);
-        std::vector<double> DZ = createDVector( dims , 2 , "DZ" , "DZV" , gridSection);
-        std::vector<double> TOPS = createTOPSVector( dims , DZ , gridSection );
+    void EclipseGrid::initDTOPSGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+        std::vector<double> DX = createDVector( dims , 0 , "DX" , "DXV" , deck);
+        std::vector<double> DY = createDVector( dims , 1 , "DY" , "DYV" , deck);
+        std::vector<double> DZ = createDVector( dims , 2 , "DZ" , "DZV" , deck);
+        std::vector<double> TOPS = createTOPSVector( dims , DZ , deck );
         
         m_grid.reset( ecl_grid_alloc_dx_dy_dz_tops( dims[0] , dims[1] , dims[2] , DX.data() , DY.data() , DZ.data() , TOPS.data() , NULL ) , ecl_grid_free);
     }
 
     
-    template <class DeckOrSectionConstPtr>
-    std::vector<double> EclipseGrid::createTOPSVector(const std::vector<int>& dims , const std::vector<double>& DZ , DeckOrSectionConstPtr gridSection) {
+    std::vector<double> EclipseGrid::createTOPSVector(const std::vector<int>& dims , const std::vector<double>& DZ , DeckConstPtr deck) {
         size_t volume = dims[0] * dims[1] * dims[2];
         size_t area = dims[0] * dims[1];
-        DeckKeywordConstPtr TOPSKeyWord = gridSection->getKeyword("TOPS");
+        DeckKeywordConstPtr TOPSKeyWord = deck->getKeyword("TOPS");
         std::vector<double> TOPS = TOPSKeyWord->getSIDoubleData();
         
         if (TOPS.size() >= area) {
@@ -430,13 +386,12 @@ namespace Opm {
 
     
     
-    template <class DeckOrSectionConstPtr>
-    std::vector<double> EclipseGrid::createDVector(const std::vector<int>& dims , size_t dim , const std::string& DKey , const std::string& DVKey, DeckOrSectionConstPtr gridSection) {
+    std::vector<double> EclipseGrid::createDVector(const std::vector<int>& dims , size_t dim , const std::string& DKey , const std::string& DVKey, DeckConstPtr deck) {
         size_t volume = dims[0] * dims[1] * dims[2];
         size_t area = dims[0] * dims[1];
         std::vector<double> D;
-        if (gridSection->hasKeyword(DKey)) {
-            DeckKeywordConstPtr DKeyWord = gridSection->getKeyword(DKey);
+        if (deck->hasKeyword(DKey)) {
+            DeckKeywordConstPtr DKeyWord = deck->getKeyword(DKey);
             D = DKeyWord->getSIDoubleData();
             
 
@@ -456,7 +411,7 @@ namespace Opm {
             if (D.size() != volume)
                 throw std::invalid_argument(DKey + " size mismatch");
         } else {
-            DeckKeywordConstPtr DVKeyWord = gridSection->getKeyword(DVKey);
+            DeckKeywordConstPtr DVKeyWord = deck->getKeyword(DVKey);
             const std::vector<double>& DV = DVKeyWord->getSIDoubleData();
             if (DV.size() != (size_t) dims[dim])
                 throw std::invalid_argument(DVKey + " size mismatch");

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -34,12 +34,10 @@ namespace Opm {
     public:
         explicit EclipseGrid(const std::string& filename);
         explicit EclipseGrid(const ecl_grid_type * src_ptr);
-        EclipseGrid(std::shared_ptr<const RUNSPECSection> runspecSection, std::shared_ptr<const GRIDSection> gridSection);
-        EclipseGrid(int nx, int ny , int nz , std::shared_ptr<const GRIDSection> gridSection);
         explicit EclipseGrid(std::shared_ptr<const Deck> deck);
 
-        static bool hasCornerPointKeywords(std::shared_ptr<const GRIDSection> gridSection);
-        static bool hasCartesianKeywords(std::shared_ptr<const GRIDSection> gridSection);
+        static bool hasCornerPointKeywords(std::shared_ptr<const Deck> deck);
+        static bool hasCartesianKeywords(std::shared_ptr<const Deck> deck);
         size_t  getNumActive( ) const;
         size_t  getNX( ) const;
         size_t  getNY( ) const;
@@ -68,31 +66,17 @@ namespace Opm {
         bool m_pinchActive;
         double m_pinchThresholdThickness;
 
-        template <class DeckOrSectionConstPtr>
-        static bool hasCornerPointKeywordsGeneric(DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        static bool hasCartesianKeywordsGeneric(DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        void initCartesianGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        void initCornerPointGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        void assertCornerPointKeywords( const std::vector<int>& dims , DeckOrSectionConstPtr gridSection ) const ;
-        template <class DeckOrSectionConstPtr>
-        void initDTOPSGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        void initDVDEPTHZGrid(const std::vector<int>& dims , DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        void initGrid( const std::vector<int>& dims , DeckOrSectionConstPtr gridSection );
-        template <class DeckOrSectionConstPtr>
-        static bool hasDVDEPTHZKeywords(DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        static bool hasDTOPSKeywords(DeckOrSectionConstPtr gridSection);
+        void initCartesianGrid(const std::vector<int>& dims , DeckConstPtr deck);
+        void initCornerPointGrid(const std::vector<int>& dims , DeckConstPtr deck);
+        void assertCornerPointKeywords( const std::vector<int>& dims , DeckConstPtr deck ) const ;
+        void initDTOPSGrid(const std::vector<int>& dims , DeckConstPtr deck);
+        void initDVDEPTHZGrid(const std::vector<int>& dims , DeckConstPtr deck);
+        void initGrid( const std::vector<int>& dims , DeckConstPtr deck );
+        static bool hasDVDEPTHZKeywords(DeckConstPtr deck);
+        static bool hasDTOPSKeywords(DeckConstPtr deck);
         static void assertVectorSize(const std::vector<double>& vector , size_t expectedSize , const std::string& msg);
-        template <class DeckOrSectionConstPtr>
-        std::vector<double> createTOPSVector(const std::vector<int>& dims , const std::vector<double>& DZ , DeckOrSectionConstPtr gridSection);
-        template <class DeckOrSectionConstPtr>
-        std::vector<double> createDVector(const std::vector<int>& dims , size_t dim , const std::string& DKey , const std::string& DVKey, DeckOrSectionConstPtr gridSection);
+        std::vector<double> createTOPSVector(const std::vector<int>& dims , const std::vector<double>& DZ , DeckConstPtr deck);
+        std::vector<double> createDVector(const std::vector<int>& dims , size_t dim , const std::string& DKey , const std::string& DVKey, DeckConstPtr deck);
         void scatterDim(const std::vector<int>& dims , size_t dim , const std::vector<double>& DV , std::vector<double>& D);
    };
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -45,9 +45,7 @@ BOOST_AUTO_TEST_CASE(CreateMissingDIMENS_throws) {
     deck->addKeyword(test1);
     deck->addKeyword(test2);
 
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    BOOST_CHECK_THROW(new Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(new Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
@@ -70,9 +68,8 @@ static Opm::DeckPtr createDeckHeaders() {
 
 BOOST_AUTO_TEST_CASE(HasGridKeywords) {
     Opm::DeckPtr deck = createDeckHeaders();
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( gridSection ));
-    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( gridSection ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( deck ));
 }
 
 static Opm::DeckPtr createCPDeck() {
@@ -188,12 +185,9 @@ static Opm::DeckPtr createCARTInvalidDeck() {
 BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
     Opm::DeckPtr deck1 = createCARTDeck();
     Opm::DeckPtr deck2 = createCARTDeckDEPTHZ();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck1) );
-    std::shared_ptr<Opm::GRIDSection> gridSection1(new Opm::GRIDSection(deck1) );
-    std::shared_ptr<Opm::GRIDSection> gridSection2(new Opm::GRIDSection(deck2) );
     
-    std::shared_ptr<Opm::EclipseGrid> grid1(new Opm::EclipseGrid( runspecSection , gridSection1 ));
-    std::shared_ptr<Opm::EclipseGrid> grid2(new Opm::EclipseGrid( runspecSection , gridSection2 ));
+    std::shared_ptr<Opm::EclipseGrid> grid1(new Opm::EclipseGrid( deck1 ));
+    std::shared_ptr<Opm::EclipseGrid> grid2(new Opm::EclipseGrid( deck2 ));
 
     BOOST_CHECK( grid1->equal( *(grid2.get()) ));
 
@@ -235,33 +229,29 @@ BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
 
 BOOST_AUTO_TEST_CASE(HasCPKeywords) {
     Opm::DeckPtr deck = createCPDeck();
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK(  Opm::EclipseGrid::hasCornerPointKeywords( gridSection ));
-    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( gridSection ));
+    BOOST_CHECK(  Opm::EclipseGrid::hasCornerPointKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( deck ));
 }
 
 
 BOOST_AUTO_TEST_CASE(HasCartKeywords) {
     Opm::DeckPtr deck = createCARTDeck();
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( gridSection ));
-    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( gridSection ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
+    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( deck ));
 }
 
 
 BOOST_AUTO_TEST_CASE(HasCartKeywordsDEPTHZ) {
     Opm::DeckPtr deck = createCARTDeckDEPTHZ();
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( gridSection ));
-    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( gridSection ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
+    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( deck ));
 }
 
 
 BOOST_AUTO_TEST_CASE(HasINVALIDCartKeywords) {
     Opm::DeckPtr deck = createCARTInvalidDeck();
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( gridSection ));
-    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( gridSection ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( deck ));
 }
 
 
@@ -270,9 +260,7 @@ BOOST_AUTO_TEST_CASE(HasINVALIDCartKeywords) {
 
 BOOST_AUTO_TEST_CASE(CreateMissingGRID_throws) {
     Opm::DeckPtr deck = createDeckHeaders();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK_THROW(new Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(new Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
@@ -302,9 +290,7 @@ static Opm::DeckPtr createInvalidDXYZCARTDeck() {
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRID) {
     Opm::DeckPtr deck = createInvalidDXYZCARTDeck();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK_THROW(new Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(new Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
@@ -334,9 +320,7 @@ static Opm::DeckPtr createInvalidDXYZCARTDeckDEPTHZ() {
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDDEPTHZ) {
     Opm::DeckPtr deck = createInvalidDXYZCARTDeckDEPTHZ();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK_THROW(new Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(new Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
@@ -388,9 +372,7 @@ static Opm::DeckPtr createInvalidDEPTHZDeck1 () {
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDInvalidDEPTHZ1) {
     Opm::DeckPtr deck = createInvalidDEPTHZDeck1();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK_THROW(new Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(new Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
@@ -418,18 +400,14 @@ static Opm::DeckPtr createInvalidDEPTHZDeck2 () {
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDInvalidDEPTHZ2) {
     Opm::DeckPtr deck = createInvalidDEPTHZDeck2();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK_THROW(new Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(new Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDOnlyTopLayerDZ) {
     Opm::DeckPtr deck = createOnlyTopDZCartGrid();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    std::shared_ptr<Opm::EclipseGrid> grid(new Opm::EclipseGrid( runspecSection , gridSection ));
+    std::shared_ptr<Opm::EclipseGrid> grid(new Opm::EclipseGrid( deck ));
 
     BOOST_CHECK_EQUAL( 10 , grid->getNX( ));
     BOOST_CHECK_EQUAL(  5 , grid->getNY( ));
@@ -441,9 +419,7 @@ BOOST_AUTO_TEST_CASE(CreateCartesianGRIDOnlyTopLayerDZ) {
 
 BOOST_AUTO_TEST_CASE(AllActiveExportActnum) {
     Opm::DeckPtr deck = createOnlyTopDZCartGrid();
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    std::shared_ptr<Opm::EclipseGrid> grid(new Opm::EclipseGrid( runspecSection , gridSection ));
+    std::shared_ptr<Opm::EclipseGrid> grid(new Opm::EclipseGrid( deck ));
 
     std::vector<int> actnum;
 
@@ -472,12 +448,10 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchCOORD) {
  
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    Opm::DeckKeywordConstPtr zcorn = gridSection->getKeyword("ZCORN");
+    Opm::DeckKeywordConstPtr zcorn = deck->getKeyword("ZCORN");
     BOOST_CHECK_EQUAL( 8000U , zcorn->getDataSize( ));
 
-    BOOST_CHECK_THROW(Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW(Opm::EclipseGrid( std::move(deck) ) , std::invalid_argument);
 }
 
 
@@ -499,10 +473,8 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchZCORN) {
  
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    Opm::DeckKeywordConstPtr zcorn = gridSection->getKeyword("ZCORN");
-    BOOST_CHECK_THROW(Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    Opm::DeckKeywordConstPtr zcorn = deck->getKeyword("ZCORN");
+    BOOST_CHECK_THROW((void)Opm::EclipseGrid(deck), std::invalid_argument);
 }
 
 
@@ -524,9 +496,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchACTNUM) {
  
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    BOOST_CHECK_THROW(Opm::EclipseGrid( runspecSection , gridSection ) , std::invalid_argument);
+    BOOST_CHECK_THROW((void)Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
 
@@ -547,10 +517,8 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
  
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
     
-    Opm::EclipseGrid grid(runspecSection , gridSection );
+    Opm::EclipseGrid grid(deck);
     BOOST_CHECK_EQUAL( 1000U , grid.getNumActive());
     std::vector<int> actnum(1000);
     actnum[0] = 1;
@@ -584,9 +552,7 @@ BOOST_AUTO_TEST_CASE(Fwrite) {
  
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection(new Opm::RUNSPECSection(deck) );
-    std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
-    Opm::EclipseGrid grid1(runspecSection , gridSection );
+    Opm::EclipseGrid grid1(deck );
 
     grid1.fwriteEGRID( "TEST.EGRID" );
 
@@ -602,6 +568,8 @@ BOOST_AUTO_TEST_CASE(Fwrite) {
 BOOST_AUTO_TEST_CASE(ConstructorNORUNSPEC) {
     const char *deckData =
         "GRID\n"
+        "SPECGRID \n"
+        "  10 10 10 / \n"
         "COORD\n"
         "  726*1 / \n"
         "ZCORN \n"
@@ -614,12 +582,9 @@ BOOST_AUTO_TEST_CASE(ConstructorNORUNSPEC) {
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck1 = parser->parseString(deckData) ;
     Opm::DeckConstPtr deck2 = createCPDeck();
-    std::shared_ptr<Opm::GRIDSection> gridSection1(new Opm::GRIDSection(deck1) );
-    std::shared_ptr<Opm::GRIDSection> gridSection2(new Opm::GRIDSection(deck2) );
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection2(new Opm::RUNSPECSection(deck2) );
-    
-    Opm::EclipseGrid grid1(10,10,10 , gridSection1 );
-    Opm::EclipseGrid grid2(runspecSection2 , gridSection2 );
+
+    Opm::EclipseGrid grid1(deck1);
+    Opm::EclipseGrid grid2(deck2);
 
     BOOST_CHECK(grid1.equal( grid2 ));
 }
@@ -641,11 +606,9 @@ BOOST_AUTO_TEST_CASE(ConstructorNoSections) {
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck1 = parser->parseString(deckData) ;
     Opm::DeckConstPtr deck2 = createCPDeck();
-    std::shared_ptr<Opm::GRIDSection> gridSection2(new Opm::GRIDSection(deck2) );
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection2(new Opm::RUNSPECSection(deck2) );
 
     Opm::EclipseGrid grid1(deck1);
-    Opm::EclipseGrid grid2(runspecSection2 , gridSection2 );
+    Opm::EclipseGrid grid2(deck2);
 
     BOOST_CHECK(grid1.equal( grid2 ));
 }
@@ -655,13 +618,9 @@ BOOST_AUTO_TEST_CASE(ConstructorNoSections) {
 BOOST_AUTO_TEST_CASE(ConstructorNORUNSPEC_PINCH) {
     Opm::DeckConstPtr deck1 = createCPDeck();
     Opm::DeckConstPtr deck2 = createPinchedCPDeck();
-    std::shared_ptr<Opm::GRIDSection> gridSection1(new Opm::GRIDSection(deck1) );
-    std::shared_ptr<Opm::GRIDSection> gridSection2(new Opm::GRIDSection(deck2) );
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection1(new Opm::RUNSPECSection(deck1) );
-    std::shared_ptr<Opm::RUNSPECSection> runspecSection2(new Opm::RUNSPECSection(deck2) );
 
-    Opm::EclipseGrid grid1(runspecSection1 , gridSection1 );
-    Opm::EclipseGrid grid2(runspecSection2 , gridSection2 );
+    Opm::EclipseGrid grid1(deck1);
+    Opm::EclipseGrid grid2(deck2);
 
     BOOST_CHECK(!grid1.equal( grid2 ));
     BOOST_CHECK(!grid1.isPinchActive());

--- a/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
@@ -36,9 +36,7 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
-    std::shared_ptr<RUNSPECSection> runspecSection(new RUNSPECSection(deck) );
-    std::shared_ptr<GRIDSection> gridSection(new GRIDSection(deck) );
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( runspecSection , gridSection ));
+    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
     BOOST_CHECK_EQUAL( 10U  , grid->getNX( ));
     BOOST_CHECK_EQUAL( 10U  , grid->getNY( ));
@@ -51,9 +49,7 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
-    std::shared_ptr<RUNSPECSection> runspecSection(new RUNSPECSection(deck) );
-    std::shared_ptr<GRIDSection> gridSection(new GRIDSection(deck) );
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( runspecSection , gridSection ));
+    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
     BOOST_CHECK_EQUAL(  10U , grid->getNX( ));
     BOOST_CHECK_EQUAL(  10U , grid->getNY( ));
@@ -67,9 +63,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
 
-    std::shared_ptr<RUNSPECSection> runspecSection(new RUNSPECSection(deck) );
-    std::shared_ptr<GRIDSection> gridSection(new GRIDSection(deck) );
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( runspecSection , gridSection ));
+    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
     std::vector<int> actnum;
 
@@ -86,9 +80,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
 
-    std::shared_ptr<RUNSPECSection> runspecSection(new RUNSPECSection(deck) );
-    std::shared_ptr<GRIDSection> gridSection(new GRIDSection(deck) );
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( runspecSection , gridSection ));
+    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
     std::vector<double> coord;
     std::vector<double> zcorn;


### PR DESCRIPTION
The new constructor allows us to create EclipseGrid objects from decks that do not have a strict sectioned structure. This should allow us to consolidate the construction process for grids around the EclipseGrid class, even for cases where we do not require strict sectioning (such as the upscaling codes).

This also modifies some implementation details. Many methods are now templates, and can take Deck or Section objects (they have the same hasKeyword/getKeyword interface).
