### PR TITLE
add a few missing includes

### DIFF
--- a/opm/json/cjson/cJSON.h
+++ b/opm/json/cjson/cJSON.h
@@ -23,6 +23,8 @@
 #ifndef cJSON__h
 #define cJSON__h
 
+#include <stdlib.h>
+
 #ifdef __cplusplus
 extern "C"
 {

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -20,6 +20,7 @@
 #ifndef RAWCONSTS_HPP
 #define	RAWCONSTS_HPP
 
+#include <string>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -22,7 +22,7 @@
 
 #include <string>
 #include <deque>
-
+#include <memory>
 
 namespace Opm {
 


### PR DESCRIPTION
these includes are required by the headers. If the affected files
would have been included without the headers included before, a
compiler error would have been produced.
