### PR TITLE
size of PLYMAX should be determined by NPLMIX in REGDIMS not MISCIBLE.

### DIFF
--- a/opm/parser/share/keywords/P/PLYMAX
+++ b/opm/parser/share/keywords/P/PLYMAX
@@ -1,4 +1,4 @@
-{"name" : "PLYMAX" , "size" : {"keyword" : "MISCIBLE" , "item" : "NTMISC"} , "items" :
+{"name" : "PLYMAX" , "size" : {"keyword" : "REGDIMS" , "item" : "NPLMIX"} , "items" :
     [
         {"name" : "MAX_POLYMER_CONCENTRATION" , "value_type" : "DOUBLE"  , "dimension" : "PolymerDensity"},
         {"name" : "MAX_SALT_CONCENTRATION" , "value_type" : "DOUBLE" , "dimension" : "PolymerDensity"}


### PR DESCRIPTION
This should fix part of https://github.com/OPM/opm-polymer/issues/68 .
