### PR TITLE
Fix shared libs

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -202,7 +202,7 @@ Utility/EndscaleWrapper.hpp
 Utility/ScalecrsWrapper.hpp
 )
 
-add_library(buildParser ${rawdeck_source} ${build_parser_source} ${deck_source} ${unit_source})
+add_library(buildParser STATIC ${rawdeck_source} ${build_parser_source} ${deck_source} ${unit_source})
 target_link_libraries(buildParser opm-json ${Boost_LIBRARIES})
 
 #-----------------------------------------------------------------


### PR DESCRIPTION
Some small fixes when building shared libs (-DBUILD_SHARED_LIBS=1)

1) The buildparser helper lib contains references to the logger classes (in functions not called by the builder app). When linking dynamic, these references are not pruned by the linker, and you thus get linker errors. fix this by building the required object.
2) Always build the parserBuilder library static. this is a 'convenience library' in libtool speak - i.e. just used during the build and not installed. No reason to build this dynamic.

fix 2 makes fix 1 unnecessary as such but better get it right no?
