### PR TITLE
fix compiler warnings and rename CF to CompletionFactor

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
@@ -24,17 +24,16 @@
 namespace Opm {
 
     Completion::Completion(int i, int j , int k , CompletionStateEnum state , 
-                           const Value<double>& CF,
+                           const Value<double>& connectionTransmissibilityFactor,
                            const Value<double>& diameter, 
                            const Value<double>& skinFactor, 
-                           const CompletionDirection::DirectionEnum direction) : m_i(i),
-                                                                                 m_j(j),
-                                                                                 m_k(k),
-        m_state(state),
-        m_CF(CF),
-        m_diameter(diameter),
-        m_skinFactor(skinFactor),
-        m_direction(direction) 
+                           const CompletionDirection::DirectionEnum direction)
+        : m_i(i), m_j(j), m_k(k),
+          m_diameter(diameter),
+          m_connectionTransmissibilityFactor(connectionTransmissibilityFactor),
+          m_skinFactor(skinFactor),
+          m_state(state),
+          m_direction(direction) 
     {  }
 
 
@@ -63,17 +62,17 @@ namespace Opm {
         int K1 = compdatRecord->getItem("K1")->getInt(0) - 1;
         int K2 = compdatRecord->getItem("K2")->getInt(0) - 1;
         CompletionStateEnum state = CompletionStateEnumFromString( compdatRecord->getItem("STATE")->getTrimmedString(0) );
-        Value<double> CF("CF");
+        Value<double> connectionTransmissibilityFactor("ConnectionTransmissibilityFactor");
         Value<double> diameter("Diameter");
         Value<double> skinFactor("SkinFactor");
 
         {
-            DeckItemConstPtr CFItem = compdatRecord->getItem("CF");
+            DeckItemConstPtr connectionTransmissibilityFactorItem = compdatRecord->getItem("CONNECTION_TRANSMISSIBILITY_FACTOR");
             DeckItemConstPtr diameterItem = compdatRecord->getItem("DIAMETER");
             DeckItemConstPtr skinFactorItem = compdatRecord->getItem("SKIN");
 
-            if (CFItem->hasData())
-                CF.setValue( CFItem->getSIDouble(0));
+            if (connectionTransmissibilityFactorItem->hasData())
+                connectionTransmissibilityFactor.setValue( connectionTransmissibilityFactorItem->getSIDouble(0));
             
             if (diameterItem->hasData())
                 diameter.setValue( diameterItem->getSIDouble(0));
@@ -85,7 +84,7 @@ namespace Opm {
         const CompletionDirection::DirectionEnum& direction = CompletionDirection::DirectionEnumFromString(compdatRecord->getItem("DIR")->getTrimmedString(0));
 
         for (int k = K1; k <= K2; k++) {
-            CompletionPtr completion(new Completion(I , J , k , state , CF, diameter, skinFactor, direction ));
+            CompletionPtr completion(new Completion(I , J , k , state , connectionTransmissibilityFactor, diameter, skinFactor, direction ));
             completions.push_back( completion );
         }
 
@@ -148,8 +147,8 @@ namespace Opm {
         return m_state;
     }
 
-    double Completion::getCF() const {
-        return m_CF.getValue();
+    double Completion::getConnectionTransmissibilityFactor() const {
+        return m_connectionTransmissibilityFactor.getValue();
     }
 
     double Completion::getDiameter() const {

--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
@@ -36,7 +36,7 @@ namespace Opm {
     class Completion {
     public:
         Completion(int i, int j , int k , CompletionStateEnum state , 
-                   const Value<double>& CF,
+                   const Value<double>& connectionTransmissibilityFactor,
                    const Value<double>& diameter, 
                    const Value<double>& skinFactor, 
                    const CompletionDirection::DirectionEnum direction = CompletionDirection::DirectionEnum::Z);
@@ -46,7 +46,7 @@ namespace Opm {
         int getJ() const;
         int getK() const;
         CompletionStateEnum getState() const;
-        double getCF() const;
+        double getConnectionTransmissibilityFactor() const;
         double getDiameter() const;
         double getSkinFactor() const;
         void   fixDefaultIJ(int wellHeadI , int wellHeadJ);
@@ -59,7 +59,7 @@ namespace Opm {
     private:
         int m_i, m_j, m_k;
         Value<double> m_diameter;
-        Value<double> m_CF;
+        Value<double> m_connectionTransmissibilityFactor;
         Value<double> m_skinFactor;
         CompletionStateEnum m_state;
         CompletionDirection::DirectionEnum m_direction;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionSetTests.cpp
@@ -48,8 +48,8 @@ BOOST_AUTO_TEST_CASE(CreateCompletionSetOK) {
 
 BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     Opm::CompletionSet completionSet;
-    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionConstPtr completion2(new Opm::Completion(11,10,10,Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion2(new Opm::Completion(11,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
 
 BOOST_AUTO_TEST_CASE(CompletionSetGetOutOfRangeThrows) {
     Opm::CompletionSet completionSet;
-    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionConstPtr completion2(new Opm::Completion(11,10,10,Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion2(new Opm::Completion(11,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -78,8 +78,8 @@ BOOST_AUTO_TEST_CASE(CompletionSetGetOutOfRangeThrows) {
 
 BOOST_AUTO_TEST_CASE(AddCompletionSameCellUpdates) {
     Opm::CompletionSet completionSet;
-    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionConstPtr completion2(new Opm::Completion(10,10,10,Opm::SHUT , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion2(new Opm::Completion(10,10,10,Opm::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
     
 
     completionSet.add( completion1 );
@@ -94,9 +94,9 @@ BOOST_AUTO_TEST_CASE(AddCompletionSameCellUpdates) {
 BOOST_AUTO_TEST_CASE(AddCompletionShallowCopy) {
     Opm::CompletionSet completionSet;
 
-    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionConstPtr completion2(new Opm::Completion(10,10,11,Opm::SHUT , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionConstPtr completion3(new Opm::Completion(10,10,12,Opm::SHUT , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion2(new Opm::Completion(10,10,11,Opm::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionConstPtr completion3(new Opm::Completion(10,10,12,Opm::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
 
     completionSet.add( completion1 );
     completionSet.add( completion2 );

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionTests.cpp
@@ -39,29 +39,29 @@
 
 
 BOOST_AUTO_TEST_CASE(CreateCompletionOK) {
-    Opm::Completion completion(10,10,10,Opm::OPEN,Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion(10,10,10,Opm::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 }
 
 
 BOOST_AUTO_TEST_CASE(testGetFunctions) {
-    Opm::Completion completion(10,11,12,Opm::OPEN,Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion(10,11,12,Opm::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
     BOOST_CHECK_EQUAL( 10 , completion.getI() );
     BOOST_CHECK_EQUAL( 11 , completion.getJ() );
     BOOST_CHECK_EQUAL( 12 , completion.getK() );
 
     BOOST_CHECK_EQUAL( Opm::OPEN , completion.getState());
-    BOOST_CHECK_EQUAL( 99.88 , completion.getCF());
+    BOOST_CHECK_EQUAL( 99.88 , completion.getConnectionTransmissibilityFactor());
     BOOST_CHECK_EQUAL( 22.33 , completion.getDiameter());
     BOOST_CHECK_EQUAL( 33.22 , completion.getSkinFactor());
 }
 
 
 BOOST_AUTO_TEST_CASE(CompletionTestssameCoordinate) {
-    Opm::Completion completion1(10,10,10,Opm::OPEN, Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion2(10,10,10,Opm::OPEN, Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion3(11,10,10,Opm::OPEN, Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion4(10,11,10,Opm::OPEN, Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion5(10,10,11,Opm::OPEN, Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion1(10,10,10,Opm::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion2(10,10,10,Opm::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion3(11,10,10,Opm::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion4(10,11,10,Opm::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion5(10,10,11,Opm::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 
     BOOST_CHECK( completion1.sameCoordinate( completion2 ));
     BOOST_CHECK_EQUAL( false , completion1.sameCoordinate( completion3 ));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -171,11 +171,11 @@ BOOST_AUTO_TEST_CASE(UpdateCompletions) {
     
     std::vector<Opm::CompletionPtr> newCompletions;
     std::vector<Opm::CompletionPtr> newCompletions2;
-    Opm::CompletionPtr comp1(new Opm::Completion( 10 , 10 , 10 , Opm::AUTO , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionPtr comp2(new Opm::Completion( 10 , 11 , 10 , Opm::SHUT , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionPtr comp3(new Opm::Completion( 10 , 10 , 12 , Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionPtr comp4(new Opm::Completion( 10 , 10 , 12 , Opm::SHUT , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    Opm::CompletionPtr comp5(new Opm::Completion( 10 , 10 , 13 , Opm::OPEN , Opm::Value<double>("CF",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionPtr comp1(new Opm::Completion( 10 , 10 , 10 , Opm::AUTO , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionPtr comp2(new Opm::Completion( 10 , 11 , 10 , Opm::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionPtr comp3(new Opm::Completion( 10 , 10 , 12 , Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionPtr comp4(new Opm::Completion( 10 , 10 , 12 , Opm::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
+    Opm::CompletionPtr comp5(new Opm::Completion( 10 , 10 , 13 , Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
 
     //std::vector<Opm::CompletionConstPtr> newCompletions2{ comp4 , comp5}; Newer c++
 

--- a/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
@@ -58,14 +58,14 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromRecord ) {
         BOOST_CHECK_EQUAL( 36 , completion0->getJ() );
         BOOST_CHECK_EQUAL( 0  , completion0->getK() );
         BOOST_CHECK_EQUAL( OPEN  , completion0->getState() );
-        BOOST_CHECK_EQUAL(  3.8134259259259256e-12 , completion0->getCF() );
+        BOOST_CHECK_EQUAL(  3.8134259259259256e-12 , completion0->getConnectionTransmissibilityFactor() );
         BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::X, completion0->getDirection() );
 
         BOOST_CHECK_EQUAL( 29 , completion2->getI() );
         BOOST_CHECK_EQUAL( 36 , completion2->getJ() );
         BOOST_CHECK_EQUAL( 2  , completion2->getK() );
         BOOST_CHECK_EQUAL( OPEN  , completion2->getState() );
-        BOOST_CHECK_EQUAL( 3.8134259259259256e-12  , completion2->getCF() );
+        BOOST_CHECK_EQUAL( 3.8134259259259256e-12  , completion2->getConnectionTransmissibilityFactor() );
         BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::X, completion2->getDirection() );
     }
 
@@ -76,7 +76,7 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromRecord ) {
         CompletionPtr comp = pair.second[0];
         /*
           This statement gives a compilation error:
-          BOOST_CHECK_THROW( comp->getCF() , std::logical_error );
+          BOOST_CHECK_THROW( comp->getConnectionTransmissibilityFactor() , std::logical_error );
         */
     }
 }
@@ -111,14 +111,14 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromKeyword ) {
     BOOST_CHECK_EQUAL( 17     , completion0->getJ() );
     BOOST_CHECK_EQUAL( 0      , completion0->getK() );
     BOOST_CHECK_EQUAL( OPEN   , completion0->getState() );
-    BOOST_CHECK_EQUAL( 3.1726851851851847e-12 , completion0->getCF() );
+    BOOST_CHECK_EQUAL( 3.1726851851851847e-12 , completion0->getConnectionTransmissibilityFactor() );
     BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::Y, completion0->getDirection() );
 
     BOOST_CHECK_EQUAL( 30     , completion4->getI() );
     BOOST_CHECK_EQUAL( 16     , completion4->getJ() );
     BOOST_CHECK_EQUAL( 3      , completion4->getK() );
     BOOST_CHECK_EQUAL( OPEN   , completion4->getState() );
-    BOOST_CHECK_EQUAL( 5.4722222222222212e-13 , completion4->getCF() );
+    BOOST_CHECK_EQUAL( 5.4722222222222212e-13 , completion4->getConnectionTransmissibilityFactor() );
     BOOST_CHECK_EQUAL( Opm::CompletionDirection::DirectionEnum::Y, completion4->getDirection() );
 }
 

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
         BOOST_CHECK_EQUAL(4U, completions->size());
 
         BOOST_CHECK_EQUAL(OPEN, completions->get(3)->getState());
-        BOOST_CHECK_EQUAL(2.2836805555555556e-12 , completions->get(3)->getCF());
+        BOOST_CHECK_EQUAL(2.2836805555555556e-12 , completions->get(3)->getConnectionTransmissibilityFactor());
         BOOST_CHECK_EQUAL(0.311/Metric::Length, completions->get(3)->getDiameter());
         BOOST_CHECK_EQUAL(3.3, completions->get(3)->getSkinFactor());
 

--- a/opm/parser/share/keywords/C/COMPDAT
+++ b/opm/parser/share/keywords/C/COMPDAT
@@ -6,7 +6,7 @@
     {"name" : "K2" , "value_type" : "INT" },
     {"name" : "STATE" , "value_type" : "STRING" , "default" : "OPEN"},
     {"name" : "SAT_TABLE" , "value_type" : "INT" , "default" : 0},
-    {"name" : "CF"     , "value_type" : "DOUBLE", "dimension" : "Viscosity*LiquidVolume/Time*Pressure"},
+    {"name" : "CONNECTION_TRANSMISSIBILITY_FACTOR"     , "value_type" : "DOUBLE", "dimension" : "Viscosity*LiquidVolume/Time*Pressure"},
     {"name" : "DIAMETER" , "value_type" : "DOUBLE", "dimension" : "Length"},
     {"name" : "Kh" , "value_type" : "DOUBLE", "dimension" : "Permeability" , "default" : -1},
     {"name" : "SKIN" , "value_type" : "DOUBLE", "dimension" : "1" , "default" : 0},


### PR DESCRIPTION
for the compiler warnings, see e.g.

https://opm-project.org/CDash/viewBuildError.php?type=1&buildid=27777

the CF to CompletionFactor rename makes things much easier to
understand for people who are not intimately familiar with the wells
code. (if "CF" does not stand for "completion factor", this only
underscores the point. In this case, please add a comment what it
means then...)

Note: this PR must be merged sychronously with OPM/opm-core#650
