### PR TITLE
Added support for wconinjh

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -312,10 +312,13 @@ namespace Opm {
             WellInjectionProperties properties(well->getInjectionPropertiesCopy(currentStep));
 
             properties.injectorType = injectorType;
+
+            const std::string& cmodeString = record->getItem("CMODE")->getTrimmedString(0);
+            WellInjector::ControlModeEnum controlMode = WellInjector::ControlModeFromString( cmodeString );
             if (!record->getItem("RATE")->defaultApplied(0)) {
                 properties.surfaceInjectionRate = injectionRate;
-                properties.addInjectionControl(WellInjector::RATE);
-                properties.controlMode = WellInjector::RATE;
+                properties.addInjectionControl(controlMode);
+                properties.controlMode = controlMode;
             }
             properties.predictionMode = false;
 

--- a/opm/parser/share/keywords/W/WCONINJH
+++ b/opm/parser/share/keywords/W/WCONINJH
@@ -10,5 +10,5 @@
     {"name" : "SURFACE_OIL_FRACTION" , "value_type" : "DOUBLE" , "default" : 0},
     {"name" : "SURFACE_WATER_FRACTION" , "value_type" : "DOUBLE" , "default" : 0},
     {"name" : "SURFACE_GAS_FRACTION" , "value_type" : "DOUBLE" , "default" : 0},
-    {"name" : "CMODE"        , "value_type" : "STRING" }
+    {"name" : "CMODE"        , "value_type" : "STRING", "default" : "RATE" }
 ]}


### PR DESCRIPTION
No injection type is set  for WCONINJH. 
In order to be able to run a schedule with WCONINJH, we must set an injection type.
We choose RATE control, as it is usually done for history matching.
