### PR TITLE
add the ALL keyword

### DIFF
--- a/opm/parser/share/keywords/A/ALL
+++ b/opm/parser/share/keywords/A/ALL
@@ -1,0 +1,5 @@
+{
+  "name" : "ALL",
+  "sections" : [ "SUMMARY" ],
+  "comment" : "This keyword is undocumented but seems to be widely used. (It is even featured by an example in the Reference Manual.)"
+}


### PR DESCRIPTION
This keyword is undocumented but seems to be widely used. (It is even
featured by an example in the Reference Manual.)
