### PR TITLE
ParserItems: make the exception message if instantiation from JSON fails more useful

### DIFF
--- a/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
@@ -69,8 +69,8 @@ namespace Opm
 
 
 
-    ParserDoubleItem::ParserDoubleItem(const Json::JsonObject& jsonConfig) :
-            ParserItem(jsonConfig)
+    ParserDoubleItem::ParserDoubleItem(const std::string& keywordName, const Json::JsonObject& jsonConfig)
+        : ParserItem(keywordName, jsonConfig)
     {
         m_default = std::numeric_limits<double>::quiet_NaN();
         if (jsonConfig.has_item("default")) 

--- a/opm/parser/eclipse/Parser/ParserDoubleItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserDoubleItem.hpp
@@ -38,7 +38,7 @@ namespace Opm {
         ParserDoubleItem(const std::string& itemName, ParserItemSizeEnum sizeType);
         ParserDoubleItem(const std::string& itemName, double defaultValue);
         ParserDoubleItem(const std::string& itemName, ParserItemSizeEnum sizeType, double defaultValue);
-        explicit ParserDoubleItem( const Json::JsonObject& jsonConfig);
+        explicit ParserDoubleItem(const std::string& keywordName, const Json::JsonObject& jsonConfig);
 
         size_t numDimensions() const;
         bool hasDimension() const;

--- a/opm/parser/eclipse/Parser/ParserFloatItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserFloatItem.cpp
@@ -71,8 +71,8 @@ namespace Opm
 
 
 
-    ParserFloatItem::ParserFloatItem(const Json::JsonObject& jsonConfig) :
-            ParserItem(jsonConfig)
+    ParserFloatItem::ParserFloatItem(const std::string& keywordName, const Json::JsonObject& jsonConfig)
+        : ParserItem(keywordName, jsonConfig)
     {
         m_default = std::numeric_limits<float>::quiet_NaN();
         if (jsonConfig.has_item("default"))

--- a/opm/parser/eclipse/Parser/ParserFloatItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserFloatItem.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         ParserFloatItem(const std::string& itemName, ParserItemSizeEnum sizeType);
         ParserFloatItem(const std::string& itemName, float defaultValue);
         ParserFloatItem(const std::string& itemName, ParserItemSizeEnum sizeType, float defaultValue);
-        explicit ParserFloatItem( const Json::JsonObject& jsonConfig);
+        explicit ParserFloatItem(const std::string& keywordName, const Json::JsonObject& jsonConfig);
 
         size_t numDimensions() const;
         bool hasDimension() const;

--- a/opm/parser/eclipse/Parser/ParserIntItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserIntItem.cpp
@@ -52,7 +52,7 @@ namespace Opm {
         setDefault(defaultValue);
     }
 
-    ParserIntItem::ParserIntItem(const Json::JsonObject& jsonConfig) : ParserItem(jsonConfig)
+    ParserIntItem::ParserIntItem(const std::string& keywordName, const Json::JsonObject& jsonConfig) : ParserItem(keywordName, jsonConfig)
     {
         m_default = -1;
         if (jsonConfig.has_item("default")) 

--- a/opm/parser/eclipse/Parser/ParserIntItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserIntItem.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType);
         ParserIntItem(const std::string& itemName, int defaultValue);
         ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType, int defaultValue);
-        explicit ParserIntItem(const Json::JsonObject& jsonConfig);
+        explicit ParserIntItem(const std::string& keywordName, const Json::JsonObject& jsonConfig);
 
         DeckItemPtr scan(RawRecordPtr rawRecord) const;
         bool equal(const ParserItem& other) const;

--- a/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -49,18 +49,18 @@ namespace Opm {
     }
 
     const std::string& ParserItem::getDimension(size_t /* index */) const {
-        throw std::invalid_argument("Should not call this ... \n");       
+        throw std::invalid_argument("The getDimension() method has not been overwritten by the actual item class\n");
     }
 
     void ParserItem::push_backDimension(const std::string& /* dimension */) {
-        throw std::invalid_argument("Should not call this ... \n");       
+        throw std::invalid_argument("The push_backDimension() method has not been overwritten by the actual item class\n");
     }
     
-    ParserItem::ParserItem(const Json::JsonObject& jsonConfig) {
+    ParserItem::ParserItem(const std::string& keywordName, const Json::JsonObject& jsonConfig) {
         if (jsonConfig.has_item("name"))
             m_name = jsonConfig.get_string("name");
         else
-            throw std::invalid_argument("Json config object missing \"name\": ... item");
+            throw std::invalid_argument("The JSON specification of keyword "+keywordName+" is missing the mandatory 'name' field for an item");
 
         if (jsonConfig.has_item("size_type")) {
             const std::string sizeTypeString = jsonConfig.get_string("size_type");

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -40,7 +40,7 @@ namespace Opm {
     public:
         ParserItem(const std::string& itemName);
         ParserItem(const std::string& itemName, ParserItemSizeEnum sizeType);
-        explicit ParserItem(const Json::JsonObject& jsonConfig);
+        explicit ParserItem(const std::string& keywordName, const Json::JsonObject& jsonConfig);
 
         virtual void push_backDimension(const std::string& dimension);
         virtual const std::string& getDimension(size_t index) const;

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -345,26 +345,26 @@ namespace Opm {
                     switch (valueType) {
                     case INT:
                         {
-                            ParserIntItemConstPtr item = ParserIntItemConstPtr(new ParserIntItem(itemConfig));
+                            ParserIntItemConstPtr item = ParserIntItemConstPtr(new ParserIntItem(getName(), itemConfig));
                             addItem(item);
                         }
                         break;
                     case STRING:
                         {
-                            ParserStringItemConstPtr item = ParserStringItemConstPtr(new ParserStringItem(itemConfig));
+                            ParserStringItemConstPtr item = ParserStringItemConstPtr(new ParserStringItem(getName(), itemConfig));
                             addItem(item);
                         }
                         break;
                     case DOUBLE:
                         {
-                            ParserDoubleItemPtr item = ParserDoubleItemPtr(new ParserDoubleItem(itemConfig));
+                            ParserDoubleItemPtr item = ParserDoubleItemPtr(new ParserDoubleItem(getName(), itemConfig));
                             initDoubleItemDimension( item , itemConfig );
                             addItem(item);
                         }
                         break;
                     case FLOAT:
                         {
-                            ParserFloatItemPtr item = ParserFloatItemPtr(new ParserFloatItem(itemConfig));
+                            ParserFloatItemPtr item = ParserFloatItemPtr(new ParserFloatItem(getName(), itemConfig));
                             initFloatItemDimension( item , itemConfig );
                             addItem(item);
                         }

--- a/opm/parser/eclipse/Parser/ParserStringItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserStringItem.cpp
@@ -45,7 +45,7 @@ namespace Opm {
     }
 
 
-    ParserStringItem::ParserStringItem(const Json::JsonObject& jsonConfig) : ParserItem(jsonConfig) {
+    ParserStringItem::ParserStringItem(const std::string& keywordName, const Json::JsonObject& jsonConfig) : ParserItem(keywordName, jsonConfig) {
         m_default = "";
         if (jsonConfig.has_item("default")) 
             setDefault( jsonConfig.get_string("default") );

--- a/opm/parser/eclipse/Parser/ParserStringItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserStringItem.hpp
@@ -36,7 +36,7 @@ namespace Opm {
         ParserStringItem(const std::string& itemName, ParserItemSizeEnum sizeType);
         ParserStringItem(const std::string& itemName, ParserItemSizeEnum sizeType, const std::string& defaultValue);
         ParserStringItem(const std::string& itemName, const std::string& defaultValue);
-        explicit ParserStringItem( const Json::JsonObject& jsonConfig);
+        explicit ParserStringItem(const std::string& keywordName, const Json::JsonObject& jsonConfig);
 
         bool equal(const ParserItem& other) const;
         DeckItemPtr scan(RawRecordPtr rawRecord) const;

--- a/opm/parser/eclipse/Parser/tests/ParserItemTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserItemTests.cpp
@@ -125,13 +125,13 @@ BOOST_AUTO_TEST_CASE(InitializeIntItem_setDescription_canReadBack) {
 /* <Json> */
 BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_missingName_throws) {
     Json::JsonObject jsonConfig("{\"nameX\": \"ITEM1\" , \"size_type\" : \"ALL\"}");
-    BOOST_CHECK_THROW( ParserIntItem item1( jsonConfig ) , std::invalid_argument );
+    BOOST_CHECK_THROW( ParserIntItem item1("TESTKEYWORD", jsonConfig ) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_defaultSizeType) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" }");
-    ParserIntItem item1( jsonConfig );
+    ParserIntItem item1("TESTKEYWORD", jsonConfig );
     BOOST_CHECK_EQUAL( SINGLE , item1.sizeType());
 }
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_defaultSizeType) {
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"ALL\"}");
-    ParserIntItem item1( jsonConfig );
+    ParserIntItem item1("TESTKEYWORD", jsonConfig);
     BOOST_CHECK_EQUAL( "ITEM1" , item1.name() );
     BOOST_CHECK_EQUAL( ALL , item1.sizeType() );
     BOOST_CHECK(item1.getDefault() < 0);
@@ -148,20 +148,20 @@ BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject) {
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_withDefault) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"SINGLE\", \"default\" : 100}");
-    ParserIntItem item1( jsonConfig );
+    ParserIntItem item1("TESTKEYWORD", jsonConfig);
     BOOST_CHECK_EQUAL( 100 , item1.getDefault() );
 }
 
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_withDefaultInvalid_throws) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"SINGLE\", \"default\" : \"100X\"}");
-    BOOST_CHECK_THROW( ParserIntItem item1( jsonConfig ) , std::invalid_argument );
+    BOOST_CHECK_THROW( ParserIntItem item1("TESTKEYWORD", jsonConfig) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_withSizeTypeALL_throws) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"ALL\", \"default\" : 100}");
-    BOOST_CHECK_THROW( ParserIntItem item1( jsonConfig ) , std::invalid_argument );
+    BOOST_CHECK_THROW( ParserIntItem item1("TESTKEYWORD", jsonConfig) , std::invalid_argument );
 }
 
 
@@ -169,7 +169,7 @@ BOOST_AUTO_TEST_CASE(InitializeIntItem_FromJsonObject_withSizeTypeALL_throws) {
 BOOST_AUTO_TEST_CASE(InitializeIntItem_WithDescription_DescriptionPropertyShouldBePopulated) {
     std::string description("Description goes here");
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"description\" : \"Description goes here\"}");
-    ParserIntItem item(jsonConfig);
+    ParserIntItem item("TESTKEYWORD", jsonConfig);
 
     BOOST_CHECK_EQUAL( "Description goes here", item.getDescription() );
 }
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE(InitializeIntItem_WithDescription_DescriptionPropertyShould
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_WithoutDescription_DescriptionPropertyShouldBeEmpty) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\"}");
-    ParserIntItem item(jsonConfig);
+    ParserIntItem item("TESTKEYWORD", jsonConfig);
 
     BOOST_CHECK_EQUAL( "", item.getDescription() );
 }
@@ -536,13 +536,13 @@ BOOST_AUTO_TEST_CASE(Scan_RawRecordErrorInRawData_ExceptionThrown) {
     BOOST_CHECK_THROW(itemInt.scan(rawRecord5), std::invalid_argument);
 }
 
-/*********************String************************'*/
+/*********************String*************************/
 /*****************************************************************/
 /*</json>*/
 
 BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject_missingName_throws) {
     Json::JsonObject jsonConfig("{\"nameX\": \"ITEM1\" , \"size_type\" : \"ALL\"}");
-    BOOST_CHECK_THROW( ParserStringItem item1( jsonConfig ) , std::invalid_argument );
+    BOOST_CHECK_THROW( ParserStringItem item1("TESTKEYWORD", jsonConfig) , std::invalid_argument );
 }
 
 
@@ -550,7 +550,7 @@ BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject_missingName_throws) {
 
 BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"ALL\"}");
-    ParserStringItem item1( jsonConfig );
+    ParserStringItem item1("TESTKEYWORD", jsonConfig);
     BOOST_CHECK_EQUAL( "ITEM1" , item1.name() );
     BOOST_CHECK_EQUAL( ALL , item1.sizeType() );
     BOOST_CHECK(item1.getDefault() == "");
@@ -559,7 +559,7 @@ BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject) {
 
 BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject_withDefault) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"SINGLE\", \"default\" : \"100\"}");
-    ParserStringItem item1( jsonConfig );
+    ParserStringItem item1("TESTKEYWORD", jsonConfig);
     BOOST_CHECK_EQUAL( "100" , item1.getDefault() );
 }
 
@@ -567,7 +567,7 @@ BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject_withDefault) {
 
 BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject_withDefaultInvalid_throws) {
     Json::JsonObject jsonConfig("{\"name\": \"ITEM1\" , \"size_type\" : \"ALL\", \"default\" : [1,2,3]}");
-    BOOST_CHECK_THROW( ParserStringItem item1( jsonConfig ) , std::invalid_argument );
+    BOOST_CHECK_THROW( ParserStringItem item1("TESTKEYWORD", jsonConfig) , std::invalid_argument );
 }
 /*</json>*/
 /*****************************************************************/


### PR DESCRIPTION
i.e. provide the name of the keyword where something went wrong. if the name is missing, you're in the dark which file is incorrect...
