### PR TITLE
fix the "only <double> can be queried for NaN" exceptions

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -32,6 +32,10 @@ void GridProperty<double>::setDataPoint(size_t sourceIdx, size_t targetIdx, Opm:
     m_data[targetIdx] = deckItem->getSIDouble(sourceIdx);
 }
 
+template<>
+bool GridProperty<int>::containsNaN( ) {
+    throw std::logic_error("Only <double> and can be meaningfully queried for nan");
+}
 
 template<>
 bool GridProperty<double>::containsNaN( ) {

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -205,9 +205,7 @@ public:
         iset(g,value);
     }
 
-    bool containsNaN( ) {
-        throw std::logic_error("Only <double> and can be meaningfully queried for nan");
-    }
+    bool containsNaN();
 
     void multiplyWith(const GridProperty<T>& other) {
         if ((m_nx == other.m_nx) && (m_ny == other.m_ny) && (m_nz == other.m_nz)) {


### PR DESCRIPTION
seems like some compilers don't overwrite an inline method of a
template class with its specialization. A compiler warning would have
been nice to have in this case, though...
