### PR TITLE
throw if multiple occurences of the same keyword were found were they are not supposed to be

### DIFF
--- a/opm/parser/eclipse/Deck/KeywordContainer.cpp
+++ b/opm/parser/eclipse/Deck/KeywordContainer.cpp
@@ -70,6 +70,9 @@ namespace Opm {
 
     DeckKeywordPtr KeywordContainer::getKeyword(const std::string& keyword) const {
         const std::vector<DeckKeywordPtr>& keywordList = getKeywordList( keyword );
+        if (keywordList.size() != 1)
+            throw std::invalid_argument("Keyword '"+keyword+"' is occures multiple times in the deck "
+                                        "but must be unique.");
         return keywordList.back();
     }
 


### PR DESCRIPTION
for now, the "keyword must be unique" property is simply defined as
"simulator uses the Deck::getKeyword(name) method". maybe it is a bit
too simplistic but it is a quite pragmatic solution...

note that before this, the getKeyword() method would have worked for
non-unique keywords but it would have returned an undefined one (the
last one which occured in the deck). This probably was not behavior
the expected by the calling code.

All decks which I tested (SPE1, SPE9 and Norne) are unaffected by
this change.
