### PR TITLE
Capture and Provide Completion Direction

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
@@ -22,7 +22,7 @@
 
 namespace Opm {
 
-    Completion::Completion(int i, int j , int k , CompletionStateEnum state , double CF, double diameter, double skinFactor) {
+    Completion::Completion(int i, int j , int k , CompletionStateEnum state , double CF, double diameter, double skinFactor, const CompletionDirection::DirectionEnum direction) {
         m_i = i;
         m_j = j;
         m_k = k;
@@ -31,6 +31,7 @@ namespace Opm {
         m_CF = CF;
         m_diameter = diameter;
         m_skinFactor = skinFactor;
+        m_direction = direction;
     }
 
 
@@ -68,10 +69,10 @@ namespace Opm {
         double CF = compdatRecord->getItem("CF")->getSIDouble(0);
         double diameter = compdatRecord->getItem("DIAMETER")->getSIDouble(0);
         double skinFactor = compdatRecord->getItem("SKIN")->getRawDouble(0);
-
+        const CompletionDirection::DirectionEnum& direction = CompletionDirection::DirectionEnumFromString(compdatRecord->getItem("DIR")->getTrimmedString(0));
 
         for (int k = K1; k <= K2; k++) {
-            CompletionPtr completion(new Completion(I , J , k , state , CF, diameter, skinFactor ));
+            CompletionPtr completion(new Completion(I , J , k , state , CF, diameter, skinFactor, direction ));
             completions.push_back( completion );
         }
 
@@ -144,6 +145,10 @@ namespace Opm {
     
     double Completion::getSkinFactor() const {
         return m_skinFactor;
+    }
+
+    CompletionDirection::DirectionEnum Completion::getDirection() const {
+        return m_direction;
     }
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
@@ -22,6 +22,7 @@
 #define COMPLETION_HPP_
 
 #include <memory>
+#include <string>
 #include <boost/date_time.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
@@ -33,7 +34,7 @@ namespace Opm {
 
     class Completion {
     public:
-        Completion(int i, int j , int k , CompletionStateEnum state , double CF, double diameter, double skinFactor);
+        Completion(int i, int j , int k , CompletionStateEnum state , double CF, double diameter, double skinFactor, const CompletionDirection::DirectionEnum direction = CompletionDirection::DirectionEnum::Z);
         bool sameCoordinate(const Completion& other) const;
         int getI() const;
         int getJ() const;
@@ -44,6 +45,8 @@ namespace Opm {
         double getSkinFactor() const;
         void   fixDefaultIJ(int wellHeadI , int wellHeadJ);
 
+        CompletionDirection::DirectionEnum getDirection() const;
+
         static std::map<std::string , std::vector<std::shared_ptr<Completion> > >  completionsFromCOMPDATKeyword( DeckKeywordConstPtr compdatKeyword );
         static std::pair<std::string , std::vector<std::shared_ptr<Completion> > > completionsFromCOMPDATRecord( DeckRecordConstPtr compdatRecord );
         
@@ -51,6 +54,7 @@ namespace Opm {
         int m_i, m_j, m_k;
         double m_CF, m_diameter, m_skinFactor;
         CompletionStateEnum m_state;
+        CompletionDirection::DirectionEnum m_direction;
     };
 
     typedef std::shared_ptr<Completion> CompletionPtr;

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -448,4 +448,48 @@ namespace Opm {
                 throw std::invalid_argument("Unknown enum state string: " + stringValue );
         }
     }
+
+
+    namespace CompletionDirection {
+        std::string
+        DirectionEnum2String(const DirectionEnum enumValue)
+        {
+            std::string stringValue;
+
+            switch (enumValue) {
+            case DirectionEnum::X:
+                stringValue = "X";
+                break;
+
+            case DirectionEnum::Y:
+                stringValue = "Y";
+                break;
+
+            case DirectionEnum::Z:
+                stringValue = "Z";
+                break;
+            }
+
+            return stringValue;
+        }
+
+        DirectionEnum
+        DirectionEnumFromString(const std::string& stringValue)
+        {
+            std::string s(stringValue);
+            boost::algorithm::trim(s);
+
+            DirectionEnum direction;
+
+            if      (s == "X") { direction = DirectionEnum::X; }
+            else if (s == "Y") { direction = DirectionEnum::Y; }
+            else if (s == "Z") { direction = DirectionEnum::Z; }
+            else {
+                std::string msg = "Unsupported completion direction " + s;
+                throw std::invalid_argument(msg);
+            }
+
+            return direction;
+        }
+    } // namespace CompletionDirection
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -45,6 +45,18 @@ namespace Opm {
     };
 
 
+    namespace CompletionDirection {
+        enum DirectionEnum {
+            X = 1,
+            Y = 2,
+            Z = 3
+        };
+
+        std::string   DirectionEnum2String(const DirectionEnum enumValue);
+        DirectionEnum DirectionEnumFromString(const std::string& stringValue);
+    } // namespace CompletionDirection
+
+
     namespace Phase { 
         enum PhaseEnum {
             OIL   = 1,

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleEnumTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleEnumTests.cpp
@@ -51,6 +51,42 @@ BOOST_AUTO_TEST_CASE(TestCompletionStateEnumLoop) {
     BOOST_CHECK_EQUAL( "SHUT" , CompletionStateEnum2String(CompletionStateEnumFromString(  "SHUT" ) ));
 }
 
+
+/*****************************************************************/
+
+BOOST_AUTO_TEST_CASE(TestCompletionDirectionEnum2String)
+{
+    using namespace CompletionDirection;
+
+    BOOST_CHECK_EQUAL("X", DirectionEnum2String(DirectionEnum::X));
+    BOOST_CHECK_EQUAL("Y", DirectionEnum2String(DirectionEnum::Y));
+    BOOST_CHECK_EQUAL("Z", DirectionEnum2String(DirectionEnum::Z));
+}
+
+BOOST_AUTO_TEST_CASE(TestCompletionDirectionEnumFromString)
+{
+    using namespace CompletionDirection;
+
+    BOOST_CHECK_THROW(DirectionEnumFromString("XXX"), std::invalid_argument);
+
+    BOOST_CHECK_EQUAL(DirectionEnum::X, DirectionEnumFromString("X"));
+    BOOST_CHECK_EQUAL(DirectionEnum::Y, DirectionEnumFromString("Y"));
+    BOOST_CHECK_EQUAL(DirectionEnum::Z, DirectionEnumFromString("Z"));
+}
+
+BOOST_AUTO_TEST_CASE(TestCompletionDirectionEnumLoop)
+{
+    using namespace CompletionDirection;
+
+    BOOST_CHECK_EQUAL(DirectionEnum::X, DirectionEnumFromString(DirectionEnum2String(DirectionEnum::X)));
+    BOOST_CHECK_EQUAL(DirectionEnum::Y, DirectionEnumFromString(DirectionEnum2String(DirectionEnum::Y)));
+    BOOST_CHECK_EQUAL(DirectionEnum::Z, DirectionEnumFromString(DirectionEnum2String(DirectionEnum::Z)));
+
+    BOOST_CHECK_EQUAL("X", DirectionEnum2String(DirectionEnumFromString("X")));
+    BOOST_CHECK_EQUAL("Y", DirectionEnum2String(DirectionEnumFromString("Y")));
+    BOOST_CHECK_EQUAL("Z", DirectionEnum2String(DirectionEnumFromString("Z")));
+}
+
 /*****************************************************************/
 
 BOOST_AUTO_TEST_CASE(TestGroupInjectionControlEnum2String) {

--- a/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
@@ -56,12 +56,14 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromRecord ) {
         BOOST_CHECK_EQUAL( 0  , completion0->getK() );
         BOOST_CHECK_EQUAL( OPEN  , completion0->getState() );
         BOOST_CHECK_EQUAL(  3.8134259259259256e-12 , completion0->getCF() );
+        BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::X, completion0->getDirection() );
 
         BOOST_CHECK_EQUAL( 29 , completion2->getI() );
         BOOST_CHECK_EQUAL( 36 , completion2->getJ() );
         BOOST_CHECK_EQUAL( 2  , completion2->getK() );
         BOOST_CHECK_EQUAL( OPEN  , completion2->getState() );
         BOOST_CHECK_EQUAL( 3.8134259259259256e-12  , completion2->getCF() );
+        BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::X, completion2->getDirection() );
     }
         
     // We do not accept a defaulted Connection Factor
@@ -99,12 +101,14 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromKeyword ) {
     BOOST_CHECK_EQUAL( 0      , completion0->getK() );
     BOOST_CHECK_EQUAL( OPEN   , completion0->getState() );
     BOOST_CHECK_EQUAL( 3.1726851851851847e-12 , completion0->getCF() );
+    BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::Y, completion0->getDirection() );
 
     BOOST_CHECK_EQUAL( 30     , completion4->getI() );
     BOOST_CHECK_EQUAL( 16     , completion4->getJ() );
     BOOST_CHECK_EQUAL( 3      , completion4->getK() );
     BOOST_CHECK_EQUAL( OPEN   , completion4->getState() );
     BOOST_CHECK_EQUAL( 5.4722222222222212e-13 , completion4->getCF() );
+    BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::Y, completion4->getDirection() );
 
     
     


### PR DESCRIPTION
This is needed for clients to act intelligently in the presence of horizontal completions (in the context of deviated wells).

Note: I am open to other alternatives, but from a client point of view I'd like to be able to put the return value of

```
Completion::getDirection()
```

into a `switch`.
