### PR TITLE
EclipseState: provide an accessor method for the unit system used by the deck

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -33,7 +33,7 @@ namespace Opm {
     
     EclipseState::EclipseState(DeckConstPtr deck, bool beStrict)
     {
-        m_unitSystem = deck->getActiveUnitSystem();
+        m_deckUnitSystem = deck->getActiveUnitSystem();
 
         if (beStrict) {
             // make sure all mandatory sections are present and that their order is correct
@@ -51,12 +51,14 @@ namespace Opm {
         initTransMult();
         initFaults(deck);
     }
-    
+
+    std::shared_ptr<const UnitSystem> EclipseState::getDeckUnitSystem() const {
+        return m_deckUnitSystem;
+    }
 
     EclipseGridConstPtr EclipseState::getEclipseGrid() const {
         return m_eclipseGrid;
     }
-
 
     EclipseGridPtr EclipseState::getEclipseGridCopy() const {
         return std::make_shared<EclipseGrid>( m_eclipseGrid->c_ptr() );
@@ -440,7 +442,7 @@ namespace Opm {
 
     double EclipseState::getSIScaling(const std::string &dimensionString) const
     {
-        return m_unitSystem->getDimension(dimensionString)->getSIScaling();
+        return m_deckUnitSystem->getDimension(dimensionString)->getSIScaling();
     }
 
     void EclipseState::processGridProperties(Opm::DeckConstPtr deck, int enabledTypes) {

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -62,6 +62,12 @@ namespace Opm {
 
         std::shared_ptr<const FaultCollection> getFaults() const;
         std::shared_ptr<const TransMult> getTransMult() const;
+
+        // the unit system used by the deck. note that it is rarely needed to convert
+        // units because internally to opm-parser everything is represented by SI
+        // units...
+        std::shared_ptr<const UnitSystem> getDeckUnitSystem()  const;
+
     private:
         void initSchedule(DeckConstPtr deck);
         void initEclipseGrid(DeckConstPtr deck);
@@ -92,7 +98,7 @@ namespace Opm {
         ScheduleConstPtr schedule;
         std::set<enum Phase::PhaseEnum> phases;
         std::string m_title;
-        std::shared_ptr<UnitSystem> m_unitSystem;
+        std::shared_ptr<const UnitSystem> m_deckUnitSystem;
         std::shared_ptr<GridProperties<int> > m_intGridProperties;
         std::shared_ptr<GridProperties<double> > m_doubleGridProperties;
         std::shared_ptr<TransMult> m_transMult;


### PR DESCRIPTION
this is required to convert calculated quantities to the same units as
the ones used in the input deck.
