### PR TITLE
get rid of the 'strict parsing' concept

### DIFF
--- a/opm/parser/eclipse/Applications/Schedule.cpp
+++ b/opm/parser/eclipse/Applications/Schedule.cpp
@@ -14,7 +14,7 @@
 int main(int /* argc */, char** argv) {
     Opm::ParserPtr parser(new Opm::Parser());
     std::string file = argv[1];
-    Opm::DeckConstPtr deck = parser->parseFile(file, false);
+    Opm::DeckConstPtr deck = parser->parseFile(file);
     Opm::Schedule sched( deck );
 
     std::cout << "Wells: " << sched.numWells() << std::endl;

--- a/opm/parser/eclipse/Applications/opm-eclkwtest.cpp
+++ b/opm/parser/eclipse/Applications/opm-eclkwtest.cpp
@@ -67,7 +67,7 @@ int main(int argc, char** argv) {
     Opm::ParserPtr parser(new Opm::Parser());
     std::string file = argv[1];
     Opm::ParserLogPtr parserLog(new Opm::ParserLog);
-    Opm::DeckConstPtr deck = parser->parseFile(file, true, parserLog);
+    Opm::DeckConstPtr deck = parser->parseFile(file, parserLog);
 
     printDeckDiagnostics(deck, parserLog, printKeywords);
 

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -34,7 +34,7 @@ EclipseState makeState(const std::string& fileName, ParserLogPtr parserLog);
 EclipseState makeState(const std::string& fileName, ParserLogPtr parserLog) {
     ParserPtr parser(new Parser( ));
     boost::filesystem::path boxFile(fileName);
-    DeckPtr deck =  parser->parseFile(boxFile.string() , false);
+    DeckPtr deck =  parser->parseFile(boxFile.string());
     EclipseState state(deck, parserLog);
     return state;
 }

--- a/opm/parser/eclipse/IntegrationTests/CheckDeckValidity.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CheckDeckValidity.cpp
@@ -101,33 +101,4 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
         // this fails because of the incorrect BOX keyword
         BOOST_CHECK(!Opm::checkDeck(deck, parserLog, Opm::SectionTopology | Opm::KeywordSection));
     }
-
-    {
-        // deck contains an unknown keyword "FOO"
-        const char *incorrectDeckString =
-            "RUNSPEC\n"
-            "FOO\n"
-            "DIMENS\n"
-            "3 3 3 /\n"
-            "GRID\n"
-            "DXV\n"
-            "1 1 1 /\n"
-            "DYV\n"
-            "1 1 1 /\n"
-            "DZV\n"
-            "1 1 1 /\n"
-            "TOPS\n"
-            "9*100 /\n"
-            "PROPS\n"
-            "SOLUTION\n"
-            "SCHEDULE\n";
-
-        auto deck = parser->parseString(incorrectDeckString, /*strict=*/false);
-        Opm::ParserLogPtr parserLog(new Opm::ParserLog());
-        BOOST_CHECK(!Opm::checkDeck(deck, parserLog));
-
-        // this is supposed to succeed as we ensure everything except that all keywords
-        // are known
-        BOOST_CHECK(Opm::checkDeck(deck, parserLog, ~Opm::UnknownKeywords));
-    }
 }

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -203,17 +203,9 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
 
 
 /***************** Testing non-recognized keywords ********************/
-BOOST_AUTO_TEST_CASE(parse_unknownkeywordWithnonstrictparsing_keywordmarked) {
+BOOST_AUTO_TEST_CASE(parse_unknownkeyword_exceptionthrown) {
     ParserPtr parser(new Parser());
-    DeckPtr deck =  parser->parseFile("testdata/integration_tests/someobscureelements.data", false);
-    BOOST_CHECK_EQUAL(4U, deck->size());
-    DeckKeywordConstPtr unknown = deck->getKeyword("GRUDINT");
-    BOOST_CHECK(!unknown->isKnown());
-}
-
-BOOST_AUTO_TEST_CASE(parse_unknownkeywordWithstrictparsing_exceptionthrown) {
-    ParserPtr parser(new Parser());
-    BOOST_CHECK_THROW( parser->parseFile("testdata/integration_tests/someobscureelements.data", true), std::invalid_argument);
+    BOOST_CHECK_THROW( parser->parseFile("testdata/integration_tests/someobscureelements.data"), std::invalid_argument);
 }
 
 /*********************Testing truncated (default) records ***************************/

--- a/opm/parser/eclipse/IntegrationTests/ParseACTION.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseACTION.cpp
@@ -50,10 +50,10 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
     BOOST_REQUIRE( parser->isRecognizedKeyword( "WCONHIST" ));
     BOOST_REQUIRE( parser->isRecognizedKeyword( "THROW" ));
 
-    BOOST_REQUIRE_THROW(  parser->parseFile( actionFile2.string() , false) , std::invalid_argument );
+    BOOST_REQUIRE_THROW(  parser->parseFile(actionFile2.string()) , std::invalid_argument );
 
     ParserLogPtr parserLog(new ParserLog);
-    DeckPtr deck =  parser->parseFile(actionFile.string() , false, parserLog);
+    DeckPtr deck =  parser->parseFile(actionFile.string(), parserLog);
     DeckKeywordConstPtr kw1 = deck->getKeyword("WCONHIST" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1->size() );
 
@@ -76,14 +76,10 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
 
 
     BOOST_CHECK_EQUAL( false , deck->hasKeyword( "DIMENS" ));
-    BOOST_CHECK_EQUAL( 2U , parserLog->size() );
+    BOOST_CHECK_EQUAL( 1U , parserLog->size() );
     {
         BOOST_CHECK_EQUAL( actionFile.string() ,  parserLog->getFileName(0));
         BOOST_CHECK_EQUAL( 2U , parserLog->getLineNumber(0));
-    }
-    {
-        BOOST_CHECK_EQUAL( actionFile.string() ,  parserLog->getFileName(1));
-        BOOST_CHECK_EQUAL( 6U , parserLog->getLineNumber(1));
     }
 
 }

--- a/opm/parser/eclipse/IntegrationTests/ParseEND.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEND.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE( parse_END_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path fileWithTitleKeyword("testdata/integration_tests/END/END1.txt");
 
-    DeckPtr deck = parser->parseFile (fileWithTitleKeyword.string(), true);
+    DeckPtr deck = parser->parseFile(fileWithTitleKeyword.string());
 
     BOOST_CHECK_EQUAL(size_t(1), deck->size());
     BOOST_CHECK_EQUAL (true, deck->hasKeyword("OIL"));
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE( parse_ENDINC_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path fileWithTitleKeyword("testdata/integration_tests/END/ENDINC1.txt");
 
-    DeckPtr deck = parser->parseFile (fileWithTitleKeyword.string(), true);
+    DeckPtr deck = parser->parseFile(fileWithTitleKeyword.string());
 
     BOOST_CHECK_EQUAL(size_t(1), deck->size());
     BOOST_CHECK_EQUAL (true, deck->hasKeyword("OIL"));

--- a/opm/parser/eclipse/IntegrationTests/ParseTITLE.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTITLE.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE( parse_TITLE_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path fileWithTitleKeyword("testdata/integration_tests/TITLE/TITLE1.txt");
 
-    DeckPtr deck = parser->parseFile (fileWithTitleKeyword.string(), true);
+    DeckPtr deck = parser->parseFile(fileWithTitleKeyword.string());
 
     BOOST_CHECK_EQUAL(size_t(2), deck->size());
     BOOST_CHECK_EQUAL (true, deck->hasKeyword("TITLE"));

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -47,9 +47,9 @@ namespace Opm {
         Parser(bool addDefault = true);
 
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
-        DeckPtr parseFile(const std::string &dataFile, bool strictParsing=true, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout)) const;
-        DeckPtr parseString(const std::string &data, bool strictParsing=true, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout)) const;
-        DeckPtr parseStream(std::shared_ptr<std::istream> inputStream, bool strictParsing=true, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout)) const;
+        DeckPtr parseFile(const std::string &dataFile, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout)) const;
+        DeckPtr parseString(const std::string &data, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout)) const;
+        DeckPtr parseStream(std::shared_ptr<std::istream> inputStream, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout)) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(ParserKeywordConstPtr parserKeyword);

--- a/testdata/integration_tests/ACTION/ACTION.txt
+++ b/testdata/integration_tests/ACTION/ACTION.txt
@@ -1,8 +1,4 @@
 
-UNRECOGNIZED
-  This Keyword should give a warning at line 2/
-
-
 DIMENS           -- /This is flagged as IGNORE_WARNING - and should give a warning at line: 6
    10 10 10 /     
 


### PR DESCRIPTION
this is the 'Joakim-style' variant of the patch, i.e., an exception
will always be thrown if an unknown keyword is encountered. Note that
this patch causes the parser to bail out on the original Norne deck
once the module gets improoved sufficiently to detect the misspelled
'fluxnum' keyword. (which currently does not seem to be recognized,
probably due to some bug...)
