### PR TITLE
.dir-locals.el: remove Statoil developer setup specific commands

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,9 +1,5 @@
 ;; <http://www.gnu.org/software/emacs/manual/html_node/emacs/Directory-Variables.html>
-(( nil . ((eval . (progn 
-                    (require 'projectile)
-                    (puthash (projectile-project-root) "cd build; make -j 4"  projectile-compilation-cmd-map)
-                    (puthash (projectile-project-root) "cd build; ctest -j 4" projectile-test-cmd-map)))))
- ( c-mode . ((c-basic-offset . 4)
+(( c-mode . ((c-basic-offset . 4)
              (tab-width . 8)
-             (indent-tabs-mode . nil))))
+             (indent-tabs-mode . nil)))
 


### PR DESCRIPTION
my emacs always asks me whether I want to apply these settings as it
consideres them unsafe. Furthermore, I use a different directory
structure, so these settings are useless to harmful for me.

If you want to keep these settings around, please move them to ~/.emacs
