### PR TITLE
work around an optimizer performance bug in clang.

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -611,25 +611,21 @@ namespace Opm {
             os << indent << lhs << "->setMatchRegex(\"" << m_matchRegexString << "\");" << std::endl;
 
         for (size_t i = 0; i < m_record->size(); i++) {
-            os << indent << "{" << std::endl;
+            const std::string local_indent = indent + "   ";
+            ParserItemConstPtr item = m_record->get(i);
+            os << local_indent << "ParserItemPtr "<<item->name()<<"item(";
+            item->inlineNew(os);
+            os << ");" << std::endl;
+            os << local_indent << item->name()<<"item->setDescription(\"" << item->getDescription() << "\");" << std::endl;
+            for (size_t idim=0; idim < item->numDimensions(); idim++)
+                os << local_indent <<item->name()<<"item->push_backDimension(\"" << item->getDimension( idim ) << "\");" << std::endl;
             {
-                const std::string local_indent = indent + "   ";
-                ParserItemConstPtr item = m_record->get(i);
-                os << local_indent << "ParserItemPtr item(";
-                item->inlineNew(os);
-                os << ");" << std::endl;
-                os << local_indent << "item->setDescription(\"" << item->getDescription() << "\");" << std::endl;
-                for (size_t idim=0; idim < item->numDimensions(); idim++)
-                    os << local_indent << "item->push_backDimension(\"" << item->getDimension( idim ) << "\");" << std::endl;
-                {
-                    std::string addItemMethod = "addItem";
-                    if (m_isDataKeyword)
-                        addItemMethod = "addDataItem";
+                std::string addItemMethod = "addItem";
+                if (m_isDataKeyword)
+                    addItemMethod = "addDataItem";
 
-                    os << local_indent << lhs << "->" << addItemMethod << "(item);" << std::endl;
-                }
+                os << local_indent << lhs << "->" << addItemMethod << "("<<item->name()<<"item);" << std::endl;
             }
-            os << indent << "}" << std::endl;
         }
     }
 


### PR DESCRIPTION
It seems like some optimization passes of CLang which are enabled by
-O2 (at least in my version, 3.3) do not like nested scopes and long
functions too much. Thus, slightly change the generated source. Timing
on my (quite beefy) machine:

without patch:

make
rm -rf generated-source
time make
[...]
real    10m31.110s
user    10m16.264s
sys     0m13.672s

with patch:

make
rm -rf generated-source
time make
[...]
real    0m47.011s
user    0m44.670s
sys     0m1.968s

the memory used by the compiler goes from 28.8GB to about 330 MB. (I
suppose not everybody has 32 Gigs of memory yet. ;)
