### PR TITLE
fixed: compile cjson object into libopm-json

### DIFF
--- a/opm/json/CMakeLists.txt
+++ b/opm/json/CMakeLists.txt
@@ -1,13 +1,10 @@
-if (NOT HAVE_CJSON)
-    add_library( cjson STATIC cjson/cJSON.c )
-    set_target_properties(cjson PROPERTIES COMPILE_FLAGS -fPIC)
-    set( CJSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
-    set( CJSON_LIBRARY cjson )
-endif()
-
-
 set( json_source JsonObject.cpp )
 set( json_headers JsonObject.hpp )
+if (NOT HAVE_CJSON)
+    list(APPEND json_source cjson/cJSON.c)
+    set( CJSON_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR} )
+    set(CJSON_LIBRARY "")
+endif()
 add_library(opm-json ${json_source})
 target_link_libraries( opm-json ${CJSON_LIBRARY} ${Boost_LIBRARIES} )
 


### PR DESCRIPTION
i see no reason to keep the separate library and this circumvents
shared vs static linking issues in downstream modules.

an alternative fix is to fix the opm buildsystems to prioritize config
mode. that would be more involved.
