### PR TITLE
Fix PORV tests v2

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -507,26 +507,27 @@ namespace Opm {
 
     void EclipseState::initProperties(DeckConstPtr deck, ParserLogPtr parserLog) {
         typedef GridProperties<int>::SupportedKeywordInfo SupportedIntKeywordInfo;
-        static std::vector<SupportedIntKeywordInfo> supportedIntKeywords =
-            {SupportedIntKeywordInfo( "SATNUM" , 1, "1" ),
-             SupportedIntKeywordInfo( "IMBNUM" , 1, "1" ),
-             SupportedIntKeywordInfo( "PVTNUM" , 1, "1" ),
-             SupportedIntKeywordInfo( "EQLNUM" , 1, "1" ),
-             SupportedIntKeywordInfo( "ENDNUM" , 1, "1" ),
-             SupportedIntKeywordInfo( "FLUXNUM" , 1 , "1" ),
-             SupportedIntKeywordInfo( "MULTNUM", 1 , "1" ),
-             SupportedIntKeywordInfo( "FIPNUM" , 1, "1" )};
+        std::shared_ptr<std::vector<SupportedIntKeywordInfo> > supportedIntKeywords(new std::vector<SupportedIntKeywordInfo>{
+            SupportedIntKeywordInfo( "SATNUM" , 1, "1" ),
+            SupportedIntKeywordInfo( "IMBNUM" , 1, "1" ),
+            SupportedIntKeywordInfo( "PVTNUM" , 1, "1" ),
+            SupportedIntKeywordInfo( "EQLNUM" , 1, "1" ),
+            SupportedIntKeywordInfo( "ENDNUM" , 1, "1" ),
+            SupportedIntKeywordInfo( "FLUXNUM" , 1 , "1" ),
+            SupportedIntKeywordInfo( "MULTNUM", 1 , "1" ),
+            SupportedIntKeywordInfo( "FIPNUM" , 1, "1" )
+            });
 
         double nan = std::numeric_limits<double>::quiet_NaN();
         const auto eptLookup = std::make_shared<GridPropertyEndpointTableLookupInitializer<>>(*deck, *this);
-        const auto distributeTopLayer = std::make_shared<GridPropertyPostProcessor::DistributeTopLayer>(*this);
+        const auto distributeTopLayer = std::make_shared<const GridPropertyPostProcessor::DistributeTopLayer>(*this);
         const auto initPORV = std::make_shared<GridPropertyPostProcessor::InitPORV>(*this);
 
 
         // Note that the variants of grid keywords for radial grids
         // are not supported. (and hopefully never will be)
         typedef GridProperties<double>::SupportedKeywordInfo SupportedDoubleKeywordInfo;
-        static std::vector<SupportedDoubleKeywordInfo> supportedDoubleKeywords = {
+        std::shared_ptr<std::vector<SupportedDoubleKeywordInfo> > supportedDoubleKeywords(new std::vector<SupportedDoubleKeywordInfo>{
             // keywords to specify the scaled connate gas
             // saturations.
             SupportedDoubleKeywordInfo( "SGL"    , eptLookup, "1" ),
@@ -692,7 +693,7 @@ namespace Opm {
 
             // initialisation
             SupportedDoubleKeywordInfo( "SWATINIT" , 0.0, "1")
-        };
+                });
 
         // create the grid properties
         m_intGridProperties = std::make_shared<GridProperties<int> >(m_eclipseGrid->getNX(),

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
@@ -52,12 +52,12 @@ public:
     typedef typename GridProperty<T>::SupportedKeywordInfo SupportedKeywordInfo;
 
     GridProperties(size_t nx , size_t ny , size_t nz ,
-                   const std::vector<SupportedKeywordInfo> & supportedKeywords) {
+                   std::shared_ptr<const std::vector<SupportedKeywordInfo> > supportedKeywords) {
         m_nx = nx;
         m_ny = ny;
         m_nz = nz;
         
-        for (auto iter = supportedKeywords.begin(); iter != supportedKeywords.end(); ++iter) 
+        for (auto iter = supportedKeywords->begin(); iter != supportedKeywords->end(); ++iter) 
             m_supportedKeywords[iter->getKeywordName()] = *iter;
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
@@ -37,9 +37,10 @@
 
 BOOST_AUTO_TEST_CASE(Empty) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    std::vector<SupportedKeywordInfo> supportedKeywords =
-        { SupportedKeywordInfo("SATNUM" , 0, "1"),
-          SupportedKeywordInfo("FIPNUM" , 2, "1") };
+    std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
+            SupportedKeywordInfo("SATNUM" , 0, "1"),
+            SupportedKeywordInfo("FIPNUM" , 2, "1")
+        });
     Opm::GridProperties<int> gridProperties( 10, 10, 100 , supportedKeywords);
     
     BOOST_CHECK( gridProperties.supportsKeyword("SATNUM") );
@@ -53,8 +54,9 @@ BOOST_AUTO_TEST_CASE(Empty) {
 
 BOOST_AUTO_TEST_CASE(addKeyword) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    std::vector<SupportedKeywordInfo> supportedKeywords =
-        { SupportedKeywordInfo("SATNUM" , 0, "1") };
+    std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
+        SupportedKeywordInfo("SATNUM" , 0, "1")
+    });
     Opm::GridProperties<int> gridProperties( 100, 10 , 10 , supportedKeywords);
     
     BOOST_CHECK_THROW( gridProperties.addKeyword("NOT-SUPPORTED") , std::invalid_argument);
@@ -69,8 +71,9 @@ BOOST_AUTO_TEST_CASE(addKeyword) {
 
 BOOST_AUTO_TEST_CASE(getKeyword) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    std::vector<SupportedKeywordInfo> supportedKeywords =
-        { SupportedKeywordInfo("SATNUM" , 0, "1") };
+    std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
+        SupportedKeywordInfo("SATNUM" , 0, "1")
+    });
     Opm::GridProperties<int> gridProperties( 100,25,4 , supportedKeywords);
     std::shared_ptr<Opm::GridProperty<int> > satnum1 = gridProperties.getKeyword("SATNUM");
     std::shared_ptr<Opm::GridProperty<int> > satnum2 = gridProperties.getKeyword("SATNUM");

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -422,10 +422,12 @@ static Opm::DeckPtr createDeck() {
 BOOST_AUTO_TEST_CASE(GridPropertyPostProcessors) {
     std::shared_ptr<TestPostProcessorMul<double> > testPostP = std::make_shared<TestPostProcessorMul<double> >(2.0);
     
-
-    Opm::GridPropertySupportedKeywordInfo<double> kwInfo1("MULTPV" , 1.0 , "1");
-    Opm::GridPropertySupportedKeywordInfo<double> kwInfo2("PORO"   , 1.0 , testPostP , "1");
-    Opm::GridProperties<double> properties(10,10,10, std::vector<Opm::GridPropertySupportedKeywordInfo<double> > { kwInfo1 , kwInfo2 });
+    typedef Opm::GridPropertySupportedKeywordInfo<double> SupportedKeywordInfo;
+    SupportedKeywordInfo kwInfo1("MULTPV" , 1.0 , "1");
+    SupportedKeywordInfo kwInfo2("PORO"   , 1.0 , testPostP , "1");
+    std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
+        kwInfo1 , kwInfo2 });
+    Opm::GridProperties<double> properties(10,10,10,supportedKeywords);
     Opm::DeckPtr deck = createDeck();
     Opm::EclipseGrid grid(deck);
     

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
@@ -107,9 +107,10 @@ static Opm::DeckPtr createInvalidMULTREGTDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidInput) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    std::vector<SupportedKeywordInfo> supportedKeywords = { SupportedKeywordInfo("FLUXNUM" , 1 , "1") , 
-                                                            SupportedKeywordInfo("OPERNUM" , 1 , "1") ,
-                                                            SupportedKeywordInfo("MULTNUM" , 1 , "1") };
+    std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
+            SupportedKeywordInfo("FLUXNUM" , 1 , "1") , 
+            SupportedKeywordInfo("OPERNUM" , 1 , "1") ,
+            SupportedKeywordInfo("MULTNUM" , 1 , "1") });
 
     Opm::MULTREGTScanner scanner;
     Opm::DeckPtr deck = createInvalidMULTREGTDeck();
@@ -244,9 +245,10 @@ static Opm::DeckPtr createSimpleMULTREGTDeck() {
 
 BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
-    std::vector<SupportedKeywordInfo> supportedKeywords = { SupportedKeywordInfo("FLUXNUM" , 1 , "1") , 
-                                                            SupportedKeywordInfo("OPERNUM" , 1 , "1") ,
-                                                            SupportedKeywordInfo("MULTNUM" , 1 , "1") };
+    std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
+            SupportedKeywordInfo("FLUXNUM" , 1 , "1") , 
+                SupportedKeywordInfo("OPERNUM" , 1 , "1") ,
+                SupportedKeywordInfo("MULTNUM" , 1 , "1") });
 
     Opm::DeckPtr deck = createSimpleMULTREGTDeck();
     Opm::EclipseGrid grid(deck);

--- a/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
@@ -227,20 +227,20 @@ static Opm::DeckPtr createDeckWithNTG() {
 BOOST_AUTO_TEST_CASE(PORV_cartesianDeck) {
     /* Check that an exception is raised if we try to create a PORV field without PORO. */
     Opm::DeckPtr deck = createCARTDeck();
-    Opm::EclipseState state(deck);
-    auto poro = state.getDoubleGridProperty("PORO");
+    auto state = std::make_shared<Opm::EclipseState>(deck);
+    auto poro = state->getDoubleGridProperty("PORO");
     BOOST_CHECK( poro->containsNaN() );
-    BOOST_CHECK_THROW( state.getDoubleGridProperty("PORV") , std::logic_error );
+    BOOST_CHECK_THROW( state->getDoubleGridProperty("PORV") , std::logic_error );
 }
 
 BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
     /* Check that the PORV field is correctly calculated from PORO. */
     Opm::DeckPtr deck = createDeckWithPORO();
-    Opm::EclipseState state(deck);
-    auto poro = state.getDoubleGridProperty("PORO");
+    auto state = std::make_shared<Opm::EclipseState>(deck);
+    auto poro = state->getDoubleGridProperty("PORO");
     BOOST_CHECK( !poro->containsNaN() );
 
-    auto porv = state.getDoubleGridProperty("PORV");
+    auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
     BOOST_CHECK_CLOSE( cell_volume * 0.10 , porv->iget(0,0,0) , 0.001);
@@ -256,8 +256,8 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
 BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
     /* Check that explicit PORV and CellVOlume * PORO can be combined. */
     Opm::DeckPtr deck = createDeckWithPORVPORO();
-    Opm::EclipseState state(deck);
-    auto porv = state.getDoubleGridProperty("PORV");
+    auto state = std::make_shared<Opm::EclipseState>(deck);
+    auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
     BOOST_CHECK_CLOSE( 77.0 , porv->iget(0,0,0) , 0.001);
@@ -273,8 +273,8 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
 BOOST_AUTO_TEST_CASE(PORV_multpv) {
     /* Check that MULTPV is correctly accounted for. */
     Opm::DeckPtr deck = createDeckWithMULTPV();
-    Opm::EclipseState state(deck);
-    auto porv = state.getDoubleGridProperty("PORV");
+    auto state = std::make_shared<Opm::EclipseState>(deck);
+    auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
     BOOST_CHECK_CLOSE( 770.0 , porv->iget(0,0,0) , 0.001);
@@ -294,8 +294,8 @@ BOOST_AUTO_TEST_CASE(PORV_multpv) {
 BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work */
     Opm::DeckPtr deck = createDeckWithBOXPORV();
-    Opm::EclipseState state(deck);
-    auto porv = state.getDoubleGridProperty("PORV");
+    auto state = std::make_shared<Opm::EclipseState>(deck);
+    auto porv = state->getDoubleGridProperty("PORV");
 
     BOOST_CHECK_CLOSE( 1234.56 , porv->iget(0,0,0) , 0.001);
     BOOST_CHECK_CLOSE( 1234.56 , porv->iget(9,9,9) , 0.001);
@@ -308,8 +308,8 @@ BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
 BOOST_AUTO_TEST_CASE(PORV_multpvAndNtg) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work and NTG */
     Opm::DeckPtr deck = createDeckWithNTG();
-    Opm::EclipseState state(deck);
-    auto porv = state.getDoubleGridProperty("PORV");
+    auto state = std::make_shared<Opm::EclipseState>(deck);
+    auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
     double poro = 0.20;
     double multpv = 10;


### PR DESCRIPTION
next try to fix the PORV test of #329. the problem was uglier than I expected, see the commit message of the second patch. On my machine, it fixes the segfaults for GCC 4.4 in debug and release mode using boost 1.44 and Clang 3.5 with boost 1.54 in debug mode. other configurations will probably work too, but I didn't test them...

One issue remains: on GCC 4.4 with optimizations, I get test failures of the following kind:

```
70: unknown location(0): fatal error in "PORV_cartesianDeck": std::logic_error: Only <double> and can be meaningfully queried for nan
70: /home/and/ctest/gcc-44/src/opm-parser/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp(232): last checkpoint
```

these seem to be unrelated, though.
