### PR TITLE
EclipseState: make specifying anything which requires a grid an error if no grid could be instantiated

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -131,8 +131,14 @@ namespace Opm {
         return m_deckUnitSystem;
     }
 
+    bool EclipseState::hasEclipseGrid() const {
+        return static_cast<bool>(m_eclipseGrid);
+    }
 
     EclipseGridConstPtr EclipseState::getEclipseGrid() const {
+        if (!hasEclipseGrid())
+            throw std::logic_error("The eclipse grid object cannot be retrieved if no grid is featured by the deck.");
+
         return m_eclipseGrid;
     }
 
@@ -253,6 +259,12 @@ namespace Opm {
     }
 
     void EclipseState::initTransMult(ParserLogPtr /*parserLog*/) {
+        if (!hasEclipseGrid())
+            // no checking required here as the class will already
+            // refrain from processing the MULT* grid properties if no
+            // grid is available...
+            return;
+
         EclipseGridConstPtr grid = getEclipseGrid();
         m_transMult = std::make_shared<TransMult>( grid->getNX() , grid->getNY() , grid->getNZ());
 
@@ -273,6 +285,16 @@ namespace Opm {
     }
 
     void EclipseState::initFaults(DeckConstPtr deck, ParserLogPtr parserLog) {
+        if (!hasEclipseGrid()) {
+            if (deck->hasKeyword("FAULTS") ||
+                deck->hasKeyword("MULTFAULT"))
+            {
+                throw std::logic_error("Grid could not be initialized, but fault transmissibility multipliers have been detected.");
+            }
+            else
+                return;
+        }
+
         EclipseGridConstPtr grid = getEclipseGrid();
         m_faults = std::make_shared<FaultCollection>();
         std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
@@ -334,6 +356,14 @@ namespace Opm {
 
     
     void EclipseState::initMULTREGT(DeckConstPtr deck, ParserLogPtr /*parserLog*/) {
+        if (!hasEclipseGrid()) {
+            if (deck->hasKeyword("MULTREGT")) {
+                throw std::logic_error("Grid could not be initialized, but region transmissibility multipliers have been detected.");
+            }
+            else
+                return;
+        }
+
         EclipseGridConstPtr grid = getEclipseGrid();
         std::shared_ptr<MULTREGTScanner> scanner = std::make_shared<MULTREGTScanner>();
 
@@ -360,7 +390,12 @@ namespace Opm {
 
 
     void EclipseState::initEclipseGrid(DeckConstPtr deck, ParserLogPtr parserLog) {
-        m_eclipseGrid = EclipseGridConstPtr( new EclipseGrid(deck, parserLog));
+        try {
+            m_eclipseGrid = EclipseGridConstPtr( new EclipseGrid(deck, parserLog));
+        } catch (const std::exception& e) {
+            std::string msg("Could not create a grid: "+std::string(e.what()));
+            parserLog->addWarning("", -1, msg);
+        }
     }
 
 
@@ -698,8 +733,33 @@ namespace Opm {
                 });
 
         // register the grid properties
-        m_intGridProperties = std::make_shared<GridProperties<int> >(m_eclipseGrid , supportedIntKeywords);
-        m_doubleGridProperties = std::make_shared<GridProperties<double> >(m_eclipseGrid , supportedDoubleKeywords);
+        m_intGridProperties = std::make_shared<GridProperties<int> >(m_eclipseGrid, supportedIntKeywords);
+        m_doubleGridProperties = std::make_shared<GridProperties<double> >(m_eclipseGrid, supportedDoubleKeywords);
+
+        if (!hasEclipseGrid()) {
+            // make sure that no grid properties are specified by the deck
+            for (size_t kwIdx = 0; kwIdx < deck->size(); ++ kwIdx) {
+                const std::string& kwName = deck->getKeyword(kwIdx)->name();
+                if (supportsGridProperty(kwName))
+                    throw std::logic_error("Grid could not be initialized, but grid property " + kwName + " has been detected.");
+            }
+
+            // make sure that no grid property modifier keywords
+            // (which can make grid properties appear out of thin air)
+            // are present in the deck.
+            if (deck->hasKeyword("ADD") ||
+                deck->hasKeyword("BOX") ||
+                deck->hasKeyword("COPY") ||
+                deck->hasKeyword("EQUALS") ||
+                deck->hasKeyword("MULTIPLY"))
+            {
+                throw std::logic_error("Grid could not be initialized, but grid properties have been detected.");
+            }
+
+            // if we don't have a grid and also no grid properties, we
+            // just skip this method.
+            return;
+        }
 
         // actually create the grid property objects. we need to first
         // process all integer grid properties before the double ones

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -67,6 +67,7 @@ namespace Opm {
         EclipseState(DeckConstPtr deck, ParserLogPtr parserLog = std::make_shared<ParserLog>(&std::cout));
 
         ScheduleConstPtr getSchedule() const;
+        bool hasEclipseGrid() const;
         EclipseGridConstPtr getEclipseGrid() const;
         EclipseGridPtr getEclipseGridCopy() const;
         bool hasPhase(enum Phase::PhaseEnum phase) const;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
@@ -34,6 +34,9 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
 
+Opm::EclipseGridPtr createDummyGrid() {
+    return std::make_shared<Opm::EclipseGrid>(10,7,9);
+}
 
 BOOST_AUTO_TEST_CASE(Empty) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
@@ -55,13 +58,14 @@ BOOST_AUTO_TEST_CASE(Empty) {
 
 
 BOOST_AUTO_TEST_CASE(addKeyword) {
+    auto grid = createDummyGrid();
+
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
         SupportedKeywordInfo("SATNUM" , 0, "1")
     });
-    std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,7,9);
     Opm::GridProperties<int> gridProperties( grid , supportedKeywords);
-    
+
     BOOST_CHECK_THROW( gridProperties.addKeyword("NOT-SUPPORTED") , std::invalid_argument);
 
     BOOST_CHECK(  gridProperties.addKeyword("SATNUM"));
@@ -72,11 +76,12 @@ BOOST_AUTO_TEST_CASE(addKeyword) {
 
 
 BOOST_AUTO_TEST_CASE(getKeyword) {
+    auto grid = createDummyGrid();
+
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
         SupportedKeywordInfo("SATNUM" , 0, "1")
     });
-    std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,7,9);
     Opm::GridProperties<int> gridProperties( grid , supportedKeywords);
     std::shared_ptr<Opm::GridProperty<int> > satnum1 = gridProperties.getKeyword("SATNUM");
     std::shared_ptr<Opm::GridProperty<int> > satnum2 = gridProperties.getKeyword("SATNUM");

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -112,7 +112,24 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     
 }
 
+static DeckPtr createEmptyDeck() {
+    const char *deckData =
+        "";
 
+    ParserPtr parser(new Parser());
+    return parser->parseString(deckData) ;
+}
+
+static DeckPtr createDeckWithoutGrid() {
+    const char *deckData =
+        "PROPS\n"
+        "EQUALS\n"
+        "'PERMX' 1.23 /\n"
+        "/\n";
+
+    ParserPtr parser(new Parser());
+    return parser->parseString(deckData) ;
+}
 
 static DeckPtr createDeck() {
     const char *deckData =
@@ -210,6 +227,22 @@ BOOST_AUTO_TEST_CASE(TitleCorrect) {
     BOOST_CHECK_EQUAL( state.getTitle(), "The title");
 }
 
+BOOST_AUTO_TEST_CASE(SupportsEmptyDeck) {
+    DeckPtr deck = createEmptyDeck();
+    ParserLogPtr parserLog(new ParserLog);
+    BOOST_CHECK_NO_THROW(EclipseState(deck, parserLog));
+
+    // we need to get a warning because no grid could be instantiated
+    BOOST_CHECK_EQUAL(parserLog->numWarnings(), 1);
+}
+
+BOOST_AUTO_TEST_CASE(SupportsDeckWithoutGrid) {
+    DeckPtr deck = createDeckWithoutGrid();
+    ParserLogPtr parserLog(new ParserLog);
+
+    // specifying grid properties without a grid is not supported!
+    BOOST_CHECK_THROW(EclipseState(deck, parserLog), std::logic_error);
+}
 
 BOOST_AUTO_TEST_CASE(IntProperties) {
     DeckPtr deck = createDeck();


### PR DESCRIPTION
this is the second version of the patch which is based on top of the current master, so that it is possible to create some grid properties if only the `DIMENS` keyword is present in the `RUNSPEC` section. in addition to that, this patch enables `EclipseState` creation even if `DIMENS` is not in the deck. Basically this should make Joakim as well as me happy...
