### PR TITLE
MULTREGT: Only apply multipliers to +face

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -26,6 +26,14 @@
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/Value.hpp>
 
+/* 
+   See documentation on top of MULTREGTScanner::checkConnection().
+   Setting the compile time symbol MULTREGT_USE_NEGATIVE_FACE to 0 will
+   give Eclipse behaviour.
+*/
+
+#define MULTREGT_USE_NEGATIVE_FACE 0  
+
 
 namespace Opm {
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
         auto cell0 = cells[0];
         auto cell1 = cells[1];
 
-        
+#if MULTREGT_USE_NEGATIVE_FACE
         BOOST_CHECK_EQUAL( 1 , std::get<0>(cell0));
         BOOST_CHECK_EQUAL( Opm::FaceDir::XMinus , std::get<1>(cell0));
         BOOST_CHECK_EQUAL( 1.50 , std::get<2>(cell0));
@@ -280,6 +280,15 @@ BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
         BOOST_CHECK_EQUAL( 3 , std::get<0>(cell1));
         BOOST_CHECK_EQUAL( Opm::FaceDir::XMinus , std::get<1>(cell1));
         BOOST_CHECK_EQUAL( 1.50 , std::get<2>(cell1));
+#else
+        BOOST_CHECK_EQUAL( 0 , std::get<0>(cell0));
+        BOOST_CHECK_EQUAL( Opm::FaceDir::XPlus , std::get<1>(cell0));
+        BOOST_CHECK_EQUAL( 1.50 , std::get<2>(cell0));
+
+        BOOST_CHECK_EQUAL( 2 , std::get<0>(cell1));
+        BOOST_CHECK_EQUAL( Opm::FaceDir::XPlus , std::get<1>(cell1));
+        BOOST_CHECK_EQUAL( 1.50 , std::get<2>(cell1));
+#endif
     }
 
 }

--- a/opm/parser/eclipse/IntegrationTests/ParseMULTREGT.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMULTREGT.cpp
@@ -52,14 +52,28 @@ BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
     EclipseState state(deck);
     auto transMult = state.getTransMult();
 
+
+
+
+#if MULTREGT_USE_NEGATIVE_FACE
     BOOST_CHECK_EQUAL( 0.10 , transMult->getMultiplier( 0 , 0 , 0 , FaceDir::XPlus ));
     BOOST_CHECK_EQUAL( 0.10 , transMult->getMultiplier( 0 , 1 , 0 , FaceDir::XPlus ));
-    BOOST_CHECK_EQUAL( 0.20 , transMult->getMultiplier( 1 , 0 , 0 , FaceDir::XMinus ));
-    BOOST_CHECK_EQUAL( 0.20 , transMult->getMultiplier( 1 , 1 , 0 , FaceDir::XMinus ));
     BOOST_CHECK_EQUAL( 1.50 , transMult->getMultiplier( 0 , 0 , 0 , FaceDir::ZPlus ));
     BOOST_CHECK_EQUAL( 1.50 , transMult->getMultiplier( 0 , 1 , 0 , FaceDir::ZPlus ));
     BOOST_CHECK_EQUAL( 1.00 , transMult->getMultiplier( 1 , 0 , 0 , FaceDir::ZPlus ));
     BOOST_CHECK_EQUAL( 1.00 , transMult->getMultiplier( 1 , 1 , 0 , FaceDir::ZPlus ));
+
+    BOOST_CHECK_EQUAL( 0.20 , transMult->getMultiplier( 1 , 0 , 0 , FaceDir::XMinus ));
+    BOOST_CHECK_EQUAL( 0.20 , transMult->getMultiplier( 1 , 1 , 0 , FaceDir::XMinus ));
     BOOST_CHECK_EQUAL( 0.60 , transMult->getMultiplier( 1 , 0 , 1 , FaceDir::ZMinus ));
     BOOST_CHECK_EQUAL( 0.60 , transMult->getMultiplier( 1 , 1 , 1 , FaceDir::ZMinus ));
+#else  // Eclipse 
+    BOOST_CHECK_CLOSE( 0.02 , transMult->getMultiplier( 0 , 0 , 0 , FaceDir::XPlus ), 0.001);
+    BOOST_CHECK_CLOSE( 0.02 , transMult->getMultiplier( 0 , 1 , 0 , FaceDir::XPlus ), 0.001);
+    BOOST_CHECK_EQUAL( 1.50 , transMult->getMultiplier( 0 , 0 , 0 , FaceDir::ZPlus ));
+    BOOST_CHECK_EQUAL( 1.50 , transMult->getMultiplier( 0 , 1 , 0 , FaceDir::ZPlus ));
+
+    BOOST_CHECK_EQUAL( 0.60 , transMult->getMultiplier( 1 , 0 , 0 , FaceDir::ZPlus ));
+    BOOST_CHECK_EQUAL( 0.60 , transMult->getMultiplier( 1 , 1 , 0 , FaceDir::ZPlus ));
+#endif
 }


### PR DESCRIPTION
[NB: Not merge ready]

With this commit a build time #define symbol is introduced to control
whether transmissibility multipliers are applied to negative faces when
resolving the MULTREGT keyword. With the definition:

   #define MULTREGT_USE_NEGATIVE_FACE 0

The transmissibility multipliers will _only_ be applied to the positive
faces, that seem to be the Eclipse behaviour.
