### PR TITLE
Added keywords SOF2 and SWFN to allow for different saturation functions.

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -173,6 +173,8 @@ EclipseState/Tables/PlymaxTable.hpp
 EclipseState/Tables/PvtgTable.hpp
 EclipseState/Tables/PlyrockTable.hpp
 EclipseState/Tables/SwofTable.hpp
+EclipseState/Tables/SwfnTable.hpp
+EclipseState/Tables/Sof2Table.hpp
 EclipseState/Tables/EnptvdTable.hpp
 EclipseState/Tables/FullTable.hpp
 EclipseState/Tables/PlyviscTable.hpp

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -49,7 +49,9 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 
 #include <set>
 #include <memory>
@@ -107,7 +109,9 @@ namespace Opm {
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
         const std::vector<SgofTable>& getSgofTables() const;
+        const std::vector<Sof2Table>& getSof2Tables() const;
         const std::vector<SwofTable>& getSwofTables() const;
+        const std::vector<SwfnTable>& getSwfnTables() const;
 
         // the unit system used by the deck. note that it is rarely needed to convert
         // units because internally to opm-parser everything is represented by SI
@@ -195,7 +199,7 @@ namespace Opm {
         void handleENDBOXKeyword(BoxManager& boxManager);
         void handleEQUALSKeyword(DeckKeywordConstPtr deckKeyword , ParserLogPtr parserLog, BoxManager& boxManager, int enabledTypes);
         void handleMULTIPLYKeyword(DeckKeywordConstPtr deckKeyword , ParserLogPtr parserLog, BoxManager& boxManager, int enabledTypes);
-        
+
         void setKeywordBox(DeckKeywordConstPtr deckKeyword, size_t recordIdx, ParserLogPtr parserLog, BoxManager& boxManager);
 
         void copyIntKeyword(const std::string& srcField , const std::string& targetField , std::shared_ptr<const Box> inputBox);
@@ -223,7 +227,9 @@ namespace Opm {
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
         std::vector<SgofTable> m_sgofTables;
+        std::vector<Sof2Table> m_sof2Tables;
         std::vector<SwofTable> m_swofTables;
+        std::vector<SwfnTable> m_swfnTables;
 
         std::set<enum Phase::PhaseEnum> phases;
         std::string m_title;

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -1,0 +1,74 @@
+/*
+  Copyright (C) 2012 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_SOF2_TABLE_HPP
+#define OPM_PARSER_SOF2_TABLE_HPP
+
+#include "SingleRecordTable.hpp"
+
+namespace Opm {
+    // forward declaration
+    class EclipseState;
+
+    class Sof2Table : protected SingleRecordTable {
+        typedef SingleRecordTable ParentType;
+
+        friend class EclipseState;
+
+        /*!
+         * \brief Read the SOF2 keyword and provide some convenience
+         *        methods for it.
+         */
+        void init(Opm::DeckKeywordConstPtr keyword,
+                  int recordIdx)
+        {
+            ParentType::init(keyword,
+                             std::vector<std::string>{"SO", "KRO" },
+                             recordIdx,
+                             /*firstEntityOffset=*/0);
+
+            ParentType::checkNonDefaultable("SO");
+            ParentType::checkNonDefaultable("KRO");
+            ParentType::checkMonotonic("SO", /*isAscending=*/true);
+            ParentType::checkMonotonic("KRO", /*isAscending=*/true, /*strict*/false);
+        }
+
+    public:
+        Sof2Table() = default;
+
+#ifdef BOOST_TEST_MODULE
+        // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
+        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
+        { init(keyword, tableIdx); }
+#endif
+
+        using ParentType::numTables;
+        using ParentType::numRows;
+        using ParentType::numColumns;
+        using ParentType::evaluate;
+
+        const std::vector<double> &getSoColumn() const
+        { return ParentType::getColumn(0); }
+
+        const std::vector<double> &getKroColumn() const
+        { return ParentType::getColumn(1); }
+    };
+}
+
+#endif
+

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -1,0 +1,81 @@
+/*
+  Copyright (C) 2014 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_SWFN_TABLE_HPP
+#define OPM_PARSER_SWFN_TABLE_HPP
+
+#include "SingleRecordTable.hpp"
+
+namespace Opm {
+    // forward declaration
+    class EclipseState;
+
+    class SwfnTable : protected SingleRecordTable {
+        typedef SingleRecordTable ParentType;
+
+        friend class EclipseState;
+
+        /*!
+         * \brief Read the SWFN keyword and provide some convenience
+         *        methods for it.
+         */
+        void init(Opm::DeckKeywordConstPtr keyword,
+                  int recordIdx)
+        {
+            ParentType::init(keyword,
+                             std::vector<std::string>{"SW", "KRW", "PCOW"},
+                             recordIdx,
+                             /*firstEntityOffset=*/0);
+
+            ParentType::checkNonDefaultable("SW");
+            ParentType::checkMonotonic("SW",   /*isAscending=*/true);
+            ParentType::applyDefaultsLinear("KRW");
+            ParentType::applyDefaultsLinear("PCOW");
+            ParentType::checkMonotonic("KRW",  /*isAscending=*/true,  /*strict=*/false);
+            ParentType::checkMonotonic("PCOW", /*isAscending=*/false, /*strict=*/false);
+        }
+
+    public:
+        SwfnTable() = default;
+
+#ifdef BOOST_TEST_MODULE
+        // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
+        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
+        { init(keyword, tableIdx); }
+#endif
+
+        using ParentType::numTables;
+        using ParentType::numRows;
+        using ParentType::numColumns;
+        using ParentType::evaluate;
+
+        const std::vector<double> &getSwColumn() const
+        { return ParentType::getColumn(0); }
+
+        const std::vector<double> &getKrwColumn() const
+        { return ParentType::getColumn(1); }
+
+        // this column is p_o - p_w (non-wetting phase pressure minus
+        // wetting phase pressure for a given water saturation)
+        const std::vector<double> &getPcowColumn() const
+        { return ParentType::getColumn(2); }
+    };
+}
+
+#endif
+

--- a/opm/parser/share/keywords/000_Eclipse100/S/SOF2
+++ b/opm/parser/share/keywords/000_Eclipse100/S/SOF2
@@ -1,0 +1,5 @@
+{"name" : "SOF2" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
+        "items" : [
+            {"name":"DATA", "value_type":"DOUBLE", "size_type" : "ALL" , "dimension" : ["1","1"]}
+         ]
+}

--- a/opm/parser/share/keywords/000_Eclipse100/S/SWFN
+++ b/opm/parser/share/keywords/000_Eclipse100/S/SWFN
@@ -1,0 +1,5 @@
+{"name" : "SWFN" , "sections" : ["PROPS"], "size" : {"keyword" : "TABDIMS" , "item" : "NTSFUN"},
+        "items" : [
+            {"name":"DATA", "value_type":"DOUBLE", "size_type" : "ALL" , "dimension" : ["1","1","Pressure"]}
+         ]
+}


### PR DESCRIPTION
This PR added the two keywords SOF2 and SWFN to allow for different saturation functions in a deck. 
The corresponding implementation in opm-core is still missing. 
