### PR TITLE
Fix the NullStream class.

### DIFF
--- a/opm/parser/eclipse/Deck/Section.hpp
+++ b/opm/parser/eclipse/Deck/Section.hpp
@@ -31,13 +31,22 @@ namespace Opm {
 
     class Section : public boost::iterator_facade<Section, DeckKeywordPtr, boost::forward_traversal_tag>
     {
+        // Defining a no-op output stream nullStream.
         // see https://stackoverflow.com/questions/11826554/standard-no-op-output-stream
-        class NullStream : public std::ostream
+        class NullBuffer : public std::streambuf
         {
         public:
             int overflow(int c) { return c; }
         };
+        class NullStream : public std::ostream
+        {
+        public:
+            NullStream() : std::ostream(&m_sb) {}
+        private:
+            NullBuffer m_sb;
+        };
         static NullStream nullStream;
+
     public:
         Section(DeckConstPtr deck, const std::string& startKeyword);
         bool hasKeyword( const std::string& keyword ) const;


### PR DESCRIPTION
It is the std::streambuf that should be inherited from. The NullStream class is just a convenience class.

Without this I get the following test results:

```
The following tests FAILED:
     21 - runSectionTests (SEGFAULT)
     25 - runParseTOPS (SEGFAULT)
     27 - runParseWellWithWildcards (SEGFAULT)
     33 - runScheduleCreateFromDeck (SEGFAULT)
     43 - runBoxTest (SEGFAULT)
     45 - runEclipseGridCreateFromDeck (SEGFAULT)
     46 - runEclipseStateTests (SEGFAULT)
     48 - runScheduleTests (SEGFAULT)
     60 - runEclipseGridTests (SEGFAULT)
Errors while running CTest
```

I am not quite sure why, it may be due implementation-defined behaviour for some ostream corner cases, anyway fixing the NullStream makes the issue go away.
