### PR TITLE
check if the keyword item has sufficiently many data points before using defaultApplied()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -135,8 +135,11 @@ public:
         const std::vector<size_t>& indexList = inputBox->getIndexList();
         for (size_t sourceIdx = 0; sourceIdx < indexList.size(); sourceIdx++) {
             size_t targetIdx = indexList[sourceIdx];
-            if (!deckItem->defaultApplied(sourceIdx))
+            if (sourceIdx < deckItem->size()
+                && !deckItem->defaultApplied(sourceIdx))
+            {
                 setDataPoint(sourceIdx, targetIdx, deckItem);
+            }
         }
     }
 


### PR DESCRIPTION
this fixes the GridPropertyTests unit test. The morale of this is that
I should probably never trust my own stupidity...

I should have done a full ctest run after each patch before merging of the grid property initializers, but the fixup seemed pretty trivial...
