### PR TITLE
remove all trailing white space

### DIFF
--- a/opm/json/JsonObject.cpp
+++ b/opm/json/JsonObject.cpp
@@ -49,10 +49,10 @@ namespace Json {
     }
 
 
-    
+
     JsonObject::JsonObject(const boost::filesystem::path& jsonFile ) {
         std::ifstream stream(jsonFile.string().c_str());
-        if (stream) { 
+        if (stream) {
             std::string content_from_file( (std::istreambuf_iterator<char>(stream)),
                                  (std::istreambuf_iterator<char>()));
             initialize( content_from_file );
@@ -67,24 +67,24 @@ namespace Json {
         root = object;
         owner = false;
     }
-    
-    
+
+
     JsonObject::~JsonObject() {
         if (owner && root)
             cJSON_Delete(root);
     }
-    
+
 
 
     bool JsonObject::has_item( const std::string& key) const {
         cJSON * object = cJSON_GetObjectItem( root , key.c_str() );
-        if (object) 
+        if (object)
             return true;
         else
             return false;
     }
 
-    
+
     bool JsonObject::is_array( ) const {
         if (root->type == cJSON_Array)
             return true;
@@ -113,8 +113,8 @@ namespace Json {
         else
             return false;
     }
-    
-    
+
+
     size_t JsonObject::size() const {
         int int_size = cJSON_GetArraySize( root );
         return (size_t) int_size;
@@ -131,17 +131,17 @@ namespace Json {
         } else
             throw std::invalid_argument("Object is not an array.");
     }
-    
+
 
     JsonObject JsonObject::get_item(const std::string& key) const {
         cJSON * c_ptr = cJSON_GetObjectItem( root , key.c_str() );
-        if (c_ptr) 
+        if (c_ptr)
             return JsonObject( c_ptr );
         else
             throw std::invalid_argument("Key: " + key + " does not exist in json object");
     }
 
-    
+
     std::string JsonObject::get_string(const std::string& key) const {
         JsonObject child = get_scalar_object( key );
         return child.as_string();
@@ -160,9 +160,9 @@ namespace Json {
         JsonObject child = get_scalar_object( key );
         return child.as_int( );
     }
-    
 
-    int JsonObject::as_int() const {    
+
+    int JsonObject::as_int() const {
         if (root->type == cJSON_Number)
             return root->valueint;
         else
@@ -174,9 +174,9 @@ namespace Json {
         JsonObject child = get_scalar_object( key );
         return child.as_double( );
     }
-    
 
-    double JsonObject::as_double() const {    
+
+    double JsonObject::as_double() const {
         if (root->type == cJSON_Number)
             return root->valuedouble;
         else

--- a/opm/json/JsonObject.hpp
+++ b/opm/json/JsonObject.hpp
@@ -35,7 +35,7 @@ namespace Json {
         explicit JsonObject(const char * inline_json);
         explicit JsonObject(cJSON * root);
         ~JsonObject();
-        
+
         bool has_item(const std::string& key) const;
         JsonObject get_array_item( size_t index ) const;
         JsonObject get_item(const std::string& key) const;
@@ -54,7 +54,7 @@ namespace Json {
         bool is_object( ) const;
 
         std::string get_content() const;
-        
+
         size_t size() const;
     private:
         JsonObject get_scalar_object(const std::string& key) const;

--- a/opm/json/tests/jsonTests.cpp
+++ b/opm/json/tests/jsonTests.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE(ParseInvalidJSON_throw) {
 BOOST_AUTO_TEST_CASE(ParsevalidJSON_getString) {
     std::string inline_json = "{\"key\": \"value\"}";
     Json::JsonObject parser(inline_json);
-    
+
     BOOST_CHECK_EQUAL( "value" , parser.get_string("key") );
 }
 
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSONString_asString) {
     std::string inline_json = "{\"key\": \"value\"}";
     Json::JsonObject parser(inline_json);
     Json::JsonObject value = parser.get_item("key");
-    
+
     BOOST_CHECK_EQUAL( "value" , value.as_string() );
 }
 
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSONnotString_asString_throws) {
     std::string inline_json = "{\"key\": 100}";
     Json::JsonObject parser(inline_json);
     Json::JsonObject value = parser.get_item("key");
-    
+
     BOOST_CHECK_THROW( value.as_string() , std::invalid_argument );
 }
 
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSONint_asNumber) {
     Json::JsonObject parser(inline_json);
     Json::JsonObject value1 = parser.get_item("key1");
     Json::JsonObject value2 = parser.get_item("key2");
-    
+
     BOOST_CHECK_EQUAL( 100 , value1.as_int() );
     BOOST_CHECK( fabs(100.100 - value2.as_double()) < 0.00001 );
 }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSONint_isNumber) {
     Json::JsonObject value1 = parser.get_item("key1");
     Json::JsonObject value2 = parser.get_item("key2");
     Json::JsonObject value3 = parser.get_item("key3");
-    
+
     BOOST_CHECK( value1.is_number()) ;
     BOOST_CHECK( value2.is_number()) ;
     BOOST_CHECK_EQUAL( false , value3.is_number()) ;
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSONnotNumber_asNumber_throws) {
     std::string inline_json = "{\"key\": \"100X\"}";
     Json::JsonObject parser(inline_json);
     Json::JsonObject value = parser.get_item("key");
-    
+
     BOOST_CHECK_THROW( value.as_int()    , std::invalid_argument );
     BOOST_CHECK_THROW( value.as_double() , std::invalid_argument );
 }
@@ -165,7 +165,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSON_CheckArraySize) {
 }
 
 
-BOOST_AUTO_TEST_CASE(ParsevalidJSON_isArray){ 
+BOOST_AUTO_TEST_CASE(ParsevalidJSON_isArray){
     std::string inline_json = "{\"key\": \"value\", \"list\": [1,2,3]}";
     Json::JsonObject parser(inline_json);
     Json::JsonObject list = parser.get_item("list");
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSON_arrayGet) {
     BOOST_CHECK_NO_THROW( list.get_array_item( 0U ));
     BOOST_CHECK_NO_THROW( list.get_array_item( 1U ));
     BOOST_CHECK_NO_THROW( list.get_array_item( 2U ));
-    
+
     BOOST_CHECK_THROW( list.get_array_item( 3U ) , std::invalid_argument );
     BOOST_CHECK_THROW( key.get_array_item( 0U ) , std::invalid_argument );
 }
@@ -193,7 +193,7 @@ BOOST_AUTO_TEST_CASE(ParsevalidJSON_arrayGet) {
 
 BOOST_AUTO_TEST_CASE(parseJSONString_testType) {
     std::string inline_json = "{\"item\": \"string\"}";
-    Json::JsonObject json(inline_json);    
+    Json::JsonObject json(inline_json);
     Json::JsonObject item = json.get_item( "item" );
 
     BOOST_CHECK( item.is_string() );
@@ -205,7 +205,7 @@ BOOST_AUTO_TEST_CASE(parseJSONString_testType) {
 
 BOOST_AUTO_TEST_CASE(parseJSONNumber_testType) {
     std::string inline_json = "{\"item\": 100}";
-    Json::JsonObject json(inline_json);    
+    Json::JsonObject json(inline_json);
     Json::JsonObject item = json.get_item( "item" );
 
     BOOST_CHECK_EQUAL( true  , item.is_number( ) );
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(parseJSONNumber_testType) {
 
 BOOST_AUTO_TEST_CASE(parseJSONArray_testType) {
     std::string inline_json = "{\"item\": [1,2,3]}";
-    Json::JsonObject json(inline_json);    
+    Json::JsonObject json(inline_json);
     Json::JsonObject item = json.get_item( "item" );
 
     BOOST_CHECK_EQUAL( false , item.is_number( ) );
@@ -229,7 +229,7 @@ BOOST_AUTO_TEST_CASE(parseJSONArray_testType) {
 
 BOOST_AUTO_TEST_CASE(parseJSONObject_testType) {
     std::string inline_json = "{\"item\": {\"list\": [0,1,2]}}";
-    Json::JsonObject json(inline_json);    
+    Json::JsonObject json(inline_json);
     Json::JsonObject item = json.get_item( "item" );
 
     BOOST_CHECK_EQUAL( false , item.is_number( ) );

--- a/opm/parser/eclipse/Applications/Schedule.cpp
+++ b/opm/parser/eclipse/Applications/Schedule.cpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   EclipseDataDoctor.cpp
  * Author: kflik
  *
@@ -16,9 +16,9 @@ int main(int /* argc */, char** argv) {
     std::string file = argv[1];
     Opm::DeckConstPtr deck = parser->parseFile(file, false);
     Opm::Schedule sched( deck );
-    
+
     std::cout << "Wells: " << sched.numWells() << std::endl;
-    
+
 
     return 0;
 }

--- a/opm/parser/eclipse/Applications/opm-eclkwtest.cpp
+++ b/opm/parser/eclipse/Applications/opm-eclkwtest.cpp
@@ -26,9 +26,9 @@
 static void printDeckDiagnostics(Opm::DeckConstPtr deck, Opm::ParserLogConstPtr parserLog, bool printAllKeywords) {
     int recognizedKeywords = 0;
     int unrecognizedKeywords = 0;
-    
+
     for (size_t i = 0; i < deck->size(); i++) {
-        if (!deck->getKeyword(i)->isKnown()) 
+        if (!deck->getKeyword(i)->isKnown())
             unrecognizedKeywords++;
         else
             recognizedKeywords++;
@@ -49,7 +49,7 @@ static void printDeckDiagnostics(Opm::DeckConstPtr deck, Opm::ParserLogConstPtr 
 
 }
 /*
- * 
+ *
  */
 int main(int argc, char** argv) {
     if (argc < 2) {

--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -31,11 +31,11 @@ namespace Opm {
     bool Deck::hasKeyword(const std::string& keyword) const {
         return m_keywords->hasKeyword(keyword);
     }
-    
+
     void Deck::addKeyword( DeckKeywordPtr keyword) {
         m_keywords->addKeyword(keyword);
     }
-    
+
     DeckKeywordPtr Deck::getKeyword(const std::string& keyword, size_t index) const {
         return m_keywords->getKeyword(keyword , index);
     }
@@ -43,11 +43,11 @@ namespace Opm {
     DeckKeywordPtr Deck::getKeyword(const std::string& keyword) const {
         return m_keywords->getKeyword(keyword);
     }
-    
+
     DeckKeywordPtr Deck::getKeyword(size_t index) const {
         return m_keywords->getKeyword(index);
     }
-      
+
     size_t Deck::numKeywords(const std::string& keyword) const {
         return m_keywords->numKeywords( keyword );
     }
@@ -71,7 +71,7 @@ namespace Opm {
     std::shared_ptr<UnitSystem> Deck::getActiveUnitSystem() const {
         return m_activeUnits;
     }
-    
+
 
     std::shared_ptr<UnitSystem> Deck::getDefaultUnitSystem() const {
         return m_defaultUnits;

--- a/opm/parser/eclipse/Deck/DeckDoubleItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckDoubleItem.cpp
@@ -32,7 +32,7 @@ namespace Opm {
 
         return m_data[index];
     }
-    
+
 
     const std::vector<double>& DeckDoubleItem::getRawDoubleData() const {
         return m_data;
@@ -54,7 +54,7 @@ namespace Opm {
         } else
             throw std::invalid_argument("No dimension has been set for item:" + name() + " can not ask for SI data");
     }
-    
+
 
 
     double DeckDoubleItem::getSIDouble(size_t index) const {
@@ -63,7 +63,7 @@ namespace Opm {
 
         return m_SIdata[index];
     }
-    
+
     const std::vector<double>& DeckDoubleItem::getSIDoubleData() const {
         assertSIData();
 
@@ -113,7 +113,7 @@ namespace Opm {
         else
             m_dimensions.push_back( activeDimension );
     }
-    
+
 
 }
 

--- a/opm/parser/eclipse/Deck/DeckDoubleItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckDoubleItem.hpp
@@ -37,14 +37,14 @@ namespace Opm {
         const std::vector<double>& getRawDoubleData() const;
         double getSIDouble(size_t index) const;
         const std::vector<double>& getSIDoubleData() const;
-        
+
         void push_back(std::deque<double> data , size_t items);
         void push_back(std::deque<double> data);
         void push_back(double value);
         void push_backDefault(double value);
         void push_backMultiple(double value, size_t numValues);
         void push_backDimension(std::shared_ptr<const Dimension> activeDimension , std::shared_ptr<const Dimension> defaultDimension);
-        
+
         size_t size() const;
     private:
         void assertSIData() const;

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -42,7 +42,7 @@ namespace Opm {
         // creates the defaulted items if all their sizes are fully specified by the
         // keyword, though...
         virtual size_t size() const = 0;
-        
+
         virtual int getInt(size_t /* index */) const {
             throw std::logic_error("This implementation of DeckItem does not support int");
         }

--- a/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -29,7 +29,7 @@ namespace Opm {
         m_fileName = "";
         m_lineNumber = -1;
     }
-    
+
     DeckKeyword::DeckKeyword(const std::string& keywordName, bool knownKeyword) {
         m_knownKeyword = knownKeyword;
         m_keywordName = keywordName;
@@ -69,7 +69,7 @@ namespace Opm {
     void DeckKeyword::setDataKeyword(bool isDataKeyword_) {
         m_isDataKeyword = isDataKeyword_;
     }
-    
+
     bool DeckKeyword::isDataKeyword() const {
         return m_isDataKeyword;
     }
@@ -94,7 +94,7 @@ namespace Opm {
     bool DeckKeyword::isKnown() const {
         return m_knownKeyword;
     }
-    
+
     void DeckKeyword::addRecord(DeckRecordConstPtr record) {
         m_recordList.push_back(record);
     }

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   DeckKeyword.hpp
  * Author: kflik
  *

--- a/opm/parser/eclipse/Deck/DeckStringItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckStringItem.cpp
@@ -64,7 +64,7 @@ namespace Opm {
     }
 
 
-  
+
     void DeckStringItem::push_backMultiple(std::string value, size_t numValues) {
         for (size_t i = 0; i < numValues; i++) {
             m_data.push_back( value );
@@ -77,8 +77,8 @@ namespace Opm {
         m_data.push_back( data );
         m_dataPointDefaulted.push_back(true);
     }
-    
-    
+
+
 
     size_t DeckStringItem::size() const {
         return m_data.size();

--- a/opm/parser/eclipse/Deck/DeckStringItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckStringItem.hpp
@@ -52,5 +52,5 @@ namespace Opm {
     typedef std::shared_ptr<DeckStringItem> DeckStringItemPtr;
     typedef std::shared_ptr<const DeckStringItem> DeckStringItemConstPtr;
 }
-#endif  
+#endif
 

--- a/opm/parser/eclipse/Deck/KeywordContainer.cpp
+++ b/opm/parser/eclipse/Deck/KeywordContainer.cpp
@@ -35,15 +35,15 @@ namespace Opm {
     size_t KeywordContainer::size() const {
         return m_keywordList.size();
     }
-    
+
     void KeywordContainer::addKeyword(DeckKeywordPtr keyword) {
         keyword->setDeckIndex( m_keywordList.size());
         m_keywordList.push_back(keyword);
-        
+
         if (!hasKeyword(keyword->name())) {
             m_keywordMap[keyword->name()] = std::vector<DeckKeywordPtr>();
         }
-        
+
         {
             std::vector<DeckKeywordPtr>& keywordList = m_keywordMap[keyword->name()];
             keywordList.push_back(keyword);
@@ -57,8 +57,8 @@ namespace Opm {
         } else
             throw std::invalid_argument("Keyword: " + keyword + " is not found in the container");
     }
-    
-    
+
+
     DeckKeywordPtr KeywordContainer::getKeyword(const std::string& keyword, size_t index) const {
         const std::vector<DeckKeywordPtr>& keywordList = getKeywordList( keyword );
         if (index < keywordList.size())

--- a/opm/parser/eclipse/Deck/KeywordContainer.hpp
+++ b/opm/parser/eclipse/Deck/KeywordContainer.hpp
@@ -1,4 +1,4 @@
-/* 
+/*
  * File:   KeywordContainer.hpp
  * Author: kflik
  *

--- a/opm/parser/eclipse/Deck/Section.cpp
+++ b/opm/parser/eclipse/Deck/Section.cpp
@@ -92,7 +92,7 @@ namespace Opm {
     DeckKeywordConstPtr Section::getKeyword(const std::string& keyword) const {
         return m_keywords.getKeyword(keyword);
     }
-    
+
     DeckKeywordConstPtr Section::getKeyword(size_t index) const {
         return m_keywords.getKeyword(index);
     }

--- a/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
@@ -71,11 +71,11 @@ BOOST_AUTO_TEST_CASE(PushBackDouble_subVectorPushed_ElementsCorrect) {
 
 BOOST_AUTO_TEST_CASE(sizeDouble_correct) {
     DeckDoubleItem deckDoubleItem("TEST");
-    
+
     BOOST_CHECK_EQUAL( 0U , deckDoubleItem.size());
     deckDoubleItem.push_back( 100 );
     BOOST_CHECK_EQUAL( 1U , deckDoubleItem.size());
-    
+
     deckDoubleItem.push_back( 100 );
     deckDoubleItem.push_back( 100 );
     BOOST_CHECK_EQUAL( 3U , deckDoubleItem.size());
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(PushBackDimensionInvalidType) {
 BOOST_AUTO_TEST_CASE(GetSIWithoutDimensionThrows) {
     DeckDoubleItem item("HEI");
     item.push_backMultiple(10.22 , 100 );
-    
+
     BOOST_CHECK_THROW( item.getSIDouble(0) , std::invalid_argument );
     BOOST_CHECK_THROW( item.getSIDoubleData( ) , std::invalid_argument );
 }
@@ -182,10 +182,10 @@ BOOST_AUTO_TEST_CASE(GetSIMultipleDim) {
     item.push_backDimension( dim4 , defaultDim );
 
     for (size_t i=0; i < 16; i+= 4) {
-        BOOST_CHECK_EQUAL( 2   , item.getSIDouble(i) );        
-        BOOST_CHECK_EQUAL( 4   , item.getSIDouble(i+ 1) );        
-        BOOST_CHECK_EQUAL( 8   , item.getSIDouble(i+2) );        
-        BOOST_CHECK_EQUAL(16   , item.getSIDouble(i+3) );        
+        BOOST_CHECK_EQUAL( 2   , item.getSIDouble(i) );
+        BOOST_CHECK_EQUAL( 4   , item.getSIDouble(i+ 1) );
+        BOOST_CHECK_EQUAL( 8   , item.getSIDouble(i+2) );
+        BOOST_CHECK_EQUAL(16   , item.getSIDouble(i+3) );
     }
 }
 

--- a/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(GetIntAtIndex_NoData_ExceptionThrown) {
 
 
 
- 
+
 BOOST_AUTO_TEST_CASE(InitializeDefaultApplied) {
     DeckIntItem deckIntItem("TEST");
     BOOST_CHECK( deckIntItem.size() == 0 );
@@ -73,11 +73,11 @@ BOOST_AUTO_TEST_CASE(PushBack_subVectorPushed_ElementsCorrect) {
 
 BOOST_AUTO_TEST_CASE(size_correct) {
     DeckIntItem deckIntItem("TEST");
-    
+
     BOOST_CHECK_EQUAL( 0U , deckIntItem.size());
     deckIntItem.push_back( 100 );
     BOOST_CHECK_EQUAL( 1U , deckIntItem.size());
-    
+
     deckIntItem.push_back( 100 );
     deckIntItem.push_back( 100 );
     BOOST_CHECK_EQUAL( 3U , deckIntItem.size());

--- a/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(addRecord_onerecord_recordadded) {
     deckKeyword->addRecord(DeckRecordConstPtr(new DeckRecord()));
     BOOST_CHECK_EQUAL(1U, deckKeyword->size());
     for (auto iter = deckKeyword->begin(); iter != deckKeyword->end(); ++iter) {
-        // 
+        //
     }
 
 }

--- a/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
@@ -120,7 +120,7 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
     RawRecordPtr rawRecord(new Opm::RawRecord(" ' VALUE ' /"));
     record1->addItem( itemString );
 
-    
+
     DeckRecordConstPtr deckRecord = record1->parse( rawRecord );
     BOOST_CHECK_EQUAL(" VALUE " , deckRecord->getItem(0)->getString(0));
 }

--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(DECKAddWarning) {
     BOOST_CHECK_EQUAL(parserLog.getDescription(2), "ERROR");
     BOOST_CHECK_EQUAL(parserLog.getFileName(2), "FILE3");
     BOOST_CHECK_EQUAL(parserLog.getLineNumber(2), 300U);
-    
+
 }
 
 

--- a/opm/parser/eclipse/Deck/tests/KeywordContainerTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/KeywordContainerTests.cpp
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_CASE(addKeyword_keywordAdded_keywordAdded) {
     KeywordContainerPtr container(new KeywordContainer());
     DeckKeywordPtr keyword = DeckKeywordPtr(new DeckKeyword("Truls"));
     container->addKeyword(keyword);
-    
+
     BOOST_CHECK_EQUAL(true, container->hasKeyword("Truls"));
     BOOST_CHECK_EQUAL(1U, container->size());
 }

--- a/opm/parser/eclipse/Deck/tests/SectionTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/SectionTests.cpp
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(SCHEDULESection_NotTerminated) {
     BOOST_CHECK_EQUAL(true, section.hasKeyword("TEST1"));
     BOOST_CHECK_EQUAL(true, section.hasKeyword("TEST2"));
     BOOST_CHECK_EQUAL(true, section.hasKeyword("TEST3"));
-    
+
     BOOST_CHECK_EQUAL( test1 , section.getKeyword("TEST1"));
     BOOST_CHECK_EQUAL( test2 , section.getKeyword("TEST2"));
     BOOST_CHECK_EQUAL( test2 , section.getKeyword(2));
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE(SCHEDULESection_NotTerminated) {
     BOOST_CHECK_EQUAL( test4 , section.getKeyword("TEST3"));
     BOOST_CHECK_EQUAL( test3 , section.getKeyword("TEST3",0));
     BOOST_CHECK_EQUAL( test4 , section.getKeyword("TEST3",1));
-    
+
     BOOST_CHECK( Section::hasSCHEDULE(deck ));
     BOOST_CHECK( !Section::hasREGIONS(deck ));
 }

--- a/opm/parser/eclipse/EclipseState/Grid/Box.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Box.cpp
@@ -40,7 +40,7 @@ namespace Opm {
         m_offset[0] = 0;
         m_offset[1] = 0;
         m_offset[2] = 0;
-        
+
         m_stride[0] = 1;
         m_stride[1] = m_dims[0];
         m_stride[2] = m_dims[0] * m_dims[1];
@@ -58,7 +58,7 @@ namespace Opm {
         m_dims[0] = (size_t) (i2 - i1 + 1);
         m_dims[1] = (size_t) (j2 - j1 + 1);
         m_dims[2] = (size_t) (k2 - k1 + 1);
-        
+
         m_offset[0] = (size_t) i1;
         m_offset[1] = (size_t) j1;
         m_offset[2] = (size_t) k1;
@@ -71,15 +71,15 @@ namespace Opm {
             m_isGlobal = true;
         else
             m_isGlobal = false;
-        
+
         initIndexList();
     }
-    
+
 
     void Box::assertDims(const Box& globalBox, size_t idim , int l1 , int l2) {
         if ((l1 < 0) || (l2 < 0) || (l1 > l2))
             throw std::invalid_argument("Invalid index values for sub box");
-        
+
         if ((size_t) l2 >= globalBox.getDim(idim))
             throw std::invalid_argument("Invalid index values for sub box");
     }
@@ -107,13 +107,13 @@ namespace Opm {
         return m_indexList;
     }
 
-    
+
     void Box::initIndexList() {
         m_indexList.resize( size() );
-        
+
         size_t ii,ij,ik;
         size_t l = 0;
-        
+
         for (ik=0; ik < m_dims[2]; ik++) {
             size_t k = ik + m_offset[2];
             for (ij=0; ij < m_dims[1]; ij++) {
@@ -121,7 +121,7 @@ namespace Opm {
                 for (ii=0; ii < m_dims[0]; ii++) {
                     size_t i = ii + m_offset[0];
                     size_t g = i * m_stride[0] + j*m_stride[1] + k*m_stride[2];
-                    
+
                     m_indexList[l] = g;
                     l++;
                 }
@@ -130,7 +130,7 @@ namespace Opm {
     }
 
     bool Box::equal(const Box& other) const {
-        
+
         if (size() != other.size())
             return false;
 
@@ -141,12 +141,12 @@ namespace Opm {
 
                 if (m_stride[idim] != other.m_stride[idim])
                     return false;
-                
+
                 if (m_offset[idim] != other.m_offset[idim])
                     return false;
             }
         }
-        
+
         return true;
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/Box.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Box.hpp
@@ -25,7 +25,7 @@
 #include <cstddef>
 
 namespace Opm {
-    
+
     class Box {
     public:
         Box(int nx , int ny , int nz);

--- a/opm/parser/eclipse/EclipseState/Grid/BoxManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/BoxManager.cpp
@@ -61,7 +61,7 @@ namespace Opm {
     void BoxManager::endInputBox() {
         if (m_keywordBox)
             throw std::invalid_argument("Hmmm - this seems like an internal error - the SECTION is terminated with an active keyword box");
-        
+
         m_inputBox.reset( );
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/BoxManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/BoxManager.hpp
@@ -40,8 +40,8 @@
           - ENDBOX
           - A new BOX
           - End of current section
-          
-       is encountered. 
+
+       is encountered.
 
    3. Some keywords allow for a Box which applies only to the elements
       of that keyword.
@@ -50,7 +50,7 @@
 
 
 namespace Opm {
-    
+
     class BoxManager {
     public:
         BoxManager(int nx , int ny , int nz);
@@ -61,7 +61,7 @@ namespace Opm {
         void endSection();
         void endInputBox();
         void endKeyword();
-        
+
         std::shared_ptr<const Box> getActiveBox() const;
         std::shared_ptr<const Box> getGlobalBox() const;
         std::shared_ptr<const Box> getInputBox() const;

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -107,7 +107,7 @@ namespace Opm {
         size_t m_nx;
         size_t m_ny;
         size_t m_nz;
-        
+
         void assertCellInfo() const;
 
         void initCartesianGrid(const std::vector<int>& dims , DeckConstPtr deck);

--- a/opm/parser/eclipse/EclipseState/Grid/FaceDir.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaceDir.cpp
@@ -26,7 +26,7 @@
 namespace Opm {
 
     namespace FaceDir {
-        
+
         DirEnum FromString(const std::string& stringValue) {
             if ((stringValue == "X") || (stringValue == "I"))
                 return XPlus;
@@ -42,7 +42,7 @@ namespace Opm {
                 return ZPlus;
             if ((stringValue == "Z-") || (stringValue == "K-"))
                 return ZMinus;
-            
+
             throw std::invalid_argument("The string value " + stringValue + " could not be converted to a FaceDir enum value");
         }
 
@@ -56,22 +56,22 @@ namespace Opm {
 
             if (stringValue == "Z")
                 return ZPlus + ZMinus;
-            
+
             if (stringValue == "XY")
                 return XPlus + YPlus + XMinus + YMinus;
 
             if (stringValue == "XZ")
                 return XPlus + ZPlus + XMinus + ZMinus;
-            
+
             if (stringValue == "YZ")
                 return YPlus + ZPlus + YMinus + ZMinus;
-            
+
             if (stringValue == "XYZ")
                 return XPlus + YPlus + ZPlus + XMinus + YMinus + ZMinus;
 
             throw std::invalid_argument("The string " + stringValue + " is not a valid MULTREGT direction value");
         }
-        
+
 
     }
 }

--- a/opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp
@@ -26,7 +26,7 @@ namespace Opm {
 
 
     namespace FaceDir {
-        
+
         enum DirEnum {
             XPlus  = 1,
             XMinus = 2,

--- a/opm/parser/eclipse/EclipseState/Grid/Fault.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/Fault.cpp
@@ -21,17 +21,17 @@
 
 namespace Opm {
 
-    Fault::Fault(const std::string& faultName) : 
-        m_name( faultName ), 
+    Fault::Fault(const std::string& faultName) :
+        m_name( faultName ),
         m_transMult( 1 )
     {
     }
 
-    
+
     const std::string& Fault::getName() const {
         return m_name;
     }
-    
+
     double Fault::getTransMult() const {
         return m_transMult;
     }
@@ -49,7 +49,7 @@ namespace Opm {
         return m_faceList.begin();
     }
 
-    
+
     std::vector<std::shared_ptr<const FaultFace> >::const_iterator Fault::end() const {
         return m_faceList.end();
     }

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -25,18 +25,18 @@ namespace Opm {
 
     FaultCollection::FaultCollection()
     {
-        
+
     }
 
     size_t FaultCollection::size() const {
         return m_faults.size();
     }
-    
+
 
     bool FaultCollection::hasFault(const std::string& faultName) const {
         return m_faults.hasKey( faultName );
     }
-    
+
 
     std::shared_ptr<Fault> FaultCollection::getFault(const std::string& faultName) const {
         return m_faults.get( faultName );
@@ -45,8 +45,8 @@ namespace Opm {
     std::shared_ptr<Fault> FaultCollection::getFault(size_t faultIndex) const {
         return m_faults.get( faultIndex );
     }
-    
-    
+
+
     void FaultCollection::addFault(std::shared_ptr<Fault> fault) {
         m_faults.insert(fault->getName() , fault);
     }

--- a/opm/parser/eclipse/EclipseState/Grid/FaultFace.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultFace.cpp
@@ -26,7 +26,7 @@ namespace Opm {
                          size_t I1 , size_t I2,
                          size_t J1 , size_t J2,
                          size_t K1 , size_t K2,
-                         FaceDir::DirEnum faceDir) 
+                         FaceDir::DirEnum faceDir)
         : m_faceDir( faceDir )
     {
         checkCoord(nx , I1,I2);
@@ -37,11 +37,11 @@ namespace Opm {
         if ((faceDir == FaceDir::XPlus) || (faceDir == FaceDir::XMinus))
             if (I1 != I2)
                 throw std::invalid_argument("When the face is in X direction we must have I1 == I2");
-        
+
         if ((faceDir == FaceDir::YPlus) || (faceDir == FaceDir::YMinus))
             if (J1 != J2)
                 throw std::invalid_argument("When the face is in Y direction we must have J1 == J2");
-        
+
         if ((faceDir == FaceDir::ZPlus) || (faceDir == FaceDir::ZMinus))
             if (K1 != K2)
                 throw std::invalid_argument("When the face is in Z direction we must have K1 == K2");
@@ -55,24 +55,24 @@ namespace Opm {
                 }
     }
 
-    
+
     void FaultFace::checkCoord(size_t dim , size_t l1 , size_t l2) {
         if (l1 > l2)
             throw std::invalid_argument("Invalid coordinates");
 
         if (l2 >= dim)
-            throw std::invalid_argument("Invalid coordinates");            
+            throw std::invalid_argument("Invalid coordinates");
     }
 
 
     std::vector<size_t>::const_iterator FaultFace::begin() const {
         return m_indexList.begin();
     }
-    
+
     std::vector<size_t>::const_iterator FaultFace::end() const {
         return m_indexList.end();
     }
-    
+
 
     FaceDir::DirEnum FaultFace::getDir() const {
         return m_faceDir;

--- a/opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp
@@ -34,12 +34,12 @@ public:
               size_t J1 , size_t J2,
               size_t K1 , size_t K2,
               FaceDir::DirEnum faceDir);
-    
+
     std::vector<size_t>::const_iterator begin() const;
     std::vector<size_t>::const_iterator end() const;
     FaceDir::DirEnum getDir() const;
-    
-private:    
+
+private:
     static void checkCoord(size_t dim , size_t l1 , size_t l2);
     FaceDir::DirEnum m_faceDir;
     std::vector<size_t> m_indexList;

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
@@ -36,12 +36,12 @@
        supported keywords as a list of strings to the constructor.
 
     2. Query the container with the supportsKeyword() and hasKeyword()
-       methods. 
-       
+       methods.
+
     3. When you ask the container to get a keyword with the
        getKeyword() method it will automatically create a new
        GridProperty object if the container does not have this
-       property. 
+       property.
 */
 
 
@@ -55,11 +55,11 @@ public:
     GridProperties(std::shared_ptr<const EclipseGrid> eclipseGrid , std::shared_ptr<const std::vector<SupportedKeywordInfo> > supportedKeywords) {
         m_eclipseGrid = eclipseGrid;
 
-        for (auto iter = supportedKeywords->begin(); iter != supportedKeywords->end(); ++iter) 
+        for (auto iter = supportedKeywords->begin(); iter != supportedKeywords->end(); ++iter)
             m_supportedKeywords[iter->getKeywordName()] = *iter;
     }
 
-    
+
     bool supportsKeyword(const std::string& keyword) {
         return m_supportedKeywords.count( keyword ) > 0;
     }
@@ -77,10 +77,10 @@ public:
     }
 
     bool addKeyword(const std::string& keywordName) {
-        if (!supportsKeyword( keywordName )) 
+        if (!supportsKeyword( keywordName ))
             throw std::invalid_argument("The keyword: " + keywordName + " is not supported in this container");
 
-        if (hasKeyword(keywordName)) 
+        if (hasKeyword(keywordName))
             return false;
         else {
             auto supportedKeyword = m_supportedKeywords.at( keywordName );
@@ -94,7 +94,7 @@ public:
         }
     }
 
-    
+
 private:
     std::shared_ptr<const EclipseGrid> m_eclipseGrid;
     std::unordered_map<std::string, SupportedKeywordInfo> m_supportedKeywords;

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -41,13 +41,13 @@ template<>
 bool GridProperty<double>::containsNaN( ) {
     bool return_value = false;
     size_t size = m_data.size();
-    size_t index = 0;    
+    size_t index = 0;
     while (true) {
         if (std::isnan(m_data[index])) {
             return_value = true;
             break;
         }
-    
+
         index++;
         if (index == size)
             break;

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -95,7 +95,7 @@ public:
           m_initializer(new Opm::GridPropertyConstantInitializer<DataType>(defaultValue)),
           m_dimensionString(dimString)
     {}
-    
+
     GridPropertySupportedKeywordInfo(const std::string& name,
                                      const DataType defaultValue,
                                      std::shared_ptr<const PostProcessor> postProcessor,
@@ -106,7 +106,7 @@ public:
           m_dimensionString(dimString)
     {}
 
-        
+
 
     GridPropertySupportedKeywordInfo(const GridPropertySupportedKeywordInfo&) = default;
 
@@ -125,15 +125,15 @@ public:
         return m_initializer;
     }
 
-    
+
     std::shared_ptr<const PostProcessor> getPostProcessor() const {
         return m_postProcessor;
     }
 
-    
+
     bool hasPostProcessor() const {
         return static_cast<bool>(m_postProcessor);
-    }   
+    }
 
 
 
@@ -157,7 +157,7 @@ public:
         m_nz = nz;
         m_kwInfo = kwInfo;
         m_data.resize( nx * ny * nz );
-        
+
         m_kwInfo.getInitializer()->apply(m_data, m_kwInfo.getKeywordName());
         m_hasRunPostProcessor = false;
     }
@@ -177,8 +177,8 @@ public:
     size_t getNZ() const {
         return m_nz;
     }
-    
-    
+
+
     T iget(size_t index) const {
         if (index < m_data.size()) {
             return m_data[index];
@@ -196,7 +196,7 @@ public:
     void iset(size_t index, T value) {
         if (index < m_data.size())
             m_data[index] = value;
-        else 
+        else
             throw std::invalid_argument("Index out of range \n");
     }
 
@@ -228,7 +228,7 @@ public:
        Due to the convention where it is only neceassary to supply the
        top layer of the petrophysical properties we can unfortunately
        not enforce that the number of elements elements in the
-       deckkeyword equals nx*ny*nz. 
+       deckkeyword equals nx*ny*nz.
     */
 
     void loadFromDeckKeyword(DeckKeywordConstPtr deckKeyword) {
@@ -259,7 +259,7 @@ public:
             } else {
                 std::string boxSize = std::to_string(static_cast<long long>(indexList.size()));
                 std::string keywordSize = std::to_string(static_cast<long long>(deckItem->size()));
-                
+
                 throw std::invalid_argument("Size mismatch: Box:" + boxSize + "  DecKeyword:" + keywordSize);
             }
         }
@@ -279,7 +279,7 @@ public:
             }
         }
     }
-    
+
     void scale(T scaleFactor , std::shared_ptr<const Box> inputBox) {
         if (inputBox->isGlobal()) {
             for (size_t i = 0; i < m_data.size(); ++i)
@@ -308,7 +308,7 @@ public:
     }
 
 
-    
+
 
     void setScalar(T value , std::shared_ptr<const Box> inputBox) {
         if (inputBox->isGlobal()) {
@@ -330,7 +330,7 @@ public:
         return m_kwInfo;
     }
 
-    
+
     bool postProcessorRunRequired() {
         if (m_kwInfo.hasPostProcessor() && !m_hasRunPostProcessor)
             return true;
@@ -350,8 +350,8 @@ public:
             postProcessor->apply( m_data );
         }
     }
-    
-    
+
+
 
 
 private:

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -27,11 +27,11 @@
 namespace Opm {
 
     namespace MULTREGT {
-        
+
         std::string RegionNameFromDeckValue(const std::string& stringValue) {
             if (stringValue == "O")
                 return "OPERNUM";
-            
+
             if (stringValue == "F")
                 return "FLUXNUM";
 
@@ -41,8 +41,8 @@ namespace Opm {
             throw std::invalid_argument("The input string: " + stringValue + " was invalid. Expected: O/F/M");
         }
 
-        
-        
+
+
         NNCBehaviourEnum NNCBehaviourFromString(const std::string& stringValue) {
             if (stringValue == "ALL")
                 return ALL;
@@ -55,17 +55,17 @@ namespace Opm {
 
             if (stringValue == "NOAQUNNC")
                 return NOAQUNNC;
-            
+
             throw std::invalid_argument("The input string: " + stringValue + " was invalid. Expected: ALL/NNC/NONNC/NOAQUNNC");
         }
 
 
     }
-    
 
-    
 
-    MULTREGTRecord::MULTREGTRecord(DeckRecordConstPtr deckRecord) : 
+
+
+    MULTREGTRecord::MULTREGTRecord(DeckRecordConstPtr deckRecord) :
         m_srcRegion("SRC_REGION"),
         m_targetRegion("TARGET_REGION"),
         m_region("REGION")
@@ -90,23 +90,23 @@ namespace Opm {
 
         if (!defItem->defaultApplied(0))
             m_region.setValue( MULTREGT::RegionNameFromDeckValue ( defItem->getString(0) ));
-    } 
+    }
 
 
     /*****************************************************************/
 
     MULTREGTScanner::MULTREGTScanner() {
-        
+
     }
 
 
     void MULTREGTScanner::assertKeywordSupported(DeckKeywordConstPtr deckKeyword) {
         for (auto iter = deckKeyword->begin(); iter != deckKeyword->end(); ++iter) {
             MULTREGTRecord record( *iter );
-            
+
             if (record.m_nncBehaviour != MULTREGT::ALL)
                 throw std::invalid_argument("Sorry - currently only \'ALL\' is supported for MULTREGT NNC behaviour.");
-            
+
             if (!record.m_srcRegion.hasValue())
                 throw std::invalid_argument("Sorry - currently it is not supported with a defaulted source region value.");
 
@@ -115,12 +115,12 @@ namespace Opm {
 
             if (record.m_srcRegion.getValue() == record.m_targetRegion.getValue())
                 throw std::invalid_argument("Sorry - multregt applied internally to a region is not yet supported");
-            
+
         }
     }
-    
 
-    
+
+
     void MULTREGTScanner::addKeyword(DeckKeywordConstPtr deckKeyword) {
         assertKeywordSupported( deckKeyword );
 
@@ -140,9 +140,9 @@ namespace Opm {
             }
             m_records.push_back( record );
         }
-        
+
     }
-    
+
 
     /*
       This function will check the region values in globalIndex1 and
@@ -169,7 +169,7 @@ namespace Opm {
     void MULTREGTScanner::checkConnection( MULTREGTSearchMap& map , std::vector< MULTREGTConnection >& connections, std::shared_ptr<GridProperty<int> > region, size_t globalIndex1 , size_t globalIndex2 , FaceDir::DirEnum faceDir1 ,FaceDir::DirEnum faceDir2) {
         int regionValue1 = region->iget(globalIndex1);
         int regionValue2 = region->iget(globalIndex2);
-        
+
         std::pair<int,int> pair{regionValue1 , regionValue2};
         if (map.count(pair) == 1) {
             const MULTREGTRecord * record = map[pair];
@@ -177,7 +177,7 @@ namespace Opm {
                 connections.push_back( MULTREGTConnection{ globalIndex1 , faceDir1 , record->m_transMultiplier } );
             }
         }
-        
+
         pair = std::pair<int,int>{regionValue2 , regionValue1};
         if (map.count(pair) == 1) {
             const MULTREGTRecord * record = map[pair];
@@ -196,9 +196,9 @@ namespace Opm {
       i.e. for the MULTREGT keyword
 
         MULTREGT
-          2  4   0.75    Z   ALL    M / 
-          2  4   2.50   XY   ALL    F / 
-        /   
+          2  4   0.75    Z   ALL    M /
+          2  4   2.50   XY   ALL    F /
+        /
 
       The first record is completely overweritten by the second
       record, this is because the both have the (2 -> 4) region
@@ -214,7 +214,7 @@ namespace Opm {
                                    ...},
                       "FLUXNUM" : {std::pair(4,8) : std::tuple(TransFactor , Face , Region),
                                    std::pair(1,4) : std::tuple(TransFactor , Face , Region),
-                                   ...}}     
+                                   ...}}
 
       Then it will go through the different regions and looking for
       interface with the wanted region values.
@@ -245,9 +245,9 @@ namespace Opm {
                 const MULTREGTRecord * record = (*iter).second;
                 std::pair<int,int> pair = (*iter).first;
                 const std::string& keyword = record->m_region.getValue();
-                if (searchMap.count(keyword) == 0) 
+                if (searchMap.count(keyword) == 0)
                     searchMap[keyword] = MULTREGTSearchMap();
-                
+
                 searchMap[keyword][pair] = record;
             }
         }
@@ -256,7 +256,7 @@ namespace Opm {
         for (auto iter = searchMap.begin(); iter != searchMap.end(); iter++) {
             std::shared_ptr<GridProperty<int> > region = regions->getKeyword( (*iter).first );
             MULTREGTSearchMap map = (*iter).second;
-            
+
 
             // Iterate through all the cells in the region.
             for (size_t k=0; k < region->getNZ(); k++) {
@@ -287,9 +287,9 @@ namespace Opm {
                     }
                 }
             }
-                
+
         }
-        
+
         return connections;
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -30,7 +30,7 @@
 namespace Opm {
 
     namespace MULTREGT {
-        
+
 
         enum NNCBehaviourEnum {
             NNC = 1,
@@ -49,7 +49,7 @@ namespace Opm {
     class MULTREGTRecord {
     public:
         MULTREGTRecord(DeckRecordConstPtr deckRecord);
-        
+
         Value<int> m_srcRegion;
         Value<int> m_targetRegion;
         double m_transMultiplier;
@@ -70,7 +70,7 @@ namespace Opm {
         void addKeyword(DeckKeywordConstPtr deckKeyword);
         const std::vector< std::tuple<size_t , FaceDir::DirEnum , double> > scanRegions( std::shared_ptr<Opm::GridProperties<int> > regions);
         static void assertKeywordSupported(DeckKeywordConstPtr deckKeyword);
-  
+
     private:
         void checkConnection( MULTREGTSearchMap& map , std::vector< MULTREGTConnection >& connections, std::shared_ptr<GridProperty<int> > region , size_t globalIndex1 , size_t globalIndex2 , FaceDir::DirEnum faceDir1 ,FaceDir::DirEnum faceDir2);
 

--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -26,7 +26,7 @@ namespace Opm {
     TransMult::TransMult(size_t nx , size_t ny , size_t nz) :
         m_nx(nx),
         m_ny(ny),
-        m_nz(nz) 
+        m_nz(nz)
     {
         m_names[FaceDir::XPlus]  = "MULTX";
         m_names[FaceDir::YPlus]  = "MULTY";
@@ -35,7 +35,7 @@ namespace Opm {
         m_names[FaceDir::YMinus] = "MULTY-";
         m_names[FaceDir::ZMinus] = "MULTZ-";
     }
-    
+
 
 
     void TransMult::assertIJK(size_t i , size_t j , size_t k) const {
@@ -64,8 +64,8 @@ namespace Opm {
         } else
             return 1.0;
     }
-    
-    
+
+
 
 
     double TransMult::getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const {
@@ -73,7 +73,7 @@ namespace Opm {
         return getMultiplier__( globalIndex , faceDir );
     }
 
-    
+
     bool TransMult::hasDirectionProperty(FaceDir::DirEnum faceDir) const {
         if (m_trans.count(faceDir) == 1)
             return true;
@@ -84,16 +84,16 @@ namespace Opm {
     void TransMult::insertNewProperty(FaceDir::DirEnum faceDir) {
         GridPropertySupportedKeywordInfo<double> kwInfo(m_names[faceDir] , 1.0 , "1");
         std::shared_ptr<GridProperty<double> > property = std::make_shared<GridProperty<double> >( m_nx , m_ny , m_nz , kwInfo );
-        std::pair<FaceDir::DirEnum , std::shared_ptr<GridProperty<double> > > pair(faceDir , property); 
-        
+        std::pair<FaceDir::DirEnum , std::shared_ptr<GridProperty<double> > > pair(faceDir , property);
+
         m_trans.insert( pair );
     }
 
-    
+
     std::shared_ptr<GridProperty<double> > TransMult::getDirectionProperty(FaceDir::DirEnum faceDir) {
-        if (m_trans.count(faceDir) == 0) 
+        if (m_trans.count(faceDir) == 0)
             insertNewProperty(faceDir);
-        
+
         return m_trans.at( faceDir );
     }
 
@@ -115,13 +115,13 @@ namespace Opm {
                 std::shared_ptr<const FaultFace> face = *face_iter;
                 FaceDir::DirEnum faceDir = face->getDir();
                 std::shared_ptr<GridProperty<double> > multProperty = getDirectionProperty(faceDir);
-                                
+
                 for (auto cell_iter = face->begin(); cell_iter != face->end(); ++cell_iter) {
                     size_t globalIndex = *cell_iter;
                     multProperty->multiplyValueAtIndex( globalIndex , transMult);
                 }
             }
-            
+
         }
     }
 
@@ -136,7 +136,7 @@ namespace Opm {
             {
                 size_t globalIndex = std::get<0>( connection );
                 double transMult = std::get<2>( connection );
-                
+
                 multProperty->multiplyValueAtIndex( globalIndex , transMult);
             }
         }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/BoxManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/BoxManagerTests.cpp
@@ -71,10 +71,10 @@ BOOST_AUTO_TEST_CASE(TestKeywordBox) {
     BOOST_CHECK( inputBox.equal( *boxManager.getInputBox()) );
     BOOST_CHECK( keywordBox.equal( *boxManager.getKeywordBox()) );
     BOOST_CHECK( keywordBox.equal( *boxManager.getActiveBox()) );
-    
+
     // Must end keyword first
     BOOST_CHECK_THROW( boxManager.endSection() , std::invalid_argument );
-    
+
     boxManager.endKeyword();
     BOOST_CHECK( inputBox.equal( *boxManager.getActiveBox()) );
     BOOST_CHECK( !boxManager.getKeywordBox() );

--- a/opm/parser/eclipse/EclipseState/Grid/tests/BoxTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/BoxTests.cpp
@@ -39,7 +39,7 @@ BOOST_AUTO_TEST_CASE(CreateBox) {
     BOOST_CHECK_EQUAL( 4 , box.getDim(0) );
     BOOST_CHECK_EQUAL( 3 , box.getDim(1) );
     BOOST_CHECK_EQUAL( 2 , box.getDim(2) );
-    
+
     BOOST_CHECK_THROW( box.getDim(5) , std::invalid_argument);
 
 
@@ -52,11 +52,11 @@ BOOST_AUTO_TEST_CASE(CreateBox) {
                 for (i=0; i < box.getDim(0); i++) {
                     size_t g = i + j*box.getDim(0) + k*box.getDim(0)*box.getDim(1);
                     BOOST_CHECK_EQUAL( indexList[g] , g);
-                    
+
                 }
             }
         }
-    }   
+    }
 }
 
 
@@ -66,25 +66,25 @@ BOOST_AUTO_TEST_CASE(CreateSubBox) {
 
     BOOST_CHECK_THROW( new Opm::Box( globalBox , -1 , 9 , 1 , 8 , 1, 8)  , std::invalid_argument);   //  Negative throw
     BOOST_CHECK_THROW( new Opm::Box( globalBox ,  1 , 19 , 1 , 8 , 1, 8) , std::invalid_argument);   //  Bigger than global: throw
-    BOOST_CHECK_THROW( new Opm::Box( globalBox ,  9 , 1  , 1 , 8 , 1, 8) , std::invalid_argument);   //  Inverted order: throw    
-    
+    BOOST_CHECK_THROW( new Opm::Box( globalBox ,  9 , 1  , 1 , 8 , 1, 8) , std::invalid_argument);   //  Inverted order: throw
+
     Opm::Box subBox1(globalBox , 0,9,0,9,0,9);
     BOOST_CHECK( subBox1.isGlobal());
 
-    
+
     Opm::Box subBox2(globalBox , 1,3,1,4,1,5);
     BOOST_CHECK( !subBox2.isGlobal());
     BOOST_CHECK_EQUAL( 60U , subBox2.size() );
-    
+
     {
         size_t i,j,k;
         size_t d = 0;
         const std::vector<size_t>& indexList = subBox2.getIndexList();
-        
+
         for (k=0; k < subBox2.getDim(2); k++) {
             for (j=0; j < subBox2.getDim(1); j++) {
                 for (i=0; i < subBox2.getDim(0); i++) {
-                    
+
                     size_t g = (i + 1) + (j + 1)*globalBox.getDim(0) + (k + 1)*globalBox.getDim(0)*globalBox.getDim(1);
                     BOOST_CHECK_EQUAL( indexList[d] , g);
                     d++;
@@ -104,7 +104,7 @@ BOOST_AUTO_TEST_CASE(BoxEqual) {
     Opm::Box subBox1( globalBox1 , 0 , 9 , 0 , 9 , 0, 9);
     Opm::Box subBox4( globalBox4 , 0 , 9 , 0 , 9 , 0, 9);
     Opm::Box subBox5( globalBox4 , 10 , 19 , 10 , 19 , 10, 19);
-    
+
     BOOST_CHECK( globalBox1.equal( globalBox2 ));
     BOOST_CHECK( !globalBox1.equal( globalBox3 ));
     BOOST_CHECK( globalBox1.equal( subBox1 ));

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -59,7 +59,7 @@ static Opm::DeckPtr createDeckHeaders() {
         "GRID\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -72,7 +72,7 @@ static Opm::DeckPtr createDeckMissingDIMS() {
         "GRID\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -116,7 +116,7 @@ static Opm::DeckPtr createCPDeck() {
         "  1000*1 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -208,7 +208,7 @@ static Opm::DeckPtr createCARTDeck() {
         "100*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -231,7 +231,7 @@ static Opm::DeckPtr createCARTDeckDEPTHZ() {
         "121*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -252,7 +252,7 @@ static Opm::DeckPtr createCARTInvalidDeck() {
         "1000*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -261,17 +261,17 @@ BOOST_AUTO_TEST_CASE(CREATE_SIMPLE) {
     Opm::EclipseGrid grid(10,20,30);
 
     BOOST_CHECK_EQUAL( grid.getNX() , 10 );
-    BOOST_CHECK_EQUAL( grid.getNY() , 20 ); 
+    BOOST_CHECK_EQUAL( grid.getNY() , 20 );
     BOOST_CHECK_EQUAL( grid.getNZ() , 30 );
     BOOST_CHECK_EQUAL( grid.getCartesianSize() , 6000 );
     BOOST_CHECK_EQUAL( false , grid.hasCellInfo() );
-    
+
 }
 
 BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
     Opm::DeckPtr deck1 = createCARTDeck();
     Opm::DeckPtr deck2 = createCARTDeckDEPTHZ();
-    
+
     std::shared_ptr<Opm::EclipseGrid> grid1(new Opm::EclipseGrid( deck1 ));
     std::shared_ptr<Opm::EclipseGrid> grid2(new Opm::EclipseGrid( deck2 ));
 
@@ -282,13 +282,13 @@ BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
         BOOST_CHECK_THROW( grid1->getCellVolume(10,0,0) , std::invalid_argument);
         BOOST_CHECK_THROW( grid1->getCellVolume(0,10,0) , std::invalid_argument);
         BOOST_CHECK_THROW( grid1->getCellVolume(0,0,10) , std::invalid_argument);
-        
+
         for (size_t g=0; g < 1000; g++)
             BOOST_CHECK_CLOSE( grid1->getCellVolume(g) , 0.25*0.25*0.25 , 0.001);
-        
-        
+
+
         for (size_t k= 0; k < 10; k++)
-            for (size_t j= 0; j < 10; j++)  
+            for (size_t j= 0; j < 10; j++)
                 for (size_t i= 0; i < 10; i++)
                     BOOST_CHECK_CLOSE( grid1->getCellVolume(i,j,k) , 0.25*0.25*0.25 , 0.001 );
     }
@@ -299,14 +299,14 @@ BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
         BOOST_CHECK_THROW( grid1->getCellCenter(0,0,10) , std::invalid_argument);
 
         for (size_t k= 0; k < 10; k++)
-            for (size_t j= 0; j < 10; j++)  
+            for (size_t j= 0; j < 10; j++)
                 for (size_t i= 0; i < 10; i++) {
                     auto pos = grid1->getCellCenter(i,j,k);
-                    
+
                     BOOST_CHECK_CLOSE( std::get<0>(pos) , i*0.25 + 0.125, 0.001);
                     BOOST_CHECK_CLOSE( std::get<1>(pos) , j*0.25 + 0.125, 0.001);
                     BOOST_CHECK_CLOSE( std::get<2>(pos) , k*0.25 + 0.125 + 0.25, 0.001);
-                    
+
                 }
     }
 }
@@ -368,7 +368,7 @@ static Opm::DeckPtr createInvalidDXYZCARTDeck() {
         "1000*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -398,7 +398,7 @@ static Opm::DeckPtr createInvalidDXYZCARTDeckDEPTHZ() {
         "101*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -429,7 +429,7 @@ static Opm::DeckPtr createOnlyTopDZCartGrid() {
         "110*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -452,7 +452,7 @@ static Opm::DeckPtr createInvalidDEPTHZDeck1 () {
         "66*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -481,7 +481,7 @@ static Opm::DeckPtr createInvalidDEPTHZDeck2 () {
         "67*0.25 /\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -533,7 +533,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchCOORD) {
         "  1000*1 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
     Opm::DeckKeywordConstPtr zcorn = deck->getKeyword("ZCORN");
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchZCORN) {
         "  1000*1 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
     Opm::DeckKeywordConstPtr zcorn = deck->getKeyword("ZCORN");
@@ -581,7 +581,7 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchACTNUM) {
         "  999*1 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
     BOOST_CHECK_THROW((void)Opm::EclipseGrid( deck ) , std::invalid_argument);
@@ -602,17 +602,17 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
         "  8000*1 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
-    
+
     Opm::EclipseGrid grid(deck);
     BOOST_CHECK_EQUAL( 1000U , grid.getNumActive());
     std::vector<int> actnum(1000);
     actnum[0] = 1;
     grid.resetACTNUM( actnum.data() );
     BOOST_CHECK_EQUAL( 1U , grid.getNumActive() );
-    
+
     grid.resetACTNUM( NULL );
     BOOST_CHECK_EQUAL( 1000U , grid.getNumActive() );
 }
@@ -637,7 +637,7 @@ BOOST_AUTO_TEST_CASE(Fwrite) {
         "  8000*1 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck = parser->parseString(deckData) ;
     Opm::EclipseGrid grid1(deck );

--- a/opm/parser/eclipse/EclipseState/Grid/tests/FaceDirTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/FaceDirTests.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE(CheckComposite) {
     BOOST_CHECK( FaceDir::ZMinus & FaceDir::FromMULTREGTString("Z"));
     BOOST_CHECK_EQUAL( FaceDir::ZPlus  + FaceDir::ZMinus ,  FaceDir::FromMULTREGTString("Z"));
 
-    
+
     BOOST_CHECK_EQUAL( FaceDir::XPlus + FaceDir::YPlus + FaceDir::XMinus + FaceDir::YMinus , FaceDir::FromMULTREGTString("XY"));
     BOOST_CHECK_EQUAL( FaceDir::XPlus + FaceDir::ZPlus + FaceDir::XMinus + FaceDir::ZMinus, FaceDir::FromMULTREGTString("XZ"));
     BOOST_CHECK_EQUAL( FaceDir::ZPlus + FaceDir::YPlus + FaceDir::ZMinus + FaceDir::YMinus, FaceDir::FromMULTREGTString("YZ"));

--- a/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(CreateFace) {
             size_t index1 = *iter1;
             size_t index2 = *iter2;
             size_t index3 = *iter3;
-        
+
             BOOST_CHECK_EQUAL( index1 , trueValues1[i] );
             BOOST_CHECK_EQUAL( index2 , trueValues2[i] );
             BOOST_CHECK_EQUAL( index3 , trueValues3[i] );
@@ -98,8 +98,8 @@ BOOST_AUTO_TEST_CASE(AddFaceToFaults) {
         BOOST_CHECK_EQUAL( *iter , face1 ); ++iter;
         BOOST_CHECK_EQUAL( *iter , face2 ); ++iter;
         BOOST_CHECK_EQUAL( *iter , face3 ); ++iter;
-    }    
-    
+    }
+
 }
 
 
@@ -115,7 +115,7 @@ BOOST_AUTO_TEST_CASE(CreateFaultCollection) {
 BOOST_AUTO_TEST_CASE(AddFaultsToCollection) {
     Opm::FaultCollection faults;
     std::shared_ptr<Opm::Fault> fault = std::make_shared<Opm::Fault>("FAULT");
-    
+
     faults.addFault(fault);
     BOOST_CHECK_EQUAL( faults.size() , 1 );
     BOOST_CHECK(faults.hasFault("FAULT"));

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(Empty) {
 
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,7,9);
     Opm::GridProperties<int> gridProperties( grid , supportedKeywords);
-    
+
     BOOST_CHECK( gridProperties.supportsKeyword("SATNUM") );
     BOOST_CHECK( gridProperties.supportsKeyword("FIPNUM") );
     BOOST_CHECK( !gridProperties.supportsKeyword("FLUXNUM") );
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE(addKeyword) {
     });
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,7,9);
     Opm::GridProperties<int> gridProperties( grid , supportedKeywords);
-    
+
     BOOST_CHECK_THROW( gridProperties.addKeyword("NOT-SUPPORTED") , std::invalid_argument);
 
     BOOST_CHECK(  gridProperties.addKeyword("SATNUM"));
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(getKeyword) {
     Opm::GridProperties<int> gridProperties( grid , supportedKeywords);
     std::shared_ptr<Opm::GridProperty<int> > satnum1 = gridProperties.getKeyword("SATNUM");
     std::shared_ptr<Opm::GridProperty<int> > satnum2 = gridProperties.getKeyword("SATNUM");
-    
+
     BOOST_CHECK_EQUAL( satnum1.get() , satnum2.get());
     BOOST_CHECK_THROW( gridProperties.getKeyword("NOT-SUPPORTED") , std::invalid_argument );
 }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE(HasNAN) {
     typedef Opm::GridProperty<double>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("PORO" , nan , "1");
     Opm::GridProperty<double> poro( 2 , 2 , 1 , keywordInfo);
-    
+
     BOOST_CHECK( poro.containsNaN() );
     poro.iset(0,0.15);
     poro.iset(1,0.15);
@@ -118,7 +118,7 @@ Opm::DeckKeywordConstPtr createTABDIMSKeyword( ) {
 
 
 BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_notData_Throws) {
-    Opm::DeckKeywordConstPtr tabdimsKw = createTABDIMSKeyword(); 
+    Opm::DeckKeywordConstPtr tabdimsKw = createTABDIMSKeyword();
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("TABDIMS" , 100, "1");
     Opm::GridProperty<int> gridProperty( 6 ,1,1 , keywordInfo);
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_notData_Throws) {
 
 
 BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_wrong_size_throws) {
-    Opm::DeckKeywordConstPtr satnumKw = createSATNUMKeyword(); 
+    Opm::DeckKeywordConstPtr satnumKw = createSATNUMKeyword();
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("SATNUM" , 66, "1");
     Opm::GridProperty<int> gridProperty( 15 ,1,1, keywordInfo);
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword_wrong_size_throws) {
 
 
 BOOST_AUTO_TEST_CASE(SetFromDeckKeyword) {
-    Opm::DeckKeywordConstPtr satnumKw = createSATNUMKeyword(); 
+    Opm::DeckKeywordConstPtr satnumKw = createSATNUMKeyword();
     typedef Opm::GridProperty<int>::SupportedKeywordInfo SupportedKeywordInfo;
     SupportedKeywordInfo keywordInfo("SATNUM" , 99, "1");
     Opm::GridProperty<int> gridProperty( 4 , 4 , 2 , keywordInfo);
@@ -147,11 +147,11 @@ BOOST_AUTO_TEST_CASE(SetFromDeckKeyword) {
         for (size_t j=0; j < 4; j++) {
             for (size_t i=0; i < 4; i++) {
                 size_t g = i + j*4 + k*16;
-                
+
                 BOOST_CHECK_EQUAL( g , data[g] );
                 BOOST_CHECK_EQUAL( g , gridProperty.iget(g) );
                 BOOST_CHECK_EQUAL( g , gridProperty.iget(i,j,k) );
-                
+
             }
         }
     }
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE(copy) {
 
     for (size_t j=0; j < 4; j++) {
         for (size_t i=0; i < 4; i++) {
-            
+
             BOOST_CHECK_EQUAL( prop2.iget(i,j,0) , 0 );
             BOOST_CHECK_EQUAL( prop2.iget(i,j,1) , 9 );
         }
@@ -190,14 +190,14 @@ BOOST_AUTO_TEST_CASE(SCALE) {
 
     std::shared_ptr<Opm::Box> global = std::make_shared<Opm::Box>(4,4,2);
     std::shared_ptr<Opm::Box> layer0 = std::make_shared<Opm::Box>(*global , 0,3,0,3,0,0);
-    
+
     prop2.copyFrom(prop1 , layer0);
     prop2.scale( 2 , global );
     prop2.scale( 2 , layer0 );
 
     for (size_t j=0; j < 4; j++) {
         for (size_t i=0; i < 4; i++) {
-            
+
             BOOST_CHECK_EQUAL( prop2.iget(i,j,0) , 4 );
             BOOST_CHECK_EQUAL( prop2.iget(i,j,1) , 18 );
         }
@@ -212,13 +212,13 @@ BOOST_AUTO_TEST_CASE(SET) {
 
     std::shared_ptr<Opm::Box> global = std::make_shared<Opm::Box>(4,4,2);
     std::shared_ptr<Opm::Box> layer0 = std::make_shared<Opm::Box>(*global , 0,3,0,3,0,0);
-    
+
     prop.setScalar( 2 , global );
     prop.setScalar( 4 , layer0 );
 
     for (size_t j=0; j < 4; j++) {
         for (size_t i=0; i < 4; i++) {
-            
+
             BOOST_CHECK_EQUAL( prop.iget(i,j,0) , 4 );
             BOOST_CHECK_EQUAL( prop.iget(i,j,1) , 2 );
         }
@@ -235,14 +235,14 @@ BOOST_AUTO_TEST_CASE(ADD) {
 
     std::shared_ptr<Opm::Box> global = std::make_shared<Opm::Box>(4,4,2);
     std::shared_ptr<Opm::Box> layer0 = std::make_shared<Opm::Box>(*global , 0,3,0,3,0,0);
-    
+
     prop2.copyFrom(prop1 , layer0);
     prop2.add( 2 , global );
     prop2.add( 2 , layer0 );
 
     for (size_t j=0; j < 4; j++) {
         for (size_t i=0; i < 4; i++) {
-            
+
             BOOST_CHECK_EQUAL( prop2.iget(i,j,0) , 5 );
             BOOST_CHECK_EQUAL( prop2.iget(i,j,1) , 11 );
         }
@@ -376,19 +376,19 @@ template <class ValueType>
 class TestPostProcessorMul : public Opm::GridPropertyBasePostProcessor<ValueType>
 {
 public:
-    TestPostProcessorMul(ValueType factor) { 
-        m_factor = factor; 
+    TestPostProcessorMul(ValueType factor) {
+        m_factor = factor;
     }
-    
-    void apply(std::vector<ValueType>& values) const { 
-        for (size_t g = 0; g < values.size(); g++) 
+
+    void apply(std::vector<ValueType>& values) const {
+        for (size_t g = 0; g < values.size(); g++)
             values[g] *= m_factor;
     };
 
 private:
     ValueType m_factor;
 };
-    
+
 
 
 
@@ -413,7 +413,7 @@ static Opm::DeckPtr createDeck() {
         "1000*0.10 / \n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -421,7 +421,7 @@ static Opm::DeckPtr createDeck() {
 
 BOOST_AUTO_TEST_CASE(GridPropertyPostProcessors) {
     std::shared_ptr<TestPostProcessorMul<double> > testPostP = std::make_shared<TestPostProcessorMul<double> >(2.0);
-    
+
     typedef Opm::GridPropertySupportedKeywordInfo<double> SupportedKeywordInfo;
     SupportedKeywordInfo kwInfo1("MULTPV" , 1.0 , "1");
     SupportedKeywordInfo kwInfo2("PORO"   , 1.0 , testPostP , "1");
@@ -430,10 +430,10 @@ BOOST_AUTO_TEST_CASE(GridPropertyPostProcessors) {
     Opm::DeckPtr deck = createDeck();
     std::shared_ptr<Opm::EclipseGrid> grid = std::make_shared<Opm::EclipseGrid>(deck);
     Opm::GridProperties<double> properties(grid, supportedKeywords);
-    
+
     {
-        auto poro = properties.getKeyword("PORO"); 
-        auto multpv = properties.getKeyword("MULTPV"); 
+        auto poro = properties.getKeyword("PORO");
+        auto multpv = properties.getKeyword("MULTPV");
 
         poro->loadFromDeckKeyword( deck->getKeyword("PORO" , 0));
         multpv->loadFromDeckKeyword( deck->getKeyword("MULTPV" , 0));
@@ -461,8 +461,8 @@ BOOST_AUTO_TEST_CASE(GridPropertyPostProcessors) {
         }
 
     }
-    
-    
+
+
     BOOST_CHECK( !kwInfo1.hasPostProcessor() );
     BOOST_CHECK( kwInfo2.hasPostProcessor() );
 }
@@ -478,7 +478,7 @@ BOOST_AUTO_TEST_CASE(multiply) {
 
     BOOST_CHECK_THROW( p1.multiplyWith(p2) , std::invalid_argument );
     p1.multiplyWith(p3);
-    
+
     for (size_t g = 0; g < p1.getCartesianSize(); g++)
         BOOST_CHECK_EQUAL( 100 , p1.iget(g));
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
@@ -78,18 +78,18 @@ static Opm::DeckPtr createInvalidMULTREGTDeck() {
         "3 4 5\n"
         "3 4 5\n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "1  2   0.50   G   ALL    M / -- Invalid direction\n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "1  2   0.50   X   ALL    G / -- Invalid region \n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "1  2   0.50   X   ALL    M / -- Region not in deck \n"
         "/\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -100,7 +100,7 @@ static Opm::DeckPtr createInvalidMULTREGTDeck() {
 BOOST_AUTO_TEST_CASE(InvalidInput) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
-            SupportedKeywordInfo("FLUXNUM" , 1 , "1") , 
+            SupportedKeywordInfo("FLUXNUM" , 1 , "1") ,
             SupportedKeywordInfo("OPERNUM" , 1 , "1") ,
             SupportedKeywordInfo("MULTNUM" , 1 , "1") });
 
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
     // Invalid direction
     BOOST_CHECK_THROW( scanner.addKeyword( multregtKeyword0 ) , std::invalid_argument);
 
-    // Not supported region 
+    // Not supported region
     BOOST_CHECK_THROW( scanner.addKeyword( multregtKeyword1 ) , std::invalid_argument);
 
     // The keyword is ok; but it refers to a region which is not in the deck.
@@ -140,21 +140,21 @@ static Opm::DeckPtr createNotSupportedMULTREGTDeck() {
         "3 4 5\n"
         "3 4 5\n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "1  2   0.50   X   NNC    M / -- Not yet support NNC behaviour \n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "*  2   0.50   X   ALL    M / -- Defaulted from region value \n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "2  *   0.50   X   ALL    M / -- Defaulted to region value \n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "2  2   0.50   X   ALL    M / -- Region values equal \n"
         "/\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -205,15 +205,15 @@ static Opm::DeckPtr createSimpleMULTREGTDeck() {
         "3 4\n"
         "3 4\n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "1  2   0.50   X   ALL    M / \n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "2  1   1.50   X   ALL    M / \n"
         "/\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }
@@ -222,7 +222,7 @@ static Opm::DeckPtr createSimpleMULTREGTDeck() {
 BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
     typedef Opm::GridProperties<int>::SupportedKeywordInfo SupportedKeywordInfo;
     std::shared_ptr<std::vector<SupportedKeywordInfo> > supportedKeywords(new std::vector<SupportedKeywordInfo>{
-            SupportedKeywordInfo("FLUXNUM" , 1 , "1") , 
+            SupportedKeywordInfo("FLUXNUM" , 1 , "1") ,
                 SupportedKeywordInfo("OPERNUM" , 1 , "1") ,
                 SupportedKeywordInfo("MULTNUM" , 1 , "1") });
 
@@ -238,16 +238,16 @@ BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
 
     Opm::DeckKeywordConstPtr multregtKeyword0 = deck->getKeyword("MULTREGT",0);
     Opm::DeckKeywordConstPtr multregtKeyword1 = deck->getKeyword("MULTREGT",1);
-    
+
     multNum->loadFromDeckKeyword( inputBox , multnumKeyword );
     fluxNum->loadFromDeckKeyword( inputBox , fluxnumKeyword );
-    
+
     {
         Opm::MULTREGTScanner scanner;
         scanner.addKeyword(multregtKeyword0);
-    
+
         auto cells = scanner.scanRegions(gridProperties);
-        
+
         BOOST_CHECK_EQUAL( 2 , cells.size() );
         auto cell0 = cells[0];
         auto cell1 = cells[1];
@@ -255,7 +255,7 @@ BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
         BOOST_CHECK_EQUAL( 0 , std::get<0>(cell0));
         BOOST_CHECK_EQUAL( Opm::FaceDir::XPlus , std::get<1>(cell0));
         BOOST_CHECK_EQUAL( 0.50 , std::get<2>(cell0));
-        
+
         BOOST_CHECK_EQUAL( 2 , std::get<0>(cell1));
         BOOST_CHECK_EQUAL( Opm::FaceDir::XPlus , std::get<1>(cell1));
         BOOST_CHECK_EQUAL( 0.50 , std::get<2>(cell1));
@@ -264,15 +264,15 @@ BOOST_AUTO_TEST_CASE(SimpleMULTREGT) {
     {
         Opm::MULTREGTScanner scanner;
         scanner.addKeyword(multregtKeyword1);
-        
+
         auto cells = scanner.scanRegions(gridProperties);
-        
+
         BOOST_CHECK_EQUAL( 2 , cells.size() );
-        
+
         auto cell0 = cells[0];
         auto cell1 = cells[1];
 
-        
+
         BOOST_CHECK_EQUAL( 1 , std::get<0>(cell0));
         BOOST_CHECK_EQUAL( Opm::FaceDir::XMinus , std::get<1>(cell0));
         BOOST_CHECK_EQUAL( 1.50 , std::get<2>(cell0));
@@ -301,12 +301,12 @@ static Opm::DeckPtr createCopyMULTNUMDeck() {
         "COPY\n"
         " FLUXNUM  MULTNUM /\n"
         "/\n"
-        "MULTREGT\n"  
+        "MULTREGT\n"
         "1  2   0.50/ \n"
         "/\n"
         "EDIT\n"
         "\n";
- 
+
     Opm::ParserPtr parser(new Opm::Parser());
     return parser->parseString(deckData) ;
 }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/TransMultTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/TransMultTests.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_CASE(Empty) {
 
     BOOST_CHECK_THROW( transMult.getMultiplier(12,10,10 , Opm::FaceDir::XPlus) , std::invalid_argument );
     BOOST_CHECK_THROW( transMult.getMultiplier(1000 , Opm::FaceDir::XPlus) , std::invalid_argument );
-    
+
     BOOST_CHECK_EQUAL( transMult.getMultiplier(9,9,9, Opm::FaceDir::YPlus) , 1.0 );
     BOOST_CHECK_EQUAL( transMult.getMultiplier(100 , Opm::FaceDir::ZPlus) , 1.0 );
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
@@ -23,23 +23,23 @@
 
 namespace Opm {
 
-    Completion::Completion(int i, int j , int k , CompletionStateEnum state , 
+    Completion::Completion(int i, int j , int k , CompletionStateEnum state ,
                            const Value<double>& connectionTransmissibilityFactor,
-                           const Value<double>& diameter, 
-                           const Value<double>& skinFactor, 
+                           const Value<double>& diameter,
+                           const Value<double>& skinFactor,
                            const CompletionDirection::DirectionEnum direction)
         : m_i(i), m_j(j), m_k(k),
           m_diameter(diameter),
           m_connectionTransmissibilityFactor(connectionTransmissibilityFactor),
           m_skinFactor(skinFactor),
           m_state(state),
-          m_direction(direction) 
+          m_direction(direction)
     {  }
 
 
     bool Completion::sameCoordinate(const Completion& other) const {
-        if ((m_i == other.m_i) && 
-            (m_j == other.m_j) && 
+        if ((m_i == other.m_i) &&
+            (m_j == other.m_j) &&
             (m_k == other.m_k))
             return true;
         else
@@ -52,7 +52,7 @@ namespace Opm {
        will return a list is that the 'K1 K2' structure is
        disentangled, and each completion is returned separately.
     */
-    
+
     std::pair<std::string , std::vector<CompletionPtr> > Completion::completionsFromCOMPDATRecord( DeckRecordConstPtr compdatRecord ) {
         std::vector<CompletionPtr> completions;
         std::string well = compdatRecord->getItem("WELL")->getTrimmedString(0);
@@ -77,7 +77,7 @@ namespace Opm {
             diameter.setValue( diameterItem->getSIDouble(0));
             skinFactor.setValue( skinFactorItem->getRawDouble(0));
         }
-        
+
         const CompletionDirection::DirectionEnum& direction = CompletionDirection::DirectionEnumFromString(compdatRecord->getItem("DIR")->getTrimmedString(0));
 
         for (int k = K1; k <= K2; k++) {
@@ -96,19 +96,19 @@ namespace Opm {
          "WELL2" : [ Completion1 , Completion2 , ... , CompletionN ],
          ...
       }
-    */   
-            
-    
+    */
+
+
     std::map<std::string , std::vector< CompletionPtr> > Completion::completionsFromCOMPDATKeyword( DeckKeywordConstPtr compdatKeyword ) {
         std::map<std::string , std::vector< CompletionPtr> > completionMapList;
         for (size_t recordIndex = 0; recordIndex < compdatKeyword->size(); recordIndex++) {
             std::pair<std::string , std::vector< CompletionPtr> > wellCompletionsPair = completionsFromCOMPDATRecord( compdatKeyword->getRecord( recordIndex ));
             std::string well = wellCompletionsPair.first;
             std::vector<CompletionPtr>& newCompletions = wellCompletionsPair.second;
-        
-            if (completionMapList.find(well) == completionMapList.end()) 
+
+            if (completionMapList.find(well) == completionMapList.end())
                  completionMapList[well] = std::vector<CompletionPtr>();
-            
+
             {
                 std::vector<CompletionPtr>& currentCompletions = completionMapList.find(well)->second;
 
@@ -122,7 +122,7 @@ namespace Opm {
     void Completion::fixDefaultIJ(int wellHeadI , int wellHeadJ) {
         if (m_i < 0)
             m_i = wellHeadI;
-        
+
         if (m_j < 0)
             m_j = wellHeadJ;
     }
@@ -151,7 +151,7 @@ namespace Opm {
     double Completion::getDiameter() const {
         return m_diameter.getValue();
     }
-    
+
     double Completion::getSkinFactor() const {
         return m_skinFactor.getValue();
     }

--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
@@ -35,10 +35,10 @@ namespace Opm {
 
     class Completion {
     public:
-        Completion(int i, int j , int k , CompletionStateEnum state , 
+        Completion(int i, int j , int k , CompletionStateEnum state ,
                    const Value<double>& connectionTransmissibilityFactor,
-                   const Value<double>& diameter, 
-                   const Value<double>& skinFactor, 
+                   const Value<double>& diameter,
+                   const Value<double>& skinFactor,
                    const CompletionDirection::DirectionEnum direction = CompletionDirection::DirectionEnum::Z);
 
         bool sameCoordinate(const Completion& other) const;
@@ -55,7 +55,7 @@ namespace Opm {
 
         static std::map<std::string , std::vector<std::shared_ptr<Completion> > >  completionsFromCOMPDATKeyword( DeckKeywordConstPtr compdatKeyword );
         static std::pair<std::string , std::vector<std::shared_ptr<Completion> > > completionsFromCOMPDATRecord( DeckRecordConstPtr compdatRecord );
-        
+
     private:
         int m_i, m_j, m_k;
         Value<double> m_diameter;

--- a/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.cpp
@@ -25,19 +25,19 @@ namespace Opm {
 
     CompletionSet::CompletionSet() {}
 
-    
+
     size_t CompletionSet::size() const {
         return m_completions.size();
     }
 
-    
+
     CompletionConstPtr CompletionSet::get(size_t index) const {
         if (index >= m_completions.size())
             throw std::range_error("Out of bounds");
-        
+
         return m_completions[index];
     }
-    
+
 
     void CompletionSet::add(CompletionConstPtr completion) {
         bool inserted = false;
@@ -49,7 +49,7 @@ namespace Opm {
                 inserted = true;
             }
         }
-        
+
         if (!inserted)
             m_completions.push_back( completion );
     }
@@ -64,5 +64,5 @@ namespace Opm {
         return copy;
     }
 
-    
+
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
@@ -49,4 +49,4 @@ namespace Opm {
 
 
 
-#endif 
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -42,13 +42,13 @@ namespace Opm {
         const T& at(size_t index) const {
             if (index >= m_timeMap->size())
                 throw std::range_error("Index value is out range.");
-            
+
             if (index >= m_data.size())
                 return m_currentValue;
-            
+
             return m_data.at(index);
         }
-        
+
 
         T get(size_t index) const {
             if (index >= m_timeMap->size())
@@ -60,7 +60,7 @@ namespace Opm {
             return m_data[index];
         }
 
-        
+
 
         size_t size() const {
             return m_data.size();
@@ -70,12 +70,12 @@ namespace Opm {
         void add(size_t index , T value) {
             if (index >= (m_timeMap->size()))
                 throw std::range_error("Index value is out range.");
- 
+
            if (m_data.size() > 0) {
                 if (index < (m_data.size() - 1))
                     throw std::invalid_argument("Elements must be added in weakly increasing order");
             }
-           
+
            {
                size_t currentSize = m_data.size();
                if (currentSize <= index) {
@@ -83,7 +83,7 @@ namespace Opm {
                        m_data.push_back( m_currentValue );
                }
            }
-           
+
            m_data[index] = value;
            m_currentValue = value;
         }
@@ -99,4 +99,4 @@ namespace Opm {
 
 
 
-#endif 
+#endif

--- a/opm/parser/eclipse/EclipseState/Schedule/Group.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group.cpp
@@ -34,10 +34,10 @@ namespace Opm {
             std::shared_ptr<DynamicState<double> > waterTarget;
             std::shared_ptr<DynamicState<double> > gasTarget;
             std::shared_ptr<DynamicState<double> > liquidTarget;
-            
+
         };
-        
-        ProductionData::ProductionData(TimeMapConstPtr timeMap) : 
+
+        ProductionData::ProductionData(TimeMapConstPtr timeMap) :
             controlMode( new DynamicState<GroupProduction::ControlEnum>(timeMap , GroupProduction::NONE)),
             exceedAction( new DynamicState<GroupProductionExceedLimit::ActionEnum>(timeMap , GroupProductionExceedLimit::NONE)),
             oilTarget( new DynamicState<double>(timeMap , 0)),
@@ -49,13 +49,13 @@ namespace Opm {
         }
     }
 
-    
-    
+
+
 
     namespace GroupInjection {
         struct InjectionData {
             InjectionData(TimeMapConstPtr timeMap);
-            
+
             std::shared_ptr<DynamicState<Phase::PhaseEnum> > phase;
             std::shared_ptr<DynamicState<GroupInjection::ControlEnum> > controlMode;
             std::shared_ptr<DynamicState<double> > rate;
@@ -64,8 +64,8 @@ namespace Opm {
             std::shared_ptr<DynamicState<double> > targetReinjectFraction;
             std::shared_ptr<DynamicState<double> > targetVoidReplacementFraction;
         };
-        
-        InjectionData::InjectionData(TimeMapConstPtr timeMap) : 
+
+        InjectionData::InjectionData(TimeMapConstPtr timeMap) :
             phase( new DynamicState<Phase::PhaseEnum>( timeMap , Phase::WATER )),
             controlMode( new DynamicState<GroupInjection::ControlEnum>( timeMap , NONE )),
             rate( new DynamicState<double>( timeMap , 0 )),
@@ -74,16 +74,16 @@ namespace Opm {
             targetReinjectFraction( new DynamicState<double>( timeMap , 0)),
             targetVoidReplacementFraction( new DynamicState<double>( timeMap , 0))
         {
-        
+
         }
     }
 
-    
-        
+
+
 
     /*****************************************************************/
-    
-    Group::Group(const std::string& name_, TimeMapConstPtr timeMap , size_t creationTimeStep) : 
+
+    Group::Group(const std::string& name_, TimeMapConstPtr timeMap , size_t creationTimeStep) :
         m_injection( new GroupInjection::InjectionData(timeMap) ),
         m_production( new GroupProduction::ProductionData( timeMap )),
         m_wells( new DynamicState<WellSetConstPtr>(timeMap , WellSetConstPtr(new WellSet() ))),
@@ -121,7 +121,7 @@ namespace Opm {
 
     /**********************************************************************/
 
-    
+
     void Group::setInjectionPhase(size_t time_step , Phase::PhaseEnum phase){
         if (m_injection->phase->size() == time_step + 1) {
             Phase::PhaseEnum currentPhase = m_injection->phase->get(time_step);
@@ -206,7 +206,7 @@ namespace Opm {
     void Group::setProductionControlMode( size_t time_step , GroupProduction::ControlEnum controlMode) {
         m_production->controlMode->add(time_step , controlMode );
     }
-    
+
     GroupProduction::ControlEnum Group::getProductionControlMode( size_t time_step ) const {
         return m_production->controlMode->get(time_step);
     }
@@ -263,7 +263,7 @@ namespace Opm {
 
 
     /*****************************************************************/
-    
+
     WellSetConstPtr Group::wellMap(size_t time_step) const {
         return m_wells->get(time_step);
     }
@@ -285,11 +285,11 @@ namespace Opm {
         WellSetConstPtr wellSet = wellMap(time_step);
         return wellSet->size();
     }
-    
+
     void Group::addWell(size_t time_step , WellPtr well) {
         WellSetConstPtr wellSet = wellMap(time_step);
         WellSetPtr newWellSet = WellSetPtr( wellSet->shallowCopy() );
-        
+
         newWellSet->addWell(well);
         m_wells->add(time_step , newWellSet);
     }
@@ -298,7 +298,7 @@ namespace Opm {
     void Group::delWell(size_t time_step, const std::string& wellName) {
         WellSetConstPtr wellSet = wellMap(time_step);
         WellSetPtr newWellSet = WellSetPtr( wellSet->shallowCopy() );
-        
+
         newWellSet->delWell(wellName);
         m_wells->add(time_step , newWellSet);
     }

--- a/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
@@ -36,11 +36,11 @@ namespace Opm {
         struct InjectionData;
     }
 
-    
+
     namespace GroupProduction {
         struct ProductionData;
     }
-    
+
     class Group {
     public:
         Group(const std::string& name, TimeMapConstPtr timeMap , size_t creationTimeStep);
@@ -53,13 +53,13 @@ namespace Opm {
         /******************************************************************/
         void             setInjectionPhase(size_t time_step , Phase::PhaseEnum phase);
         Phase::PhaseEnum getInjectionPhase(size_t time_step) const;
-        
+
         void                      setInjectionControlMode(size_t time_step , GroupInjection::ControlEnum ControlMode);
         GroupInjection::ControlEnum getInjectionControlMode( size_t time_step) const;
 
         void   setInjectionRate(size_t time_step , double rate);
         double getInjectionRate( size_t time_step) const;
-        
+
         void   setSurfaceMaxRate( size_t time_step , double rate);
         double getSurfaceMaxRate( size_t time_step ) const;
 
@@ -79,7 +79,7 @@ namespace Opm {
 
         GroupProductionExceedLimit::ActionEnum getProductionExceedLimitAction(size_t time_step) const;
         void setProductionExceedLimitAction(size_t time_step , GroupProductionExceedLimit::ActionEnum action);
-        
+
         void   setOilTargetRate(size_t time_step , double oilTargetRate);
         double getOilTargetRate(size_t time_step) const;
         void   setGasTargetRate(size_t time_step , double gasTargetRate);

--- a/opm/parser/eclipse/EclipseState/Schedule/GroupTreeNode.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/GroupTreeNode.cpp
@@ -38,7 +38,7 @@ namespace Opm {
         m_childGroups[childName] = child;
         return child;
     }
-    
+
     void GroupTreeNode::addChildGroup(std::shared_ptr<GroupTreeNode> childGroup) {
         if (hasChildGroup(childGroup->name())) {
             throw std::invalid_argument("Child group with name \"" + childGroup->name() + "\"already exists under node " + m_name);

--- a/opm/parser/eclipse/EclipseState/Schedule/GroupTreeNode.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/GroupTreeNode.hpp
@@ -26,9 +26,9 @@
 
 namespace Opm {
 
-    /// This Class is currently ONLY keeping track of the actual group nodes, 
-    /// and knows nothing about the wells. The wells will know which group 
-    /// (leaf) node they belong to. 
+    /// This Class is currently ONLY keeping track of the actual group nodes,
+    /// and knows nothing about the wells. The wells will know which group
+    /// (leaf) node they belong to.
     class GroupTreeNode {
     public:
         const std::string& name() const;
@@ -43,7 +43,7 @@ namespace Opm {
         std::map<std::string, std::shared_ptr<GroupTreeNode> >::const_iterator begin() const;
         std::map<std::string, std::shared_ptr<GroupTreeNode> >::const_iterator end() const;
 
-        
+
     private:
         GroupTreeNode(const std::string& name);
         std::string m_name;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -272,7 +272,7 @@ namespace Opm {
 
                 properties.injectorType = injectorType;
                 properties.predictionMode = true;
-                
+
                 if (!record->getItem("RATE")->defaultApplied(0)) {
                     properties.surfaceInjectionRate = convertInjectionRateToSI(record->getItem("RATE")->getRawDouble(0) , injectorType, *deck->getActiveUnitSystem());
                     properties.addInjectionControl(WellInjector::RATE);
@@ -291,7 +291,7 @@ namespace Opm {
                     properties.THPLimit = record->getItem("THP")->getSIDouble(0);
                     properties.addInjectionControl(WellInjector::THP);
                 } else
-                    properties.dropInjectionControl(WellInjector::THP);                                    
+                    properties.dropInjectionControl(WellInjector::THP);
 
                 /*
                   What a mess; there is a sensible default BHP limit
@@ -335,7 +335,7 @@ namespace Opm {
                 WellPtr well = *wellIter;
 
                 WellPolymerProperties properties(well->getPolymerPropertiesCopy(currentStep));
-                
+
                 properties.m_polymerConcentration = record->getItem("POLYMER_CONCENTRATION")->getSIDouble(0);
                 properties.m_saltConcentration = record->getItem("SALT_CONCENTRATION")->getSIDouble(0);
 
@@ -452,7 +452,7 @@ namespace Opm {
                 GroupProductionExceedLimit::ActionEnum exceedAction = GroupProductionExceedLimit::ActionEnumFromString(record->getItem("EXCEED_PROC")->getTrimmedString(0) );
                 group->setProductionExceedLimitAction( currentStep , exceedAction );
             }
-            
+
             group->setProductionGroup(currentStep, true);
         }
     }
@@ -460,7 +460,7 @@ namespace Opm {
     void Schedule::handleCOMPDAT(DeckKeywordConstPtr keyword, ParserLogPtr /*parserLog*/, size_t currentStep) {
         std::map<std::string , std::vector< CompletionPtr> > completionMapList = Completion::completionsFromCOMPDATKeyword( keyword );
         std::map<std::string , std::vector< CompletionPtr> >::iterator iter;
-        
+
         for( iter= completionMapList.begin(); iter != completionMapList.end(); iter++) {
             const std::string wellName = iter->first;
             WellPtr well = getWell(wellName);
@@ -482,7 +482,7 @@ namespace Opm {
             if (!record->getItem("PHASE")->defaultApplied(0)) {
                 std::string guideRatePhase = record->getItem("PHASE")->getTrimmedString(0);
                 well->setGuideRatePhase(currentStep, GuideRate::GuideRatePhaseEnumFromString(guideRatePhase));
-            } else 
+            } else
                 well->setGuideRatePhase(currentStep, GuideRate::UNDEFINED);
 
             well->setGuideRateScalingFactor(currentStep, record->getItem("SCALING_FACTOR")->getRawDouble(0));
@@ -500,7 +500,7 @@ namespace Opm {
 
             if (!hasGroup(parentName))
                 addGroup( parentName , currentStep );
-            
+
             if (!hasGroup(childName))
                 addGroup( childName , currentStep );
         }
@@ -655,7 +655,7 @@ namespace Opm {
             throw std::logic_error("Unknown injection phase");
         }
     }
-    
+
 
     bool Schedule::convertEclipseStringToBool(const std::string& eclipseString) {
         std::string lowerTrimmed = boost::algorithm::to_lower_copy(eclipseString);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -33,9 +33,9 @@
 
 #include <map>
 
-namespace Opm 
+namespace Opm
 {
-    
+
     const boost::gregorian::date defaultStartDate( 1983 , boost::gregorian::Jan , 1);
 
     class Schedule {
@@ -59,7 +59,7 @@ namespace Opm
         bool hasGroup(const std::string& groupName) const;
         GroupPtr getGroup(const std::string& groupName) const;
 
-  
+
     private:
         TimeMapPtr m_timeMap;
         OrderedMap<WellPtr> m_wells;

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -38,8 +38,8 @@ namespace Opm {
           throw std::invalid_argument("Unhandled enum value");
         }
     }
-    
-    
+
+
     CompletionStateEnum CompletionStateEnumFromString( const std::string& origStringValue ) {
         std::string stringValue(origStringValue);
         boost::algorithm::trim(stringValue);
@@ -56,7 +56,7 @@ namespace Opm {
     /*****************************************************************/
 
     namespace GroupInjection {
-    
+
         const std::string ControlEnum2String( ControlEnum enumValue ) {
             switch( enumValue ) {
             case NONE:
@@ -75,8 +75,8 @@ namespace Opm {
                 throw std::invalid_argument("Unhandled enum value");
             }
         }
-    
-    
+
+
         ControlEnum ControlEnumFromString( const std::string& origStringValue ) {
             std::string stringValue(origStringValue);
             boost::algorithm::trim(stringValue);
@@ -96,13 +96,13 @@ namespace Opm {
             else
                 throw std::invalid_argument("Unknown enum state string: " + stringValue );
         }
-        
+
     }
 
     /*****************************************************************/
 
     namespace GroupProduction {
-        
+
         const std::string ControlEnum2String( ControlEnum enumValue ) {
             switch( enumValue ) {
             case NONE:
@@ -125,8 +125,8 @@ namespace Opm {
                 throw std::invalid_argument("Unhandled enum value");
             }
         }
-    
-    
+
+
         ControlEnum ControlEnumFromString( const std::string& stringValue ) {
             if (stringValue == "NONE")
                 return NONE;
@@ -167,7 +167,7 @@ namespace Opm {
             case RATE:
                 return "RATE";
             default:
-                throw std::invalid_argument("unhandled enum value"); 
+                throw std::invalid_argument("unhandled enum value");
             }
         }
 
@@ -195,7 +195,7 @@ namespace Opm {
     }
 
     /*****************************************************************/
-    
+
     namespace Phase {
         const std::string PhaseEnum2String( PhaseEnum enumValue ) {
             switch( enumValue ) {
@@ -209,7 +209,7 @@ namespace Opm {
                 throw std::invalid_argument("unhandled enum value");
             }
         }
-    
+
         PhaseEnum PhaseEnumFromString( const std::string& origStringValue ) {
             std::string stringValue(origStringValue);
             boost::algorithm::trim(stringValue);
@@ -224,11 +224,11 @@ namespace Opm {
                 throw std::invalid_argument("Unknown enum state string: " + stringValue );
         }
     }
-    
+
     /*****************************************************************/
 
     namespace WellProducer {
-        
+
         const std::string ControlMode2String( ControlModeEnum enumValue ) {
             switch( enumValue ) {
             case ORAT:
@@ -253,7 +253,7 @@ namespace Opm {
                 throw std::invalid_argument("unhandled enum value");
             }
         }
-    
+
         ControlModeEnum ControlModeFromString( const std::string& origStringValue ) {
             std::string stringValue(origStringValue);
             boost::algorithm::trim(stringValue);
@@ -298,7 +298,7 @@ namespace Opm {
                 throw std::invalid_argument("unhandled enum value");
             }
         }
-    
+
         TypeEnum TypeFromString( const std::string& origStringValue ) {
             std::string stringValue(origStringValue);
             boost::algorithm::trim(stringValue);
@@ -333,7 +333,7 @@ namespace Opm {
                 throw std::invalid_argument("unhandled enum value");
             }
         }
-    
+
         ControlModeEnum ControlModeFromString( const std::string& origStringValue ) {
             std::string stringValue(origStringValue);
             boost::algorithm::trim(stringValue);
@@ -356,7 +356,7 @@ namespace Opm {
 
 
     namespace WellCommon {
-        
+
         const std::string Status2String(StatusEnum enumValue) {
             switch( enumValue ) {
             case OPEN:
@@ -388,7 +388,7 @@ namespace Opm {
             else
                 throw std::invalid_argument("Unknown enum state string: " + stringValue );
         }
-        
+
     }
 
     namespace GuideRate {

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -29,8 +29,8 @@ namespace Opm {
         enum StatusEnum {
             OPEN = 1,
             STOP = 2,
-            SHUT = 3, 
-            AUTO = 4 
+            SHUT = 3,
+            AUTO = 4
         };
 
         const std::string Status2String(StatusEnum enumValue);
@@ -57,7 +57,7 @@ namespace Opm {
     } // namespace CompletionDirection
 
 
-    namespace Phase { 
+    namespace Phase {
         enum PhaseEnum {
             OIL   = 1,
             GAS   = 2,
@@ -78,10 +78,10 @@ namespace Opm {
             MULTI = 4
         };
 
-        
+
         enum ControlModeEnum {
             RATE =  1 ,
-            RESV =  2 , 
+            RESV =  2 ,
             BHP  =  4 ,
             THP  =  8 ,
             GRUP = 16 ,
@@ -92,8 +92,8 @@ namespace Opm {
           of which controls are present, i.e. the 2^n structure must
           be intact.
         */
-        
-        
+
+
 
         const std::string ControlMode2String( ControlModeEnum enumValue );
         ControlModeEnum ControlModeFromString( const std::string& stringValue );
@@ -107,15 +107,15 @@ namespace Opm {
 
         enum ControlModeEnum {
             ORAT =     1,
-            WRAT =     2, 
+            WRAT =     2,
             GRAT =     4,
             LRAT =     8,
             CRAT =    16,
             RESV =    32,
-            BHP  =    64, 
-            THP  =   128, 
-            GRUP =   256,  
-            CMODE_UNDEFINED = 1024   
+            BHP  =    64,
+            THP  =   128,
+            GRUP =   256,
+            CMODE_UNDEFINED = 1024
         };
 
         /*
@@ -134,9 +134,9 @@ namespace Opm {
         ControlModeEnum ControlModeFromString( const std::string& stringValue );
     }
 
-    
+
     namespace GroupInjection {
-        
+
           enum ControlEnum {
             NONE = 0,
             RATE = 1,
@@ -150,7 +150,7 @@ namespace Opm {
         ControlEnum ControlEnumFromString( const std::string& stringValue );
     }
 
-    
+
     namespace GroupProductionExceedLimit {
         enum ActionEnum {
             NONE = 0,
@@ -160,12 +160,12 @@ namespace Opm {
             PLUG = 4,
             RATE = 5
         };
-            
+
         const std::string ActionEnum2String( ActionEnum enumValue );
         ActionEnum ActionEnumFromString( const std::string& stringValue );
     }
-    
-    
+
+
 
     namespace GroupProduction {
 
@@ -179,9 +179,9 @@ namespace Opm {
             RESV = 6,
             PRBL = 7
         };
-        
+
         const std::string ControlEnum2String( GroupProduction::ControlEnum enumValue );
-        GroupProduction::ControlEnum ControlEnumFromString( const std::string& stringValue );    
+        GroupProduction::ControlEnum ControlEnumFromString( const std::string& stringValue );
     }
 
     namespace GuideRate {
@@ -204,7 +204,7 @@ namespace Opm {
     const std::string CompletionStateEnum2String( CompletionStateEnum enumValue );
     CompletionStateEnum CompletionStateEnumFromString( const std::string& stringValue );
 
-    
+
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -66,14 +66,14 @@ namespace Opm {
                 addFromDATESKeyword(keyword);
         }
     }
-    
-    size_t TimeMap::numTimesteps() const { 
-        return m_timeList.size() - 1; 
+
+    size_t TimeMap::numTimesteps() const {
+        return m_timeList.size() - 1;
     }
 
 
     boost::posix_time::ptime TimeMap::getStartTime(size_t tStepIdx) const {
-        return m_timeList[tStepIdx]; 
+        return m_timeList[tStepIdx];
     }
 
 
@@ -128,7 +128,7 @@ namespace Opm {
             monthNames.insert( std::make_pair( "DEC" , boost::gregorian::Dec ));
             monthNames.insert( std::make_pair( "DES" , boost::gregorian::Dec ));
         }
-        
+
         return monthNames;
     }
 
@@ -187,7 +187,7 @@ namespace Opm {
         {
             DeckRecordConstPtr record = TSTEPKeyword->getRecord( 0 );
             DeckItemConstPtr item = record->getItem( 0 );
-            
+
             for (size_t itemIndex = 0; itemIndex < item->size(); itemIndex++) {
                 double days = item->getRawDouble( itemIndex );
                 long int wholeSeconds = static_cast<long int>(days * 24*60*60);
@@ -198,7 +198,7 @@ namespace Opm {
                 addTStep( step );
             }
         }
-    } 
+    }
 
     double TimeMap::getTimeStepLength(size_t tStepIdx) const
     {

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -127,11 +127,11 @@ namespace Opm {
     WellCommon::StatusEnum Well::getStatus(size_t timeStep) const {
         return m_status->get( timeStep );
     }
-    
+
     void Well::setStatus(size_t timeStep, WellCommon::StatusEnum status) {
         m_status->add( timeStep , status );
     }
-    
+
     bool Well::isProducer(size_t timeStep) const {
         return m_isProducer->get(timeStep);
     }
@@ -139,7 +139,7 @@ namespace Opm {
     bool Well::isInjector(size_t timeStep) const {
         return !isProducer(timeStep);
     }
-    
+
     bool Well::isAvailableForGroupControl(size_t timeStep) const {
         return m_isAvailableForGroupControl->get(timeStep);
     }
@@ -175,7 +175,7 @@ namespace Opm {
     /*****************************************************************/
 
     // WELSPECS
-    
+
     int Well::getHeadI() const {
         return m_headI;
     }
@@ -199,7 +199,7 @@ namespace Opm {
     CompletionSetConstPtr Well::getCompletions(size_t timeStep) const {
         return m_completions->get( timeStep );
     }
-    
+
     void Well::addCompletions(size_t time_step , const std::vector<CompletionPtr>& newCompletions) {
         CompletionSetConstPtr currentCompletionSet = m_completions->get(time_step);
         CompletionSetPtr newCompletionSet = CompletionSetPtr( currentCompletionSet->shallowCopy() );
@@ -208,10 +208,10 @@ namespace Opm {
             newCompletions[ic]->fixDefaultIJ( m_headI , m_headJ );
             newCompletionSet->add( newCompletions[ic] );
         }
-        
+
         m_completions->add( time_step , newCompletionSet);
     }
-    
+
     const std::string Well::getGroupName(size_t time_step) const {
         return m_groupName->get(time_step);
     }

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -60,7 +60,7 @@ namespace Opm {
         bool   getRefDepthDefaulted() const;
         double getRefDepth() const;
         Phase::PhaseEnum getPreferredPhase() const;
-        
+
         bool isAvailableForGroupControl(size_t timeStep) const;
         void setAvailableForGroupControl(size_t timeStep, bool isAvailableForGroupControl);
         double getGuideRate(size_t timeStep) const;
@@ -75,11 +75,11 @@ namespace Opm {
         void addWELSPECS(DeckRecordConstPtr deckRecord);
         void addCompletions(size_t time_step , const std::vector<CompletionPtr>& newCompletions);
         CompletionSetConstPtr getCompletions(size_t timeStep) const;
-    
+
         void                            setProductionProperties(size_t timeStep , const WellProductionProperties properties);
         WellProductionProperties        getProductionPropertiesCopy(size_t timeStep) const;
         const WellProductionProperties& getProductionProperties(size_t timeStep)  const;
-        
+
         void                           setInjectionProperties(size_t timeStep , const WellInjectionProperties properties);
         WellInjectionProperties        getInjectionPropertiesCopy(size_t timeStep) const;
         const WellInjectionProperties& getInjectionProperties(size_t timeStep) const;
@@ -91,7 +91,7 @@ namespace Opm {
     private:
         size_t m_creationTimeStep;
         std::string m_name;
-        
+
         std::shared_ptr<DynamicState<WellCommon::StatusEnum> > m_status;
 
         std::shared_ptr<DynamicState<bool> > m_isAvailableForGroupControl;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
@@ -4,16 +4,16 @@
 #include <vector>
 
 namespace Opm {
-    
+
     WellInjectionProperties::WellInjectionProperties() {
-        surfaceInjectionRate=0.0; 
-        reservoirInjectionRate=0.0; 
-        BHPLimit=0.0; 
-        THPLimit=0.0; 
+        surfaceInjectionRate=0.0;
+        reservoirInjectionRate=0.0;
+        BHPLimit=0.0;
+        THPLimit=0.0;
         predictionMode=true;
         injectionControls=0;
         injectorType = WellInjector::WATER;
         controlMode = WellInjector::CMODE_UNDEFINED;
     }
-    
+
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -23,7 +23,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 
 namespace Opm {
-    
+
     struct WellInjectionProperties {
         double  surfaceInjectionRate;
         double  reservoirInjectionRate;
@@ -35,7 +35,7 @@ namespace Opm {
         WellInjector::ControlModeEnum controlMode;
 
         WellInjectionProperties();
-        
+
         bool hasInjectionControl(WellInjector::ControlModeEnum controlModeArg) const {
             if (injectionControls & controlModeArg)
                 return true;
@@ -54,7 +54,7 @@ namespace Opm {
                 injectionControls += controlModeArg;
             }
         }
-    }; 
+    };
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.cpp
@@ -4,7 +4,7 @@
 #include <vector>
 
 namespace Opm {
-    
+
     WellPolymerProperties::WellPolymerProperties() {
         m_polymerConcentration = 0.0;
         m_saltConcentration = 0.0;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.hpp
@@ -22,13 +22,13 @@
 
 
 namespace Opm {
-    
+
     struct WellPolymerProperties {
         double m_polymerConcentration;
         double m_saltConcentration;
 
         WellPolymerProperties();
-    }; 
+    };
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -53,19 +53,19 @@ namespace Opm {
         if (!record->getItem("BHP")->defaultApplied(0)) {
             p.addProductionControl(WellProducer::BHP);
         }
-        
+
         {
             const auto cmodeItem = record->getItem("CMODE");
             if (!cmodeItem->defaultApplied(0)) {
                 const WellProducer::ControlModeEnum cmode = WellProducer::ControlModeFromString( cmodeItem->getString(0) );
-                
+
                 if (p.hasProductionControl( cmode ))
                     p.controlMode = cmode;
-                else 
+                else
                     throw std::invalid_argument("Setting CMODE to unspecified control");
             }
         }
-        
+
         return p;
     }
 
@@ -102,10 +102,10 @@ namespace Opm {
             const auto cmodeItem = record->getItem("CMODE");
             if (!cmodeItem->defaultApplied(0)) {
                 const WellProducer::ControlModeEnum cmode = WellProducer::ControlModeFromString( cmodeItem->getString(0) );
-                
+
                 if (p.hasProductionControl( cmode ))
                     p.controlMode = cmode;
-                else 
+                else
                     throw std::invalid_argument("Setting CMODE to unspecified control");
             }
         }

--- a/opm/parser/eclipse/EclipseState/Schedule/WellSet.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellSet.cpp
@@ -19,8 +19,8 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp>
 namespace Opm {
-    
-        
+
+
     WellSet::WellSet() {
     }
 
@@ -41,10 +41,10 @@ namespace Opm {
             throw std::invalid_argument("Does not have this well?!\n");
     }
 
-    
+
     void WellSet::addWell(WellPtr well) {
         const std::string& wellName = well->name();
-        if (!hasWell(wellName)) 
+        if (!hasWell(wellName))
             m_wells[wellName] = well;
         else if (well != getWell(wellName))
             throw std::invalid_argument("Well has changed - internal fuckup");
@@ -61,10 +61,10 @@ namespace Opm {
 
     WellSet * WellSet::shallowCopy() const {
         WellSet * copy = new WellSet();
-        
-        for (std::map<std::string , WellPtr>::const_iterator iter=m_wells.begin(); iter != m_wells.end(); ++iter) 
+
+        for (std::map<std::string , WellPtr>::const_iterator iter=m_wells.begin(); iter != m_wells.end(); ++iter)
             copy->addWell( (*iter).second );
-        
+
         return copy;
     }
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp
@@ -29,7 +29,7 @@
 #include <map>
 
 namespace Opm {
-    
+
     class WellSet {
     public:
         WellSet();
@@ -42,7 +42,7 @@ namespace Opm {
     private:
         std::map<std::string , WellPtr> m_wells;
     };
-    
+
     typedef std::shared_ptr<WellSet> WellSetPtr;
     typedef std::shared_ptr<const WellSet> WellSetConstPtr;
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionSetTests.cpp
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(AddCompletionSameCellUpdates) {
     Opm::CompletionSet completionSet;
     Opm::CompletionConstPtr completion1(new Opm::Completion(10,10,10,Opm::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
     Opm::CompletionConstPtr completion2(new Opm::Completion(10,10,10,Opm::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
-    
+
 
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(AddCompletionShallowCopy) {
 
     Opm::CompletionSetConstPtr copy = Opm::CompletionSetConstPtr( completionSet.shallowCopy() );
     BOOST_CHECK_EQUAL( 3U , copy->size() );
-    
+
     BOOST_CHECK_EQUAL( completion1 , copy->get(0));
     BOOST_CHECK_EQUAL( completion2 , copy->get(1));
     BOOST_CHECK_EQUAL( completion3 , copy->get(2));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/DynamicStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/DynamicStateTests.cpp
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(DynamicStateSetOutOfRangeThrows) {
     Opm::DynamicState<int> state(timeMap , 137);
     for (size_t i = 0; i < 2; i++)
         timeMap->addTStep( boost::posix_time::hours( (i+1) * 24 ));
-    
+
     BOOST_CHECK_THROW( state.add(3 , 100) , std::range_error);
 }
 
@@ -73,7 +73,7 @@ BOOST_AUTO_TEST_CASE(DynamicStateSetOK) {
     Opm::DynamicState<int> state(timeMap , 137);
     for (size_t i = 0; i < 10; i++)
         timeMap->addTStep( boost::posix_time::hours( (i+1) * 24 ));
-    
+
     state.add(2 , 23 );
     BOOST_CHECK_EQUAL( 137 , state.get(0));
     BOOST_CHECK_EQUAL( 137 , state.get(1));
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(DynamicStateSetOK) {
     BOOST_CHECK_EQUAL( 137 , state.get(1));
     BOOST_CHECK_EQUAL( 17 , state.get(2));
     BOOST_CHECK_EQUAL( 17 , state.get(5));
-    
+
     state.add(6 , 60);
     BOOST_CHECK_EQUAL( 17 , state.get(2));
     BOOST_CHECK_EQUAL( 17 , state.get(5));
@@ -124,7 +124,7 @@ BOOST_AUTO_TEST_CASE(DynamicStateAddAt) {
         BOOST_CHECK( &v1 != &v2 );
     }
 }
-    
+
 
 BOOST_AUTO_TEST_CASE(DynamicStateCheckSize) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(GroupChangePhaseSameTimeThrows) {
 BOOST_AUTO_TEST_CASE(GroupMiscInjection) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
-    
+
     group.setSurfaceMaxRate( 3 , 100 );
     BOOST_CHECK_EQUAL( 100 , group.getSurfaceMaxRate( 5 ));
 
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE(GroupMiscInjection) {
 BOOST_AUTO_TEST_CASE(GroupDoesNotHaveWell) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(false , group.hasWell("NO", 2));
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     BOOST_CHECK_THROW(group.getWell("NO" , 2) , std::invalid_argument);
@@ -150,7 +150,7 @@ BOOST_AUTO_TEST_CASE(GroupAddWell) {
     Opm::Group group("G1" , timeMap , 0);
     Opm::WellPtr well1(new Opm::Well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap, 0));
     Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, Opm::Phase::OIL, timeMap, 0));
-    
+
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1 );
     BOOST_CHECK_EQUAL( 1U , group.numWells(3));
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
     BOOST_CHECK_EQUAL( 1U , group.numWells(5));
     BOOST_CHECK_EQUAL( 2U , group.numWells(6));
     BOOST_CHECK_EQUAL( 2U , group.numWells(8));
-    
+
     group.delWell( 7 , "WELL1");
     BOOST_CHECK_EQUAL(false , group.hasWell("WELL1" , 7));
     BOOST_CHECK_EQUAL(true , group.hasWell("WELL2" , 7));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTreeTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTreeTests.cpp
@@ -97,14 +97,14 @@ BOOST_AUTO_TEST_CASE(UpdateTree_ChildExists_ChildMoved) {
     BOOST_CHECK(oldParent->hasChildGroup("THECHILD"));
     GroupTreeNodePtr theChild = oldParent->getChildGroup("THECHILD");
     BOOST_CHECK(theChild->hasChildGroup("GRANDCHILD1"));
-    
+
     GroupTreeNodePtr newParent = tree.getNode("NEWPARENT");
     BOOST_CHECK(!newParent->hasChildGroup("THECHILD"));
 
     tree.updateTree("THECHILD", "NEWPARENT");
-    
+
     BOOST_CHECK(!oldParent->hasChildGroup("THECHILD"));
-    
+
     BOOST_CHECK(newParent->hasChildGroup("THECHILD"));
     theChild = newParent->getChildGroup("THECHILD");
     BOOST_CHECK(theChild->hasChildGroup("GRANDCHILD1"));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleEnumTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleEnumTests.cpp
@@ -189,7 +189,7 @@ BOOST_AUTO_TEST_CASE(TestGroupProductionExceedLimitControlEnum2String) {
 
 BOOST_AUTO_TEST_CASE(TestGroupProductionExceedLimitActionEnumFromString) {
     BOOST_CHECK_THROW( GroupProductionExceedLimit::ActionEnumFromString("XXX") , std::invalid_argument );
-    
+
     BOOST_CHECK_EQUAL(GroupProductionExceedLimit::NONE     , GroupProductionExceedLimit::ActionEnumFromString("NONE"));
     BOOST_CHECK_EQUAL(GroupProductionExceedLimit::CON      , GroupProductionExceedLimit::ActionEnumFromString("CON" ));
     BOOST_CHECK_EQUAL(GroupProductionExceedLimit::CON_PLUS , GroupProductionExceedLimit::ActionEnumFromString("+CON"));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     DeckPtr deck = createDeckWithWellsOrdered();
     Schedule schedule(deck);
     std::vector<WellConstPtr> wells = schedule.getWells();
-    
+
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
     BOOST_CHECK_EQUAL( "BW_2" , wells[1]->name());
     BOOST_CHECK_EQUAL( "AW_3" , wells[2]->name());
@@ -154,14 +154,14 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     DeckPtr deck(new Deck());
     DeckKeywordPtr keyword(new DeckKeyword("SCHEDULE"));
     deck->addKeyword( keyword );
-    
+
     BOOST_CHECK_NO_THROW(Schedule schedule(deck));
 }
 
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     DeckPtr deck = createDeck();
-    Schedule schedule(deck); 
+    Schedule schedule(deck);
     BOOST_CHECK_EQUAL( 0U , schedule.numWells() );
     BOOST_CHECK_EQUAL( false , schedule.hasWell("WELL1") );
     BOOST_CHECK_THROW( schedule.getWell("WELL2") , std::invalid_argument );
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
 
 BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForTimeStepZero) {
     DeckPtr deck = createDeck();
-    Schedule schedule(deck); 
+    Schedule schedule(deck);
     BOOST_CHECK_EQUAL("FIELD", schedule.getGroupTree(0)->getNode("FIELD")->name());
 }
 
@@ -178,18 +178,18 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForT
 BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTimeStepZero) {
     DeckPtr deck = createDeck();
     DeckKeywordPtr gruptreeKeyword(new DeckKeyword("GRUPTREE"));
-    
+
     DeckRecordPtr recordChildOfField(new DeckRecord());
     DeckStringItemPtr itemChild1(new DeckStringItem("CHILD_GROUP"));
     itemChild1->push_back("BARNET");
     DeckStringItemPtr itemParent1(new DeckStringItem("PARENT_GROUP"));
     itemParent1->push_back("FAREN");
-    
+
     recordChildOfField->addItem(itemChild1);
     recordChildOfField->addItem(itemParent1);
     gruptreeKeyword->addRecord(recordChildOfField);
     deck->addKeyword(gruptreeKeyword);
-    Schedule schedule(deck); 
+    Schedule schedule(deck);
     GroupTreeNodePtr fieldNode = schedule.getGroupTree(0)->getNode("FIELD");
     BOOST_CHECK_EQUAL("FIELD", fieldNode->name());
     GroupTreeNodePtr FAREN = fieldNode->getChildGroup("FAREN");
@@ -201,7 +201,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
     DeckPtr deck = createDeck();
-    Schedule schedule(deck); 
+    Schedule schedule(deck);
     BOOST_CHECK_EQUAL( 1U , schedule.numGroups() );
     BOOST_CHECK_EQUAL( true , schedule.hasGroup("FIELD") );
     BOOST_CHECK_EQUAL( false , schedule.hasGroup("GROUP") );

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellPropertiesTests.cpp
@@ -123,7 +123,7 @@ namespace {
         properties(const std::string& input)
         {
             Opm::Parser parser;
-            
+
             Opm::DeckPtr             deck   = parser.parseString(input);
             Opm::DeckKeywordConstPtr kwd    = deck->getKeyword("WCONHIST");
             Opm::DeckRecordConstPtr  record = kwd->getRecord(0);
@@ -148,7 +148,7 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
     BOOST_REQUIRE(p.hasProductionControl(Opm::WellProducer::RESV));
 
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::ORAT);
-    
+
     // BHP must be explicitly provided/specified
     BOOST_REQUIRE(! p.hasProductionControl(Opm::WellProducer::BHP));
 }
@@ -184,7 +184,7 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
     BOOST_REQUIRE(p.hasProductionControl(Opm::WellProducer::LRAT));
     BOOST_REQUIRE(p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::GRAT);
-    
+
     // BHP must be explicitly provided/specified
     BOOST_REQUIRE(! p.hasProductionControl(Opm::WellProducer::BHP));
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
@@ -56,18 +56,18 @@ BOOST_AUTO_TEST_CASE(AddAndDeleteWell) {
     Opm::WellPtr well(new Opm::Well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
     Opm::WellPtr well2(new Opm::Well("WELL2" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
 
-    wellSet.addWell( well ); 
+    wellSet.addWell( well );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL1"));
     BOOST_CHECK_EQUAL(1U , wellSet.size());
     BOOST_CHECK_EQUAL( well , wellSet.getWell("WELL1"));
 
 
-    wellSet.addWell( well2 ); 
+    wellSet.addWell( well2 );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL2"));
     BOOST_CHECK_EQUAL(2U , wellSet.size());
     BOOST_CHECK_EQUAL( well2 , wellSet.getWell("WELL2"));
 
-    wellSet.delWell("WELL1"); 
+    wellSet.delWell("WELL1");
     BOOST_CHECK_EQUAL(false , wellSet.hasWell("WELL1"));
     BOOST_CHECK_EQUAL(1U , wellSet.size());
     BOOST_CHECK_EQUAL( well2 , wellSet.getWell("WELL2"));
@@ -81,7 +81,7 @@ BOOST_AUTO_TEST_CASE(AddWellSameName) {
     Opm::WellPtr well1(new Opm::Well("WELL" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
     Opm::WellPtr well2(new Opm::Well("WELL" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0));
 
-    wellSet.addWell( well1 ); 
+    wellSet.addWell( well1 );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL"));
 
     BOOST_CHECK_NO_THROW( wellSet.addWell( well1 ));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -74,7 +74,7 @@ BOOST_AUTO_TEST_CASE(CreateWellCreateTimeStepOK) {
     BOOST_CHECK_EQUAL( false , well.hasBeenDefined(4) );
     BOOST_CHECK_EQUAL( true , well.hasBeenDefined(5) );
     BOOST_CHECK_EQUAL( true , well.hasBeenDefined(7) );
-    
+
 }
 
 
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE(setWellProductionProperties_PropertiesSetCorrect) {
 BOOST_AUTO_TEST_CASE(setOilRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).OilRate);
     Opm::WellProductionProperties props;
     props.OilRate = 99;
@@ -117,7 +117,7 @@ BOOST_AUTO_TEST_CASE(setOilRate_RateSetCorrect) {
 BOOST_AUTO_TEST_CASE(seLiquidRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).LiquidRate);
     Opm::WellProductionProperties props;
     props.LiquidRate = 99;
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(seLiquidRate_RateSetCorrect) {
 BOOST_AUTO_TEST_CASE(setPredictionModeProduction_ModeSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL( true, well.getProductionPropertiesCopy(5).predictionMode);
     Opm::WellProductionProperties props;
     props.predictionMode = false;
@@ -168,7 +168,7 @@ BOOST_AUTO_TEST_CASE(UpdateCompletions) {
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
     Opm::CompletionSetConstPtr completions = well.getCompletions( 0 );
     BOOST_CHECK_EQUAL( 0U , completions->size());
-    
+
     std::vector<Opm::CompletionPtr> newCompletions;
     std::vector<Opm::CompletionPtr> newCompletions2;
     Opm::CompletionPtr comp1(new Opm::Completion( 10 , 10 , 10 , Opm::AUTO , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22)));
@@ -197,14 +197,14 @@ BOOST_AUTO_TEST_CASE(UpdateCompletions) {
     completions = well.getCompletions( 6 );
     BOOST_CHECK_EQUAL( 4U , completions->size());
     BOOST_CHECK_EQUAL( comp4 , completions->get(2));
-    
+
 }
 
 
 BOOST_AUTO_TEST_CASE(setGasRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::GAS, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).GasRate);
     Opm::WellProductionProperties properties;
     properties.GasRate = 108;
@@ -218,7 +218,7 @@ BOOST_AUTO_TEST_CASE(setGasRate_RateSetCorrect) {
 BOOST_AUTO_TEST_CASE(setWaterRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).WaterRate);
     Opm::WellProductionProperties properties;
     properties.WaterRate = 108;
@@ -231,7 +231,7 @@ BOOST_AUTO_TEST_CASE(setWaterRate_RateSetCorrect) {
 BOOST_AUTO_TEST_CASE(setSurfaceInjectionRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(0.0 , well.getInjectionPropertiesCopy(5).surfaceInjectionRate);
     Opm::WellInjectionProperties props(well.getInjectionPropertiesCopy(5));
     props.surfaceInjectionRate = 108;
@@ -244,7 +244,7 @@ BOOST_AUTO_TEST_CASE(setSurfaceInjectionRate_RateSetCorrect) {
 BOOST_AUTO_TEST_CASE(setReservoirInjectionRate_RateSetCorrect) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1" , 0, 0, 0.0, Opm::Phase::WATER, timeMap , 0);
-    
+
     BOOST_CHECK_EQUAL(0.0 , well.getInjectionPropertiesCopy(5).reservoirInjectionRate);
     Opm::WellInjectionProperties properties(well.getInjectionPropertiesCopy(5));
     properties.reservoirInjectionRate = 108;
@@ -271,7 +271,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     BOOST_CHECK_EQUAL( true  , well.isInjector(3));
     BOOST_CHECK_EQUAL( false , well.isProducer(3));
     BOOST_CHECK_EQUAL( 100 , well.getInjectionPropertiesCopy(3).surfaceInjectionRate);
-    
+
     /* Set a reservoir injection rate => Well becomes an Injector */
     Opm::WellInjectionProperties injectionProps2(well.getInjectionPropertiesCopy(4));
     injectionProps2.reservoirInjectionRate = 200;
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     BOOST_CHECK_EQUAL( true  , well.isInjector(4));
     BOOST_CHECK_EQUAL( false , well.isProducer(4));
     BOOST_CHECK_EQUAL( 200 , well.getInjectionPropertiesCopy(4).reservoirInjectionRate);
-    
+
 
     /* Set rates => Well becomes a producer; injection rate should be set to 0. */
     Opm::WellInjectionProperties injectionProps3;
@@ -296,7 +296,7 @@ BOOST_AUTO_TEST_CASE(isProducerCorrectlySet) {
     BOOST_CHECK_EQUAL( 100 , well.getProductionPropertiesCopy(4).OilRate);
     BOOST_CHECK_EQUAL( 200 , well.getProductionPropertiesCopy(4).GasRate);
     BOOST_CHECK_EQUAL( 300 , well.getProductionPropertiesCopy(4).WaterRate);
-    
+
     /* Set injection rate => Well becomes injector - all produced rates -> 0 */
     Opm::WellProductionProperties prodProps2;
     well.setProductionProperties(6, prodProps2);
@@ -342,7 +342,7 @@ BOOST_AUTO_TEST_CASE(addWELSPECS_setData_dataSet) {
 BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
-    
+
 
     Opm::WellProductionProperties productionProps(well.getProductionPropertiesCopy(1));
     productionProps.BHPLimit = 100;
@@ -350,7 +350,7 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
     well.setProductionProperties(1, productionProps);
     BOOST_CHECK_EQUAL( 100 , well.getProductionPropertiesCopy(5).BHPLimit);
     BOOST_CHECK( well.getProductionPropertiesCopy(5).hasProductionControl( Opm::WellProducer::BHP ));
-    
+
     Opm::WellInjectionProperties injProps(well.getInjectionPropertiesCopy(1));
     injProps.THPLimit = 200;
     well.setInjectionProperties(1, injProps);
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(XHPLimitDefault) {
 BOOST_AUTO_TEST_CASE(InjectorType) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
-    
+
     Opm::WellInjectionProperties injectionProps(well.getInjectionPropertiesCopy(1));
     injectionProps.injectorType = Opm::WellInjector::WATER;
     well.setInjectionProperties(1, injectionProps);
@@ -378,7 +378,7 @@ BOOST_AUTO_TEST_CASE(InjectorType) {
 BOOST_AUTO_TEST_CASE(WellStatus) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
-    
+
     well.setStatus( 1 , Opm::WellCommon::OPEN );
     BOOST_CHECK_EQUAL( Opm::WellCommon::OPEN , well.getStatus( 5 ));
 }
@@ -393,10 +393,10 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
     Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::OIL, timeMap, 0);
 
-    
+
     BOOST_CHECK( !well.getProductionPropertiesCopy(1).hasProductionControl( Opm::WellProducer::ORAT ));
     BOOST_CHECK( !well.getProductionPropertiesCopy(1).hasProductionControl( Opm::WellProducer::RESV ));
-    
+
     Opm::WellProductionProperties properties(well.getProductionPropertiesCopy(1));
     properties.OilRate = 100;
     properties.addProductionControl(Opm::WellProducer::ORAT);
@@ -409,7 +409,7 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
     properties2.addProductionControl(Opm::WellProducer::RESV);
     well.setProductionProperties(2, properties2);
     BOOST_CHECK( well.getProductionPropertiesCopy(2).hasProductionControl( Opm::WellProducer::RESV ));
-    
+
     Opm::WellProductionProperties properties3(well.getProductionPropertiesCopy(2));
     properties3.OilRate = 100;
     properties3.WaterRate = 100;
@@ -426,7 +426,7 @@ BOOST_AUTO_TEST_CASE(WellHaveProductionControlLimit) {
     BOOST_CHECK( well.getProductionPropertiesCopy(10).hasProductionControl( Opm::WellProducer::ORAT ));
     BOOST_CHECK( well.getProductionPropertiesCopy(10).hasProductionControl( Opm::WellProducer::LRAT ));
     BOOST_CHECK( well.getProductionPropertiesCopy(10).hasProductionControl( Opm::WellProducer::BHP ));
-    
+
     Opm::WellProductionProperties properties4(well.getProductionPropertiesCopy(10));
     properties4.dropProductionControl( Opm::WellProducer::LRAT );
     well.setProductionProperties(10, properties4);
@@ -442,10 +442,10 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
 
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(20);
     Opm::Well well("WELL1", 1, 2, 2334.32, Opm::Phase::WATER, timeMap, 0);
-    
+
     BOOST_CHECK( !well.getInjectionPropertiesCopy(1).hasInjectionControl( Opm::WellInjector::RATE ));
     BOOST_CHECK( !well.getInjectionPropertiesCopy(1).hasInjectionControl( Opm::WellInjector::RESV ));
-    
+
     Opm::WellInjectionProperties injProps1(well.getInjectionPropertiesCopy(2));
     injProps1.surfaceInjectionRate = 100;
     injProps1.addInjectionControl(Opm::WellInjector::RATE);
@@ -458,7 +458,7 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
     injProps2.addInjectionControl(Opm::WellInjector::RESV);
     well.setInjectionProperties(2, injProps2);
     BOOST_CHECK( well.getInjectionPropertiesCopy(2).hasInjectionControl( Opm::WellInjector::RESV ));
-    
+
     Opm::WellInjectionProperties injProps3(well.getInjectionPropertiesCopy(10));
     injProps3.BHPLimit = 100;
     injProps3.addInjectionControl(Opm::WellInjector::BHP);
@@ -474,7 +474,7 @@ BOOST_AUTO_TEST_CASE(WellHaveInjectionControlLimit) {
     Opm::WellInjectionProperties injProps4(well.getInjectionPropertiesCopy(11));
     injProps4.dropInjectionControl( Opm::WellInjector::RESV );
     well.setInjectionProperties(11, injProps4);
-    
+
     BOOST_CHECK(  well.getInjectionPropertiesCopy(11).hasInjectionControl( Opm::WellInjector::RATE ));
     BOOST_CHECK( !well.getInjectionPropertiesCopy(11).hasInjectionControl( Opm::WellInjector::RESV ));
     BOOST_CHECK(  well.getInjectionPropertiesCopy(11).hasInjectionControl( Opm::WellInjector::THP ));

--- a/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -28,7 +28,7 @@
 
 namespace Opm {
 
-template <typename T> 
+template <typename T>
 class OrderedMap {
 private:
     std::unordered_map<std::string , size_t> m_map;
@@ -37,7 +37,7 @@ private:
 public:
     bool hasKey(const std::string& key) const {
         auto iter = m_map.find(key);
-        if (iter == m_map.end()) 
+        if (iter == m_map.end())
             return false;
         else
             return true;
@@ -55,7 +55,7 @@ public:
             m_map.insert( std::pair<std::string, size_t>(key , index));
         }
     }
-    
+
 
     T get(const std::string& key) const {
         auto iter = m_map.find( key );
@@ -91,4 +91,4 @@ public:
 };
 }
 
-#endif 
+#endif

--- a/opm/parser/eclipse/EclipseState/Util/Value.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/Value.hpp
@@ -35,43 +35,43 @@
 
 namespace Opm {
 
-template <typename T> 
+template <typename T>
 class Value {
 
 private:
     std::string m_name;
     bool m_initialized;
     T m_value;
-    
-    
+
+
 public:
 
-    Value(const std::string& name) : 
+    Value(const std::string& name) :
         m_name( name ),
         m_initialized( false )
     { }
 
 
-    Value(const std::string& name ,T value) : 
+    Value(const std::string& name ,T value) :
         m_name( name )
-    { 
+    {
         setValue( value );
     }
-    
-    
+
+
     bool hasValue() const {
         return m_initialized;
     }
-    
+
 
     T getValue() const {
         if (m_initialized)
             return m_value;
         else
-            throw std::logic_error("The value has: " + m_name + " has not been initialized"); 
+            throw std::logic_error("The value has: " + m_name + " has not been initialized");
     }
 
-    
+
     void setValue( T value ) {
         m_initialized = true;
         m_value = value;
@@ -94,8 +94,8 @@ public:
         } else
             return false;
     }
-    
-    
+
+
 };
 }
 

--- a/opm/parser/eclipse/EclipseState/Util/tests/OrderedMapTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Util/tests/OrderedMapTests.cpp
@@ -47,7 +47,7 @@ BOOST_AUTO_TEST_CASE( check_order ) {
     BOOST_CHECK( map.hasKey("CKEY1"));
     BOOST_CHECK( map.hasKey("BKEY2"));
     BOOST_CHECK( map.hasKey("AKEY3"));
-    
+
     BOOST_CHECK_EQUAL( "Value1" , map.get("CKEY1"));
     BOOST_CHECK_EQUAL( "Value1" , map.get( 0 ));
 
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE( check_order ) {
 
     {
         std::vector<std::string> values;
-        for (auto iter = map.begin(); iter != map.end(); ++iter) 
+        for (auto iter = map.begin(); iter != map.end(); ++iter)
             values.push_back( *iter );
 
         BOOST_CHECK_EQUAL( values[0] , "NewValue1");

--- a/opm/parser/eclipse/EclipseState/Util/tests/ValueTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Util/tests/ValueTests.cpp
@@ -30,7 +30,7 @@
 
 BOOST_AUTO_TEST_CASE( check_default_constructor ) {
     Opm::Value<int> v("Value");
-    
+
     BOOST_CHECK_EQUAL( false , v.hasValue() );
     BOOST_CHECK_THROW( v.getValue() , std::logic_error );
 
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE( check_default_constructor ) {
 
 BOOST_AUTO_TEST_CASE( check_value_constructor ) {
     Opm::Value<int> v("Value" , 100);
-    
+
     BOOST_CHECK_EQUAL( true , v.hasValue() );
     BOOST_CHECK_EQUAL( 100 , v.getValue());
 }

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -47,7 +47,7 @@ using namespace Opm;
 
   An issue has been posted on Stackoverflow: questions/26275555
 
-*/ 
+*/
 
 static DeckPtr createDeckTOP() {
     const char *deckData =
@@ -109,7 +109,7 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
         BOOST_CHECK_EQUAL( 0.10 , poro->iget(i) );
         BOOST_CHECK_EQUAL( 0.25 * Metric::Permeability , permx->iget(i) );
     }
-    
+
 }
 
 
@@ -240,9 +240,9 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
     std::shared_ptr<GridProperty<int> > satNUM = state.getIntGridProperty( "SATNUM" );
 
     BOOST_CHECK_EQUAL(1000U , satNUM->getCartesianSize() );
-    for (size_t i=0; i < satNUM->getCartesianSize(); i++) 
+    for (size_t i=0; i < satNUM->getCartesianSize(); i++)
         BOOST_CHECK_EQUAL( 2 , satNUM->iget(i) );
-    
+
     BOOST_CHECK_THROW( satNUM->iget(100000) , std::invalid_argument);
 }
 
@@ -251,8 +251,8 @@ BOOST_AUTO_TEST_CASE(GetTransMult) {
     DeckPtr deck = createDeck();
     EclipseState state(deck);
     std::shared_ptr<const TransMult> transMult = state.getTransMult();
-    
-    
+
+
     BOOST_CHECK_EQUAL( 1.0 , transMult->getMultiplier(1,0,0,FaceDir::XPlus));
     BOOST_CHECK_THROW(transMult->getMultiplier(1000 , FaceDir::XPlus) , std::invalid_argument);
 }

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -49,7 +49,7 @@ EclipseState makeState(const std::string& fileName, ParserLogPtr parserLog) {
 
   An issue has been posted on Stackoverflow: questions/26275555
 
-*/ 
+*/
 
 BOOST_AUTO_TEST_CASE( PERMX ) {
     ParserLogPtr parserLog(new ParserLog());
@@ -59,14 +59,14 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
     std::shared_ptr<GridProperty<double> > permz = state.getDoubleGridProperty("PERMZ");
     size_t i,j,k;
     std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
-    
+
     for (k = 0; k < grid->getNZ(); k++) {
         for (j = 0; j < grid->getNY(); j++) {
             for (i = 0; i < grid->getNX(); i++) {
-                
+
                 BOOST_CHECK_CLOSE( permx->iget(i,j,k) * 0.25 , permz->iget(i,j,k) , 0.001);
                 BOOST_CHECK_EQUAL( permx->iget(i,j,k) * 2 , permy->iget(i,j,k));
-                    
+
             }
         }
     }
@@ -90,7 +90,7 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
                         BOOST_CHECK_EQUAL(satnum->iget(g) , 10);
                     else
                         BOOST_CHECK_EQUAL(satnum->iget(g) , 2);
-                    
+
                 }
             }
         }
@@ -106,11 +106,11 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     std::shared_ptr<GridProperty<int> > fipnum = state.getIntGridProperty("FIPNUM");
     size_t i,j,k;
     std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
-    
+
     for (k = 0; k < grid->getNZ(); k++) {
         for (j = 0; j < grid->getNY(); j++) {
             for (i = 0; i < grid->getNX(); i++) {
-                
+
                 size_t g = i + j*grid->getNX() + k * grid->getNX() * grid->getNY();
                 if (i <= 1 && j <= 1 && k <= 1)
                     BOOST_CHECK_EQUAL(4*satnum->iget(g) , fipnum->iget(g));
@@ -145,15 +145,15 @@ BOOST_AUTO_TEST_CASE( EQUAL ) {
     std::shared_ptr<GridProperty<double> > poro = state.getDoubleGridProperty("PORO");
     size_t i,j,k;
     std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
-    
+
     for (k = 0; k < grid->getNZ(); k++) {
         for (j = 0; j < grid->getNY(); j++) {
             for (i = 0; i < grid->getNX(); i++) {
-                
+
                 BOOST_CHECK_EQUAL( pvtnum->iget(i,j,k) , k );
                 BOOST_CHECK_EQUAL( eqlnum->iget(i,j,k) , 77 + 2 * k );
                 BOOST_CHECK_EQUAL( poro->iget(i,j,k) , 0.25 );
-                
+
             }
         }
     }

--- a/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromRecord ) {
     DeckKeywordConstPtr COMPDAT1 = deck->getKeyword("COMPDAT" , 0);
     DeckRecordConstPtr line0 = COMPDAT1->getRecord(0);
     DeckRecordConstPtr line1 = COMPDAT1->getRecord(1);
-    
+
     std::pair< std::string , std::vector<CompletionPtr> > completionsList = Completion::completionsFromCOMPDATRecord( line0 );
     BOOST_CHECK_EQUAL( "W_1" , completionsList.first );
     BOOST_CHECK_EQUAL( 3U , completionsList.second.size() );
@@ -89,21 +89,21 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromKeyword ) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMPDAT1");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     DeckKeywordConstPtr COMPDAT1 = deck->getKeyword("COMPDAT" , 1);
-    
+
     std::map< std::string , std::vector<CompletionPtr> > completions = Completion::completionsFromCOMPDATKeyword( COMPDAT1 );
     BOOST_CHECK_EQUAL( 3U , completions.size() );
-    
-    
+
+
     BOOST_CHECK( completions.find("W_1") != completions.end() );
     BOOST_CHECK( completions.find("W_2") != completions.end() );
     BOOST_CHECK( completions.find("W_3") != completions.end() );
-    
+
     BOOST_CHECK_EQUAL( 17U , completions.find("W_1")->second.size() );
     BOOST_CHECK_EQUAL(  5U , completions.find("W_2")->second.size() );
     BOOST_CHECK_EQUAL(  5U , completions.find("W_3")->second.size() );
 
     std::vector<CompletionPtr> W_3Completions = completions.find("W_3")->second;
-    
+
     CompletionConstPtr completion0 = W_3Completions[0];
     CompletionConstPtr completion4 = W_3Completions[4];
 

--- a/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     {
         const std::vector<int>& deckActnum = deck->getKeyword("ACTNUM")->getIntData();
         const std::vector<double>& deckZCORN = deck->getKeyword("ZCORN")->getSIDoubleData();
-        
+
         for (size_t i = 0; i < volume; i++) {
             BOOST_CHECK_EQUAL( deckActnum[i] , actnum[i]);
             for (size_t j=0; j < 8; j++)

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -236,22 +236,22 @@ BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {
     BOOST_CHECK_NO_THROW(radfin4_2_nodata->getRecord(0)->getItem(0)->getString(0));
     BOOST_CHECK( radfin4_2_nodata->getRecord(0)->getItem(0)->defaultApplied(0));
 
-    
+
     // Specified in datafile
     BOOST_CHECK_EQUAL(213, radfin4_0_full->getRecord(0)->getItem(1)->getInt(0));
     BOOST_CHECK_EQUAL(213, radfin4_1_partial->getRecord(0)->getItem(1)->getInt(0));
     // Default int
     BOOST_CHECK_NO_THROW( radfin4_2_nodata->getRecord(0)->getItem(1)->getInt(0));
     BOOST_CHECK( radfin4_2_nodata->getRecord(0)->getItem(1)->defaultApplied(0));
-    
-    
+
+
     ParserKeywordConstPtr parserKeyword = parser->getParserKeywordFromDeckName("RADFIN4");
     ParserRecordConstPtr parserRecord = parserKeyword->getRecord();
     ParserItemConstPtr nwmaxItem = parserRecord->get("NWMAX");
     ParserIntItemConstPtr intItem = std::static_pointer_cast<const ParserIntItem>(nwmaxItem);
-    
+
     BOOST_CHECK_EQUAL(18, radfin4_0_full->getRecord(0)->getItem(10)->getInt(0));
     BOOST_CHECK_EQUAL(intItem->getDefault(), radfin4_1_partial->getRecord(0)->getItem(10)->getInt(0));
     BOOST_CHECK_EQUAL(intItem->getDefault(), radfin4_2_nodata->getRecord(0)->getItem(10)->getInt(0));
-    
+
 }

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTestsInternalData.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTestsInternalData.cpp
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE(ParseFileWithManyKeywords) {
     ParserPtr parser(new Parser());
     DeckPtr deck =  parser->parseFile(multipleKeywordFile.string() , false);
     SchedulePtr schedule(new Schedule(deck));
-    
+
     GroupTreePtr treeAtStart = schedule->getGroupTree(0);
     GroupTreeNodePtr fieldNode = treeAtStart->getNode("FIELD");
     BOOST_CHECK(fieldNode);

--- a/opm/parser/eclipse/IntegrationTests/ParseACTION.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseACTION.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
     boost::filesystem::path actionFile2("testdata/integration_tests/ACTION/ACTION_EXCEPTION.txt");
     ParserKeywordConstPtr DIMENS = ParserKeyword::createFixedSized("DIMENS" , (size_t) 1 , IGNORE_WARNING );
     ParserKeywordConstPtr THROW = ParserKeyword::createFixedSized("THROW" , UNKNOWN , THROW_EXCEPTION );
-    
+
     BOOST_REQUIRE( parser->loadKeywordFromFile( boost::filesystem::path( std::string(KEYWORD_DIRECTORY) + std::string("/W/WCONHIST") )) );
     parser->addParserKeyword( DIMENS );
     parser->addParserKeyword( THROW );
@@ -49,9 +49,9 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
     BOOST_REQUIRE( parser->isRecognizedKeyword( "DIMENS" ));
     BOOST_REQUIRE( parser->isRecognizedKeyword( "WCONHIST" ));
     BOOST_REQUIRE( parser->isRecognizedKeyword( "THROW" ));
-    
+
     BOOST_REQUIRE_THROW(  parser->parseFile( actionFile2.string() , false) , std::invalid_argument );
-    
+
     ParserLogPtr parserLog(new ParserLog);
     DeckPtr deck =  parser->parseFile(actionFile.string() , false, parserLog);
     DeckKeywordConstPtr kw1 = deck->getKeyword("WCONHIST" , 0);
@@ -66,15 +66,15 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
 
     DeckItemConstPtr item1       = rec1->getItem("WELL");
     DeckItemConstPtr item1_index = rec1->getItem(0);
-    
+
     BOOST_CHECK_EQUAL( item1  , item1_index );
     BOOST_CHECK_EQUAL( "OP_1" , item1->getString(0));
 
 
     item1 = rec3->getItem("WELL");
     BOOST_CHECK_EQUAL( "OP_3" , item1->getString(0));
-    
-    
+
+
     BOOST_CHECK_EQUAL( false , deck->hasKeyword( "DIMENS" ));
     BOOST_CHECK_EQUAL( 2U , parserLog->size() );
     {
@@ -85,5 +85,5 @@ BOOST_AUTO_TEST_CASE( parse_ACTION_OK ) {
         BOOST_CHECK_EQUAL( actionFile.string() ,  parserLog->getFileName(1));
         BOOST_CHECK_EQUAL( 6U , parserLog->getLineNumber(1));
     }
-    
+
 }

--- a/opm/parser/eclipse/IntegrationTests/ParseDATAWithDefault.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseDATAWithDefault.cpp
@@ -77,11 +77,11 @@ BOOST_AUTO_TEST_CASE( parse_DATAWithDefult_OK ) {
     DeckRecordConstPtr rec0 = keyword->getRecord(0);
     DeckRecordConstPtr rec1 = keyword->getRecord(1);
     DeckRecordConstPtr rec2 = keyword->getRecord(2);
-    
+
     DeckItemConstPtr item0 = rec0->getItem(0);
     DeckItemConstPtr item1 = rec1->getItem(0);
     DeckItemConstPtr item2 = rec2->getItem(0);
-    
+
     BOOST_CHECK_EQUAL( 3U , keyword->size());
     BOOST_CHECK( !item0->defaultApplied(0) );
     BOOST_CHECK( item0->defaultApplied(1) );
@@ -97,7 +97,7 @@ BOOST_AUTO_TEST_CASE( parse_DATAWithDefult_OK ) {
     BOOST_CHECK_EQUAL( 55 , item0->getRawDouble(13));
     BOOST_CHECK_EQUAL( 55 , item0->getRawDouble(14));
     BOOST_CHECK_EQUAL( 10 , item0->getRawDouble(15));
-    
+
     BOOST_CHECK_EQUAL( 100 , item1->getRawDouble(0));
     BOOST_CHECK_EQUAL(  -1  , item1->getRawDouble(1));
 

--- a/opm/parser/eclipse/IntegrationTests/ParseDENSITY.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseDENSITY.cpp
@@ -43,19 +43,19 @@ BOOST_AUTO_TEST_CASE(ParseDENSITY) {
     DeckPtr deck =  parser->parseFile(file.string());
     DeckKeywordPtr densityKw = deck->getKeyword("DENSITY" , 0);
 
-    
+
     BOOST_CHECK_EQUAL( 2U , densityKw->size());
     DeckRecordConstPtr rec1 = densityKw->getRecord(0);
     DeckRecordConstPtr rec2 = densityKw->getRecord(1);
-    
+
     {
         DeckItemPtr oilDensity = rec1->getItem("OIL");
         DeckItemPtr waterDensity = rec1->getItem("WATER");
         DeckItemPtr gasDensity = rec1->getItem("GAS");
-        
+
         BOOST_CHECK_CLOSE(  500 * Field::Density , oilDensity->getSIDouble(0) , 0.001);
         BOOST_CHECK_CLOSE( 1000 * Field::Density , waterDensity->getSIDouble(0) , 0.001);
         BOOST_CHECK_CLOSE(    1 * Field::Density , gasDensity->getSIDouble(0) , 0.001);
     }
-    
+
 }

--- a/opm/parser/eclipse/IntegrationTests/ParseEND.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEND.cpp
@@ -38,7 +38,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_END_OK ) {
     ParserPtr parser(new Parser());
     boost::filesystem::path fileWithTitleKeyword("testdata/integration_tests/END/END1.txt");
-    
+
     DeckPtr deck = parser->parseFile (fileWithTitleKeyword.string(), true);
 
     BOOST_CHECK_EQUAL(size_t(1), deck->size());

--- a/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
@@ -58,14 +58,14 @@ BOOST_AUTO_TEST_CASE( parse_EQUIL_OK ) {
 
     DeckItemPtr item1       = rec1->getItem("OWC");
     DeckItemPtr item1_index = rec1->getItem(2);
-    
+
     BOOST_CHECK_EQUAL( item1  , item1_index );
     BOOST_CHECK( fabs(item1->getSIDouble(0) - 1705) < 0.001);
 
     DeckItemPtr item3       = rec3->getItem("OWC");
     DeckItemPtr item3_index = rec3->getItem(2);
-    
+
     BOOST_CHECK_EQUAL( item3  , item3_index );
     BOOST_CHECK( fabs(item3->getSIDouble(0) - 3000) < 0.001);
-    
+
 }

--- a/opm/parser/eclipse/IntegrationTests/ParsePLYADS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePLYADS.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE( PARSE_PLYADS_OK) {
     ParserPtr parser(new Parser());
     boost::filesystem::path deckFile("testdata/integration_tests/POLYMER/plyads.data");
     DeckPtr deck =  parser->parseFile(deckFile.string());
-    DeckKeywordConstPtr kw = deck->getKeyword("PLYADS");    
+    DeckKeywordConstPtr kw = deck->getKeyword("PLYADS");
     DeckRecordConstPtr rec = kw->getRecord(0);
     DeckItemPtr item = rec->getItem(0);
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePLYVISC.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePLYVISC.cpp
@@ -35,7 +35,7 @@ BOOST_AUTO_TEST_CASE( PARSE_PLYVISC_OK) {
     ParserPtr parser(new Parser());
     boost::filesystem::path deckFile("testdata/integration_tests/POLYMER/plyvisc.data");
     DeckPtr deck =  parser->parseFile(deckFile.string());
-    DeckKeywordConstPtr kw = deck->getKeyword("PLYVISC");    
+    DeckKeywordConstPtr kw = deck->getKeyword("PLYVISC");
     DeckRecordConstPtr rec = kw->getRecord(0);
     DeckItemPtr item = rec->getItem(0);
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePORO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePORO.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(ParsePOROandPERMX) {
 
     BOOST_CHECK_THROW( kw1->getIntData() , std::logic_error );
     BOOST_CHECK_THROW( kw1->getStringData() , std::logic_error );
-    
+
     {
         const std::vector<double>& poro = kw1->getRawDoubleData();
         BOOST_CHECK_EQUAL( 440U , poro.size() );

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
@@ -110,11 +110,11 @@ static void check_parser(ParserPtr parser) {
     BOOST_CHECK_EQUAL(9U , item4_1->size());
     BOOST_CHECK_EQUAL(2U , record4->size());
 
-    
+
     {
         Opm::PvtgTable pvtgTable;
         pvtgTable.initFORUNITTESTONLY(kw1, 0);
-        
+
         const auto &outerTable = *pvtgTable.getOuterTable();
         const auto &innerTable0 = *pvtgTable.getInnerTable(0);
 
@@ -122,7 +122,7 @@ static void check_parser(ParserPtr parser) {
         BOOST_CHECK_EQUAL(4U, outerTable.numColumns());
         BOOST_CHECK_EQUAL(3U, innerTable0.numRows());
         BOOST_CHECK_EQUAL(3U, innerTable0.numColumns());
-        
+
         BOOST_CHECK_EQUAL(20.0e5, outerTable.getPressureColumn()[0]);
         BOOST_CHECK_EQUAL(0.00002448, outerTable.getOilSolubilityColumn()[0]);
         BOOST_CHECK_EQUAL(outerTable.getOilSolubilityColumn()[0], innerTable0.getOilSolubilityColumn()[0]);

--- a/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
@@ -41,19 +41,19 @@ BOOST_AUTO_TEST_CASE( PARSE_TOPS_OK) {
     BOOST_CHECK_EQUAL( grid->getNX() , 9 );
     BOOST_CHECK_EQUAL( grid->getNY() , 9 );
     BOOST_CHECK_EQUAL( grid->getNZ() , 2 );
-    
+
     for (size_t g=0; g < 9*9*2; g++)
         BOOST_CHECK_CLOSE( grid->getCellVolume( g ) , 400*300*10 , 0.1);
-    
+
     for (size_t k=0; k < grid->getNZ(); k++) {
         for (size_t j=0; j < grid->getNY(); j++) {
             for (size_t i=0; i < grid->getNX(); i++) {
-                
+
                 auto pos = grid->getCellCenter( i,j,k );
                 BOOST_CHECK_CLOSE( std::get<0>(pos) , i*400 + 200 , 0.10 );
                 BOOST_CHECK_CLOSE( std::get<1>(pos) , j*300 + 150 , 0.10 );
                 BOOST_CHECK_CLOSE( std::get<2>(pos) , k*10  + 5 + 2202 , 0.10 );
-                
+
             }
         }
     }

--- a/opm/parser/eclipse/IntegrationTests/ParseWCONHIST.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWCONHIST.cpp
@@ -51,7 +51,7 @@ BOOST_AUTO_TEST_CASE( parse_WCHONHIST_OK ) {
 
     DeckItemConstPtr item1       = rec1->getItem("WELL");
     DeckItemConstPtr item1_index = rec1->getItem(0);
-    
+
     BOOST_CHECK_EQUAL( item1  , item1_index );
     BOOST_CHECK_EQUAL( "OP_1" , item1->getString(0));
 
@@ -59,9 +59,9 @@ BOOST_AUTO_TEST_CASE( parse_WCHONHIST_OK ) {
     item1 = rec3->getItem("WELL");
     BOOST_CHECK_EQUAL( "OP_3" , item1->getString(0));
 
-    
+
     /*****************************************************************/
-    
+
     BOOST_CHECK_EQUAL( 2U , deck->numKeywords("WCONHIST"));
     kw1 = deck->getKeyword("WCONHIST" , 1 );
     rec3 = kw1->getRecord(2);

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(WCONPROD_Missing_DATA) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_CMODE_MISSING_DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
-    
+
     BOOST_CHECK_THROW( new Schedule(deck) , std::invalid_argument );
 }
 
@@ -114,7 +114,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
         BOOST_CHECK_EQUAL( WellCommon::AUTO , well3->getStatus(3));
         BOOST_CHECK_EQUAL( 0 , well3->getProductionPropertiesCopy(2).LiquidRate);
-        
+
         {
             const WellProductionProperties& prop7 = well3->getProductionProperties(7);
             BOOST_CHECK_CLOSE( 999/Metric::Time , prop7.LiquidRate , 0.001);
@@ -154,10 +154,10 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
         BOOST_CHECK(!well1->getProductionPropertiesCopy(8).predictionMode);
         BOOST_CHECK_CLOSE(13000/Metric::Time , well1->getProductionPropertiesCopy(8).OilRate , 0.001);
-        
+
         BOOST_CHECK_CLOSE(123.00 * Metric::Pressure , well1->getInjectionPropertiesCopy(10).BHPLimit, 0.001);
         BOOST_CHECK_CLOSE(678.00 * Metric::Pressure , well1->getInjectionPropertiesCopy(10).THPLimit, 0.001);
-        
+
         {
             const WellInjectionProperties& prop11 = well1->getInjectionProperties(11);
             BOOST_CHECK_CLOSE(5000/Metric::Time , prop11.surfaceInjectionRate, 0.001);
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
             BOOST_CHECK( !prop9.hasInjectionControl(WellInjector::BHP));
         }
 
-        
+
         BOOST_CHECK_EQUAL( WellCommon::SHUT , well1->getStatus( 12 ));
         BOOST_CHECK(  well1->getInjectionPropertiesCopy(12).hasInjectionControl(WellInjector::RATE ));
         BOOST_CHECK( !well1->getInjectionPropertiesCopy(12).hasInjectionControl(WellInjector::RESV));
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GRUPTREE");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr schedule(new Schedule(deck));
-    
+
     BOOST_CHECK( schedule->hasGroup( "FIELD" ));
     BOOST_CHECK( schedule->hasGroup( "PROD" ));
     BOOST_CHECK( schedule->hasGroup( "INJE" ));
@@ -276,9 +276,9 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_iter_function) 
 
     int iter_counted = 0;
 
-    for (auto iter=root->begin(); iter != root->end(); ++iter) 
+    for (auto iter=root->begin(); iter != root->end(); ++iter)
         iter_counted++;
-    
+
     BOOST_CHECK_EQUAL(2, iter_counted);
     // Time 1, a new group added in tree
     iter_counted = 0;
@@ -319,7 +319,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     BOOST_CHECK_EQUAL("GROUP_ODD", GROUP_ODD1->name());
 
     // - from GRUPTREE
-    
+
     BOOST_CHECK(GROUP_BJARNE1->hasChildGroup("GROUP_BIRGER"));
     GroupTreeNodePtr GROUP_BIRGER = GROUP_BJARNE1->getChildGroup("GROUP_BIRGER");
     BOOST_CHECK_EQUAL("GROUP_BIRGER", GROUP_BIRGER->name());
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     BOOST_CHECK(root1->hasChildGroup("GROUP_NEW"));
     GroupTreeNodePtr GROUP_NEW = root1->getChildGroup("GROUP_NEW");
     BOOST_CHECK_EQUAL("GROUP_NEW", GROUP_NEW->name());
-    
+
     BOOST_CHECK(GROUP_NEW->hasChildGroup("GROUP_NILS"));
     GroupTreeNodePtr GROUP_NILS = GROUP_NEW->getChildGroup("GROUP_NILS");
     BOOST_CHECK_EQUAL("GROUP_NILS", GROUP_NILS->name());
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     GroupTreeNodePtr GROUP_NEW0 = root0->getChildGroup("GROUP_NEW");
     BOOST_CHECK_EQUAL("GROUP_NEW", GROUP_NEW0->name());
 
-    
+
     BOOST_CHECK(GROUP_BJARNE0->hasChildGroup("GROUP_BIRGER"));
     GroupTreeNodePtr GROUP_BIRGER0 = GROUP_BJARNE0->getChildGroup("GROUP_BIRGER");
     BOOST_CHECK_EQUAL("GROUP_BIRGER", GROUP_BIRGER0->name());
@@ -359,7 +359,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     BOOST_CHECK(GROUP_NEW0->hasChildGroup("GROUP_NILS"));
     GroupTreeNodePtr GROUP_NILS0 = GROUP_NEW0->getChildGroup("GROUP_NILS");
     BOOST_CHECK_EQUAL("GROUP_NILS", GROUP_NILS0->name());
-    
+
     // SÅ den nye strukturen med et barneflytt
 }
 
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GROUPS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched( new Schedule(deck));
-    
+
     BOOST_CHECK_EQUAL( 3U , sched->numGroups() );
     BOOST_CHECK( sched->hasGroup( "INJ" ));
     BOOST_CHECK( sched->hasGroup( "OP" ));
@@ -394,14 +394,14 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
         BOOST_CHECK_CLOSE( 20/Metric::Time , group->getReservoirMaxRate( 3 ) , 0.001);
         BOOST_CHECK_EQUAL( 0.75 , group->getTargetReinjectFraction( 3 ));
         BOOST_CHECK_EQUAL( 0.95 , group->getTargetVoidReplacementFraction( 3 ));
-    
+
         BOOST_CHECK_EQUAL( Phase::OIL , group->getInjectionPhase( 6 ));
         BOOST_CHECK_EQUAL( GroupInjection::RATE , group->getInjectionControlMode( 6 ));
         BOOST_CHECK_CLOSE( 1000/Metric::Time , group->getSurfaceMaxRate( 6 ) , 0.0001);
 
         BOOST_CHECK(group->isInjectionGroup(3));
     }
-    
+
     {
         GroupPtr group = sched->getGroup("OP");
         BOOST_CHECK_EQUAL( GroupProduction::ORAT , group->getProductionControlMode(3));
@@ -424,7 +424,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
 
     GroupPtr group1 = sched->getGroup("GROUP1");
     GroupPtr group2 = sched->getGroup("GROUP2");
-    
+
     BOOST_CHECK( group1->hasBeenDefined(0) );
     BOOST_CHECK_EQUAL(false , group2->hasBeenDefined(0));
     BOOST_CHECK( group2->hasBeenDefined(1));
@@ -433,7 +433,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     BOOST_CHECK_EQUAL( true , group1->hasWell("W_2" , 0));
     BOOST_CHECK_EQUAL( false, group2->hasWell("W_1" , 0));
     BOOST_CHECK_EQUAL( false, group2->hasWell("W_2" , 0));
-    
+
 
 
     BOOST_CHECK_EQUAL( true  , group1->hasWell("W_1" , 1));
@@ -577,7 +577,7 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_SHUT_WELL");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     ScheduleConstPtr sched(new Schedule(deck));
-    
+
     WellConstPtr well1 = sched->getWell("W1");
     WellConstPtr well2 = sched->getWell("W2");
     WellConstPtr well3 = sched->getWell("W3");
@@ -586,7 +586,7 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::OPEN , well2->getStatus(1));
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::OPEN , well3->getStatus(1));
 
-    
+
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::SHUT , well1->getStatus(2));
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::SHUT , well2->getStatus(2));
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::SHUT , well3->getStatus(2));
@@ -601,7 +601,7 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
     BOOST_CHECK_EQUAL(4U, sched->numWells());
     BOOST_CHECK(sched->hasWell("INJE01"));
     BOOST_CHECK(sched->hasWell("PROD01"));
-    
+
     WellConstPtr well1 = sched->getWell("INJE01");
     BOOST_CHECK( well1->isInjector(0));
     {

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -304,7 +304,7 @@ namespace Opm {
                                 DeckKeywordPtr deckKeyword = parserKeyword->parse(parserState->rawKeyword);
                                 deckKeyword->setParserKeyword(parserKeyword);
                                 parserState->deck->addKeyword(deckKeyword);
-                            } else if (action == IGNORE_WARNING) 
+                            } else if (action == IGNORE_WARNING)
                                 parserState->parserLog.addWarning(parserState->dataFile.string(),
                                                                   parserState->rawKeyword->getLineNR(),
                                                                   "The keyword " + parserState->rawKeyword->getKeywordName() + " is ignored - this might potentially affect the results");
@@ -347,10 +347,10 @@ namespace Opm {
         if (isRecognizedKeyword(keywordString)) {
             ParserKeywordConstPtr parserKeyword = getParserKeywordFromDeckName( keywordString );
             ParserKeywordActionEnum action = parserKeyword->getAction();
-            
+
             if (action == THROW_EXCEPTION)
                 throw std::invalid_argument("Parsing terminated by fatal keyword: " + keywordString);
-            
+
             if (parserKeyword->getSizeType() == SLASH_TERMINATED || parserKeyword->getSizeType() == UNKNOWN) {
                 Raw::KeywordSizeEnum rawSizeType;
                 if (parserKeyword->getSizeType() == SLASH_TERMINATED)
@@ -425,7 +425,7 @@ namespace Opm {
             if (parserState->rawKeyword != NULL && parserState->rawKeyword->isFinished())
                 return true;
         }
-        if (parserState->rawKeyword && parserState->rawKeyword->getSizeType() == Raw::UNKNOWN) 
+        if (parserState->rawKeyword && parserState->rawKeyword->getSizeType() == Raw::UNKNOWN)
             parserState->rawKeyword->finalizeUnknownSize();
 
         return false;
@@ -438,7 +438,7 @@ namespace Opm {
             ParserKeywordConstPtr parserKeyword = ParserKeyword::createFromJson(jsonKeyword);
             addParserKeyword(parserKeyword);
             return true;
-        } 
+        }
         catch (...) {
             return false;
         }
@@ -485,6 +485,6 @@ namespace Opm {
             }
         }
     }
-    
+
 
 } // namespace Opm

--- a/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
@@ -60,7 +60,7 @@ namespace Opm
     double ParserDoubleItem::getDefault() const {
         return m_default;
     }
-    
+
 
     void ParserDoubleItem::setDefault(double defaultValue) {
         m_default = defaultValue;
@@ -73,7 +73,7 @@ namespace Opm
             ParserItem(jsonConfig)
     {
         m_default = std::numeric_limits<double>::quiet_NaN();
-        if (jsonConfig.has_item("default")) 
+        if (jsonConfig.has_item("default"))
             setDefault( jsonConfig.get_double("default") );
     }
 
@@ -90,14 +90,14 @@ namespace Opm
                 if (other.getDimension(idim) != getDimension(idim))
                     equal_ = false;
             }
-        } 
+        }
         return equal_;
     }
 
     void ParserDoubleItem::push_backDimension(const std::string& dimension) {
         if ((sizeType() == SINGLE) && (m_dimensions.size() > 0))
             throw std::invalid_argument("Internal error: cannot add more than one dimension to an item of size 1");
-        
+
         m_dimensions.push_back( dimension );
     }
 
@@ -120,7 +120,7 @@ namespace Opm
     DeckItemPtr ParserDoubleItem::scan(RawRecordPtr rawRecord) const {
         return ParserItemScan<ParserDoubleItem,DeckDoubleItem,double>(this , rawRecord);
     }
-    
+
     void ParserDoubleItem::inlineNew(std::ostream& os) const {
         os << "new ParserDoubleItem(" << "\"" << name() << "\"" << "," << ParserItemSizeEnum2String( sizeType() );
         if (m_defaultSet)

--- a/opm/parser/eclipse/Parser/ParserEnums.cpp
+++ b/opm/parser/eclipse/Parser/ParserEnums.cpp
@@ -22,7 +22,7 @@
 
 namespace Opm {
 
-    
+
 
     const std::string ParserItemSizeEnum2String(ParserItemSizeEnum enumValue) {
         switch (enumValue) {
@@ -36,7 +36,7 @@ namespace Opm {
             throw std::invalid_argument("Implementation error - should NOT be here");
         }
     }
-    
+
 
     ParserItemSizeEnum ParserItemSizeEnumFromString(const std::string& stringValue) {
         if (stringValue == "ALL")
@@ -83,7 +83,7 @@ namespace Opm {
         else
             throw std::invalid_argument("String: " + stringValue + " can not be converted to enum value");
     }
-    
+
     /*****************************************************************/
 
     const std::string ParserValueTypeEnum2String(ParserValueTypeEnum enumValue) {
@@ -101,7 +101,7 @@ namespace Opm {
             throw std::invalid_argument("Implementation error - should NOT be here");
         }
     }
-    
+
 
     ParserValueTypeEnum ParserValueTypeEnumFromString(const std::string& stringValue) {
         if (stringValue == "INT")
@@ -136,7 +136,7 @@ namespace Opm {
             throw std::invalid_argument("Implementation error - should NOT be here");
         }
     }
-    
+
     ParserKeywordActionEnum ParserKeywordActionEnumFromString(const std::string& stringValue) {
         if (stringValue == "INTERNALIZE")
             return INTERNALIZE;

--- a/opm/parser/eclipse/Parser/ParserEnums.hpp
+++ b/opm/parser/eclipse/Parser/ParserEnums.hpp
@@ -48,19 +48,19 @@ namespace Opm {
         DOUBLE = 3
     };
 
-    
+
     enum ParserKeywordActionEnum {
         INTERNALIZE = 0,
         IGNORE = 1,
         IGNORE_WARNING = 2,
         THROW_EXCEPTION = 3
     };
-    
+
     const std::string ParserKeywordActionEnum2String(ParserKeywordActionEnum enumValue);
     const std::string ParserItemSizeEnum2String(ParserItemSizeEnum enumValue);
     const std::string ParserKeywordSizeEnum2String(ParserKeywordSizeEnum enumValue);
     const std::string ParserValueTypeEnum2String(ParserValueTypeEnum enumValue);
-        
+
     ParserItemSizeEnum ParserItemSizeEnumFromString(const std::string& stringValue);
     ParserKeywordSizeEnum ParserKeywordSizeEnumFromString(const std::string& stringValue);
     ParserValueTypeEnum ParserValueTypeEnumFromString(const std::string& stringValue);

--- a/opm/parser/eclipse/Parser/ParserFloatItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserFloatItem.cpp
@@ -121,7 +121,7 @@ namespace Opm
     DeckItemPtr ParserFloatItem::scan(RawRecordPtr rawRecord) const {
         return ParserItemScan<ParserFloatItem,DeckFloatItem,float>(this , rawRecord);
     }
-    
+
     void ParserFloatItem::inlineNew(std::ostream& os) const {
         os << "new ParserFloatItem(" << "\"" << name() << "\"" << "," << ParserItemSizeEnum2String( sizeType() );
         if (m_defaultSet)

--- a/opm/parser/eclipse/Parser/ParserIntItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserIntItem.cpp
@@ -28,7 +28,7 @@
 namespace Opm {
 
 
-    ParserIntItem::ParserIntItem(const std::string& itemName) : ParserItem(itemName) 
+    ParserIntItem::ParserIntItem(const std::string& itemName) : ParserItem(itemName)
     {
         // integers do not have a representation for NaN. Let's use a negative value as
         // this is usually meaningless. (Keep in mind that in the deck it can be queried
@@ -36,18 +36,18 @@ namespace Opm {
         m_default = -1;
     }
 
-    ParserIntItem::ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType_) : ParserItem(itemName, sizeType_) 
+    ParserIntItem::ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType_) : ParserItem(itemName, sizeType_)
     {
         m_default = -1;
     }
 
-    ParserIntItem::ParserIntItem(const std::string& itemName, int defaultValue) : ParserItem(itemName) 
+    ParserIntItem::ParserIntItem(const std::string& itemName, int defaultValue) : ParserItem(itemName)
     {
         setDefault(defaultValue);
     }
 
 
-    ParserIntItem::ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType_, int defaultValue) : ParserItem(itemName, sizeType_) 
+    ParserIntItem::ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType_, int defaultValue) : ParserItem(itemName, sizeType_)
     {
         setDefault(defaultValue);
     }
@@ -55,7 +55,7 @@ namespace Opm {
     ParserIntItem::ParserIntItem(const Json::JsonObject& jsonConfig) : ParserItem(jsonConfig)
     {
         m_default = -1;
-        if (jsonConfig.has_item("default")) 
+        if (jsonConfig.has_item("default"))
             setDefault( jsonConfig.get_int("default") );
     }
 
@@ -80,7 +80,7 @@ namespace Opm {
     {
         return parserRawItemEqual<ParserIntItem>(other);
     }
-    
+
 
     void ParserIntItem::inlineNew(std::ostream& os) const {
         os << "new ParserIntItem(" << "\"" << name() << "\"" << "," << ParserItemSizeEnum2String( sizeType() );

--- a/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -49,13 +49,13 @@ namespace Opm {
     }
 
     const std::string& ParserItem::getDimension(size_t /* index */) const {
-        throw std::invalid_argument("Should not call this ... \n");       
+        throw std::invalid_argument("Should not call this ... \n");
     }
 
     void ParserItem::push_backDimension(const std::string& /* dimension */) {
-        throw std::invalid_argument("Should not call this ... \n");       
+        throw std::invalid_argument("Should not call this ... \n");
     }
-    
+
     ParserItem::ParserItem(const Json::JsonObject& jsonConfig) {
         if (jsonConfig.has_item("name"))
             m_name = jsonConfig.get_string("name");
@@ -67,7 +67,7 @@ namespace Opm {
             m_sizeType = ParserItemSizeEnumFromString( sizeTypeString );
         } else
           m_sizeType = SINGLE;
-        
+
         if (jsonConfig.has_item("description")) {
             m_description = jsonConfig.get_string("description");
         }

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -35,7 +35,7 @@
 #include <opm/parser/eclipse/RawDeck/StarToken.hpp>
 
 namespace Opm {
-    
+
     class ParserItem {
     public:
         ParserItem(const std::string& itemName);
@@ -105,7 +105,7 @@ namespace Opm {
     template<typename ParserItemType , typename DeckItemType , typename ValueType>
     DeckItemPtr ParserItemScan(const ParserItemType * self , RawRecordPtr rawRecord) {
         std::shared_ptr<DeckItemType> deckItem = std::make_shared<DeckItemType>( self->name() , self->scalar() );
-        
+
         if (self->sizeType() == ALL) {
             while (rawRecord->size() > 0) {
                 std::string token = rawRecord->pop_front();
@@ -168,7 +168,7 @@ namespace Opm {
         return deckItem;
     }
 
-    
+
 
 }
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -104,7 +104,7 @@ namespace Opm {
 
             if (!numTablesObject.is_object())
                 throw std::invalid_argument("The num_tables key must point to a {} object");
-            
+
             initSizeKeyword(numTablesObject);
             m_isTableCollection = true;
         } else {
@@ -208,7 +208,7 @@ namespace Opm {
 
         if (!isalpha(name[0]))
             return false;
-        
+
         return true;
     }
 
@@ -383,7 +383,7 @@ namespace Opm {
             throw std::invalid_argument("The items: object must be an array");
     }
 
-    
+
     void ParserKeyword::initFloatItemDimension( ParserFloatItemPtr item, const Json::JsonObject itemConfig) {
         if (itemConfig.has_item("dimension")) {
             const Json::JsonObject dimensionConfig = itemConfig.get_item("dimension");
@@ -396,7 +396,7 @@ namespace Opm {
                 }
             } else
                 throw std::invalid_argument("The dimension: attribute must be a string/list of strings");
-        } 
+        }
     }
 
 
@@ -412,10 +412,10 @@ namespace Opm {
                 }
             } else
                 throw std::invalid_argument("The dimension: attribute must be a string/list of strings");
-        } 
+        }
     }
 
-    
+
 
     void ParserKeyword::initData(const Json::JsonObject& jsonConfig) {
         m_fixedSize = 1U;

--- a/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -68,7 +68,7 @@ namespace Opm {
                 for (size_t idim=0; idim < (*iter)->numDimensions(); idim++) {
                     std::shared_ptr<const Dimension> activeDimension  = deck->getActiveUnitSystem()->getNewDimension( parserItem->getDimension(idim) );
                     std::shared_ptr<const Dimension> defaultDimension = deck->getDefaultUnitSystem()->getNewDimension( parserItem->getDimension(idim) );
-                    deckItem->push_backDimension( activeDimension , defaultDimension ); 
+                    deckItem->push_backDimension( activeDimension , defaultDimension );
                 }
             }
         }
@@ -101,8 +101,8 @@ namespace Opm {
         }
         const size_t recordSize = rawRecord->size();
         if (recordSize > 0)
-            throw std::invalid_argument("The RawRecord for keyword \""  + rawRecord->getKeywordName() + "\" in file\"" + rawRecord->getFileName() + "\" contained " + 
-                                        boost::lexical_cast<std::string>(recordSize) + 
+            throw std::invalid_argument("The RawRecord for keyword \""  + rawRecord->getKeywordName() + "\" in file\"" + rawRecord->getFileName() + "\" contained " +
+                                        boost::lexical_cast<std::string>(recordSize) +
                                         " too many items according to the spec. RawRecord was: " + recordBeforeParsing);
 
         return deckRecord;
@@ -118,7 +118,7 @@ namespace Opm {
                {
                    ParserItemConstPtr item = get(itemIndex);
                    ParserItemConstPtr otherItem = other.get(itemIndex);
-                   
+
                    if (!item->equal(*otherItem)) {
                        equal_ = false;
                        break;

--- a/opm/parser/eclipse/Parser/ParserStringItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserStringItem.cpp
@@ -24,13 +24,13 @@
 #include <opm/parser/eclipse/RawDeck/StarToken.hpp>
 namespace Opm {
 
-    ParserStringItem::ParserStringItem(const std::string& itemName) : ParserItem(itemName) 
+    ParserStringItem::ParserStringItem(const std::string& itemName) : ParserItem(itemName)
     {
         m_default = "";
     }
 
 
-    ParserStringItem::ParserStringItem(const std::string& itemName, ParserItemSizeEnum sizeType_) : ParserItem(itemName, sizeType_) 
+    ParserStringItem::ParserStringItem(const std::string& itemName, ParserItemSizeEnum sizeType_) : ParserItem(itemName, sizeType_)
     {
         m_default = "";
     }
@@ -47,7 +47,7 @@ namespace Opm {
 
     ParserStringItem::ParserStringItem(const Json::JsonObject& jsonConfig) : ParserItem(jsonConfig) {
         m_default = "";
-        if (jsonConfig.has_item("default")) 
+        if (jsonConfig.has_item("default"))
             setDefault( jsonConfig.get_string("default") );
     }
 
@@ -71,13 +71,13 @@ namespace Opm {
         return ParserItemScan<ParserStringItem,DeckStringItem,std::string>(this , rawRecord);
     }
 
-     
-     
+
+
     bool ParserStringItem::equal(const ParserItem& other) const
     {
         return parserRawItemEqual<ParserStringItem>(other);
     }
-    
+
     void ParserStringItem::inlineNew(std::ostream& os) const {
         os << "new ParserStringItem(" << "\"" << name() << "\"" << "," << ParserItemSizeEnum2String( sizeType() );
         if (m_defaultSet)

--- a/opm/parser/eclipse/Parser/UnitSystem.cpp
+++ b/opm/parser/eclipse/Parser/UnitSystem.cpp
@@ -15,7 +15,7 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/ 
+*/
 
 /*#include <boost/algorithm/string.hpp>
 #include <stdexcept>
@@ -34,17 +34,17 @@
 
 namespace Opm {
 
-    UnitSystem::UnitSystem(const std::string& unitSystem) : 
+    UnitSystem::UnitSystem(const std::string& unitSystem) :
         m_name( unitSystem )
     {
-        
+
     }
 
     bool UnitSystem::hasDimension(const std::string& dimension) const {
         return (m_dimensions.find( dimension ) != m_dimensions.end());
     }
 
-    
+
     const Dimension& UnitSystem::getDimension(const std::string& dimension) const {
         if (hasDimension( dimension ))
             return m_dimensions.at( dimension );
@@ -56,7 +56,7 @@ namespace Opm {
     void UnitSystem::addDimension(const std::string& dimension , double SI_factor) {
         if (hasDimension(dimension))
             m_dimensions.erase( dimension );
-        
+
         m_dimensions.insert( std::make_pair(dimension , Dimension(dimension , SI_factor)));
     }
 
@@ -76,7 +76,7 @@ namespace Opm {
         }
         return Dimension::newComposite( dimension , SIfactor );
     }
-    
+
 
 
     std::shared_ptr<const Dimension> UnitSystem::parse(const std::string& dimension) const {
@@ -96,7 +96,7 @@ namespace Opm {
             boost::split(parts , dimension , boost::is_any_of("/"));
             Dimension dividend = parseFactor( parts[0] );
             Dimension divisor = parseFactor( parts[1] );
-        
+
             return Dimension::newComposite( dimension , dividend.getSIScaling() / divisor.getSIScaling() );
         } else {
             return parseFactor( dimension );
@@ -106,7 +106,7 @@ namespace Opm {
 
     UnitSystem * UnitSystem::newMETRIC() {
         UnitSystem * system = new UnitSystem("Metric");
-        
+
         system->addDimension("1" , 1);
         system->addDimension("Length" , 1);
         system->addDimension("Time" , 86400 );
@@ -115,15 +115,15 @@ namespace Opm {
         system->addDimension("Permeability" , 9.869233e-10 );
         system->addDimension("Viscosity" , 0.001); // viscosity. ECLiPSE uses cP for metric units
         system->addDimension("GasDissolutionFactor" , 1); // Gas dissolution factor. ECLiPSE uses m^3/m^3 for metric units
-        
+
         return system;
     }
 
 
-    
+
     UnitSystem * UnitSystem::newFIELD() {
         UnitSystem * system = new UnitSystem("Field");
-        
+
         system->addDimension("1" , 1);
         system->addDimension("Length" , 0.3048);
         system->addDimension("Time" , 86400 );
@@ -132,7 +132,7 @@ namespace Opm {
         system->addDimension("Permeability" , 9.869233e-10 );
         system->addDimension("Viscosity" , 0.001); // viscosity. ECLiPSE uses cP for field units
         system->addDimension("GasDissolutionFactor" , 28.316847/0.15898729); // Gas dissolution factor. ECLiPSE uses Mscft/stb for field units
-        
+
         return system;
     }
 

--- a/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
+++ b/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
@@ -85,7 +85,7 @@ static bool areStreamsEqual( std::istream& lhs, std::istream& rhs )
 
 
 static void generateKeywordSignature(std::iostream& of , KeywordMapType& keywordMap)
-{    
+{
     for (auto iter=keywordMap.begin(); iter != keywordMap.end(); ++iter) {
         KeywordElementType  keywordElement = *iter;
         const std::string& keywordName = keywordElement.first;
@@ -93,7 +93,7 @@ static void generateKeywordSignature(std::iostream& of , KeywordMapType& keyword
         Json::JsonObject * jsonKeyword = new Json::JsonObject(boost::filesystem::path(fileName));
 
         of << keywordName << std::endl << jsonKeyword->get_content() << std::endl;
-        
+
         delete jsonKeyword;
     }
 }
@@ -117,7 +117,7 @@ static void testKeyword(ParserKeywordConstPtr parserKeyword , const std::string&
 
     of << "    ParserKeywordPtr ";
     parserKeyword->inlineNew(of , "inlineKeyword" , "   ");
-    
+
     of << "BOOST_CHECK( parserKeyword->equal( *inlineKeyword));" << std::endl;
     if (parserKeyword->hasDimension()) {
         of << "{" << std::endl;
@@ -127,7 +127,7 @@ static void testKeyword(ParserKeywordConstPtr parserKeyword , const std::string&
         of << "        for (size_t j=0; j < item->numDimensions(); j++) {" << std::endl;
         of << "            std::string dimString = item->getDimension(j);" << std::endl;
         of << "            BOOST_CHECK_NO_THROW( unitSystem->getNewDimension( dimString ));" << std::endl;
-        of << "         }" << std::endl; 
+        of << "         }" << std::endl;
         of << "    }" << std::endl;
         of << "}" << std::endl;
     }
@@ -147,9 +147,9 @@ static void generateTestForKeyword(std::iostream& of, KeywordElementType keyword
 static void generateKeywordTest(const char * test_file_name , KeywordMapType& keywordMap) {
     std::fstream test_file_stream( test_file_name , std::fstream::out );
     createTestHeader( test_file_stream , "TEST_KEYWORDS");
-    for (auto iter=keywordMap.begin(); iter != keywordMap.end(); ++iter) 
+    for (auto iter=keywordMap.begin(); iter != keywordMap.end(); ++iter)
         generateTestForKeyword(test_file_stream , *iter);
-    
+
     test_file_stream.close( );
 }
 
@@ -166,7 +166,7 @@ static void generateSourceForKeyword(std::iostream& of, KeywordElementType keywo
     parserKeyword->inlineNew(of , keywordName , indent);
     of << indent << "parser->addParserKeyword( " << keywordName << ");" << std::endl;
     of << "}" << std::endl << std::endl;
-    
+
     std::cout << "Creating keyword: " << keywordName << std::endl;
 }
 

--- a/opm/parser/eclipse/Parser/tests/ParserEnumTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserEnumTests.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(TestKeywordSizeEnumLoop) {
     BOOST_CHECK_EQUAL( SLASH_TERMINATED , ParserKeywordSizeEnumFromString( ParserKeywordSizeEnum2String( SLASH_TERMINATED ) ));
     BOOST_CHECK_EQUAL( OTHER_KEYWORD_IN_DECK     , ParserKeywordSizeEnumFromString( ParserKeywordSizeEnum2String( OTHER_KEYWORD_IN_DECK ) ));
     BOOST_CHECK_EQUAL( UNKNOWN , ParserKeywordSizeEnumFromString( ParserKeywordSizeEnum2String( UNKNOWN ) ));
-    
+
     BOOST_CHECK_EQUAL( "FIXED"     , ParserKeywordSizeEnum2String(ParserKeywordSizeEnumFromString(  "FIXED" ) ));
     BOOST_CHECK_EQUAL( "SLASH_TERMINATED" , ParserKeywordSizeEnum2String(ParserKeywordSizeEnumFromString(  "SLASH_TERMINATED" ) ));
     BOOST_CHECK_EQUAL( "OTHER_KEYWORD_IN_DECK"     , ParserKeywordSizeEnum2String(ParserKeywordSizeEnumFromString(  "OTHER_KEYWORD_IN_DECK" ) ));
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(TestKeywordActionEnum2String) {
     BOOST_CHECK_EQUAL( "IGNORE_WARNING"  , ParserKeywordActionEnum2String(IGNORE_WARNING));
     BOOST_CHECK_EQUAL( "THROW_EXCEPTION" , ParserKeywordActionEnum2String(THROW_EXCEPTION));
 }
- 
+
 
 BOOST_AUTO_TEST_CASE(TestKeywordActionEnumFromString) {
     BOOST_CHECK_THROW( ParserKeywordActionEnumFromString("XXX") , std::invalid_argument );
@@ -135,7 +135,7 @@ BOOST_AUTO_TEST_CASE(TestKeywordActionEnumLoop) {
     BOOST_CHECK_EQUAL( IGNORE , ParserKeywordActionEnumFromString( ParserKeywordActionEnum2String( IGNORE ) ));
     BOOST_CHECK_EQUAL( IGNORE_WARNING    , ParserKeywordActionEnumFromString( ParserKeywordActionEnum2String( IGNORE_WARNING ) ));
     BOOST_CHECK_EQUAL( THROW_EXCEPTION    , ParserKeywordActionEnumFromString( ParserKeywordActionEnum2String( THROW_EXCEPTION ) ));
-    
+
     BOOST_CHECK_EQUAL( "INTERNALIZE"    , ParserKeywordActionEnum2String(ParserKeywordActionEnumFromString(  "INTERNALIZE" ) ));
     BOOST_CHECK_EQUAL( "IGNORE" , ParserKeywordActionEnum2String(ParserKeywordActionEnumFromString(  "IGNORE" ) ));
     BOOST_CHECK_EQUAL( "IGNORE_WARNING"    , ParserKeywordActionEnum2String(ParserKeywordActionEnumFromString(  "IGNORE_WARNING" ) ));

--- a/opm/parser/eclipse/Parser/tests/ParserItemTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserItemTests.cpp
@@ -110,7 +110,7 @@ BOOST_AUTO_TEST_CASE(scan_PreMatureTerminator_defaultUsed) {
     // whit the defaultApplied(0) method returning true...
     BOOST_CHECK(defaulted->defaultApplied(0));
     BOOST_CHECK(defaulted->getInt(0) < 0);
-}    
+}
 
 BOOST_AUTO_TEST_CASE(InitializeIntItem_setDescription_canReadBack) {
     ParserIntItem itemInt(std::string("ITEM1"));
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(DoubleItem_DimEqual_ReturnsTrue) {
 
     item1.push_backDimension("Length*Length");
     item2.push_backDimension("Length*Length");
-    
+
     BOOST_CHECK( item1.equal( item2 ));
 }
 
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(DoubleItem_DimDifferent_ReturnsFalse) {
 
     item3.push_backDimension("Length");
     item3.push_backDimension("Length");
-    
+
     item4.push_backDimension("Time");
 
     BOOST_CHECK_EQUAL(false , item1.equal( item2 ));
@@ -427,7 +427,7 @@ BOOST_AUTO_TEST_CASE(Scan_SeveralInts_CorrectIntsSetInDeckItem) {
     RawRecordPtr rawRecord(new RawRecord("100 443 338932 222.33 'Heisann' /"));
     DeckItemConstPtr deckIntItem1 = itemInt1.scan(rawRecord);
     BOOST_CHECK_EQUAL(100, deckIntItem1->getInt(0));
-        
+
     DeckItemConstPtr deckIntItem2 = itemInt2.scan(rawRecord);
     BOOST_CHECK_EQUAL(443, deckIntItem2->getInt(0));
 
@@ -675,7 +675,7 @@ BOOST_AUTO_TEST_CASE(scan_intsAndStrings_dataCorrect) {
 BOOST_AUTO_TEST_CASE(ParserItemCheckEqualsOverride) {
     ParserItemConstPtr itemDefault10( new ParserIntItem("ITEM" ,  10) );
     ParserItemConstPtr itemDefault20( new ParserIntItem("ITEM" ,  20) );
-    
+
     BOOST_CHECK( itemDefault10->equal( *itemDefault10 ));
     BOOST_CHECK_EQUAL( false , itemDefault10->equal( *itemDefault20 ));
 }
@@ -706,7 +706,7 @@ BOOST_AUTO_TEST_CASE(ParserIntItemGetDimensionThrows) {
 
 BOOST_AUTO_TEST_CASE(ParserDoubleItemAddMultipleDimensionToSIngleSizeThrows) {
     ParserDoubleItem doubleItem(std::string("SOMEDOUBLE"));
-    
+
     doubleItem.push_backDimension("Length*Length");
     BOOST_CHECK_THROW( doubleItem.push_backDimension("Length*Length"), std::invalid_argument);
 }

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -116,7 +116,7 @@ BOOST_AUTO_TEST_CASE(AddDataKeyword_correctlyConfigured) {
     BOOST_CHECK_EQUAL( false , parserKeyword->isDataKeyword() );
     parserKeyword->addDataItem( item );
     BOOST_CHECK_EQUAL( true , parserKeyword->isDataKeyword() );
-    
+
     BOOST_CHECK_EQUAL(true , parserKeyword->hasFixedSize( ));
     BOOST_CHECK_EQUAL(1U , parserKeyword->getFixedSize() );
     BOOST_CHECK_EQUAL(1U , parserKeyword->numItems() );
@@ -260,7 +260,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_ItemMissingValueType_throws) {
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_ItemInvalidEnum_throws) {
     Json::JsonObject jsonObject1("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"XSINGLE\" , \"value_type\" : \"INT\"}]}");
     Json::JsonObject jsonObject2("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"SINGLE\" , \"value_type\" : \"INTX\"}]}");
-    
+
     BOOST_CHECK_THROW(ParserKeyword::createFromJson(jsonObject1) , std::invalid_argument);
     BOOST_CHECK_THROW(ParserKeyword::createFromJson(jsonObject2) , std::invalid_argument);
 }
@@ -272,7 +272,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObjectItemsOK) {
     ParserItemConstPtr item = record->get( 0 );
     BOOST_CHECK_EQUAL( 1U , record->size( ) );
     BOOST_CHECK_EQUAL( "I" , item->name( ) );
-    BOOST_CHECK_EQUAL( SINGLE , item->sizeType()); 
+    BOOST_CHECK_EQUAL( SINGLE , item->sizeType());
 }
 
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_sizeFromOther) {
@@ -326,7 +326,7 @@ BOOST_AUTO_TEST_CASE(AddkeywordFromJson_isTableCollection) {
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_InvalidSize_throws) {
     Json::JsonObject jsonObject1("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : \"string\" , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"SINGLE\" , \"value_type\" : \"INT\"}]}");
     Json::JsonObject jsonObject2("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : [1,2,3]    , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"SINGLE\" , \"value_type\" : \"INT\"}]}");
-    
+
     BOOST_CHECK_THROW(ParserKeyword::createFromJson(jsonObject1) , std::invalid_argument);
     BOOST_CHECK_THROW(ParserKeyword::createFromJson(jsonObject2) , std::invalid_argument);
 
@@ -335,7 +335,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_InvalidSize_throws) {
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_SizeUNKNOWN_OK) {
     Json::JsonObject jsonObject1("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : \"UNKNOWN\" , \"items\" : [{\"name\" : \"I\" , \"size_type\" : \"SINGLE\" , \"value_type\" : \"INT\"}]}");
     ParserKeywordConstPtr parserKeyword = ParserKeyword::createFromJson(jsonObject1);
-    
+
     BOOST_CHECK_EQUAL( UNKNOWN , parserKeyword->getSizeType() );
 }
 
@@ -431,9 +431,9 @@ BOOST_AUTO_TEST_CASE(ParseKeywordHasDimensionCorrect) {
     ParserKeywordPtr parserKeyword = ParserKeyword::createDynamicSized("JA");
     ParserIntItemConstPtr itemI(new ParserIntItem("I", SINGLE));
     ParserDoubleItemPtr item2(new ParserDoubleItem("ID", SINGLE));
-    
+
     BOOST_CHECK_EQUAL( false , parserKeyword->hasDimension());
-    
+
     parserKeyword->addItem( itemI );
     parserKeyword->addItem( item2 );
     BOOST_CHECK_EQUAL( false , parserKeyword->hasDimension());
@@ -448,7 +448,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_withDimension) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\" , \"dimension\" : \"Length*Length/Time\"}]}");
     ParserKeywordPtr parserKeyword = ParserKeyword::createFromJson(jsonObject);
     ParserRecordConstPtr record = parserKeyword->getRecord();
-    ParserItemConstPtr item = record->get("ItemX");      
+    ParserItemConstPtr item = record->get("ItemX");
 
     BOOST_CHECK_EQUAL("BPR" , parserKeyword->getName());
     BOOST_CHECK_EQUAL( true , parserKeyword->hasFixedSize() );
@@ -464,7 +464,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_withDimensionList) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"ALL\" , \"value_type\" : \"DOUBLE\" , \"dimension\" : [\"Length*Length/Time\" , \"Time\", \"1\"]}]}");
     ParserKeywordPtr parserKeyword = ParserKeyword::createFromJson(jsonObject);
     ParserRecordConstPtr record = parserKeyword->getRecord();
-    ParserItemConstPtr item = record->get("ItemX");      
+    ParserItemConstPtr item = record->get("ItemX");
 
     BOOST_CHECK_EQUAL("BPR" , parserKeyword->getName());
     BOOST_CHECK_EQUAL( true , parserKeyword->hasFixedSize() );

--- a/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
@@ -250,7 +250,7 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
         DeckItemConstPtr deckStringItem = itemString->scan(rawRecord);
         DeckItemConstPtr deckIntItem = itemInt->scan(rawRecord);
         DeckItemConstPtr deckDoubleItem = itemDouble->scan(rawRecord);
-        
+
         BOOST_CHECK(deckStringItem->size() == 1);
         BOOST_CHECK(deckIntItem->size() == 1);
         BOOST_CHECK(deckDoubleItem->size() == 1);
@@ -302,10 +302,10 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooManyItems_Throws) {
     parserRecord->addItem(itemJ);
     parserRecord->addItem(itemK);
 
-        
+
     RawRecordPtr rawRecord(new RawRecord("3 3 3 /"));
     BOOST_CHECK_NO_THROW(parserRecord->parse(rawRecord));
-    
+
     RawRecordPtr rawRecordOneExtra(new RawRecord("3 3 3 4 /"));
     BOOST_CHECK_THROW(parserRecord->parse(rawRecordOneExtra), std::invalid_argument);
 
@@ -335,13 +335,13 @@ BOOST_AUTO_TEST_CASE(ParseRecordHasDimensionCorrect) {
     ParserRecordPtr parserRecord(new ParserRecord());
     ParserIntItemConstPtr itemI(new ParserIntItem("I", SINGLE));
     ParserDoubleItemPtr item2(new ParserDoubleItem("ID", SINGLE));
-    
+
     BOOST_CHECK_EQUAL( false , parserRecord->hasDimension());
-    
+
     parserRecord->addItem( itemI );
     parserRecord->addItem( item2 );
     BOOST_CHECK_EQUAL( false , parserRecord->hasDimension());
-    
+
     item2->push_backDimension("Length*Length/Time");
     BOOST_CHECK_EQUAL( true , parserRecord->hasDimension());
 }

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -113,14 +113,14 @@ BOOST_AUTO_TEST_CASE(addParserKeywordJSON_size_isObject_allGood) {
 BOOST_AUTO_TEST_CASE(loadKeywordsJSON_notArray_throw) {
     ParserPtr parser(new Parser());
     Json::JsonObject jsonConfig( "{\"name\" : \"BPR\" , \"size\" : 100, \"sections\":[\"SUMMARY\"]}");
-    
+
     BOOST_CHECK_THROW(parser->loadKeywords( jsonConfig ) , std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(loadKeywordsJSON_noSectionsItem_throw) {
     ParserPtr parser(new Parser());
     Json::JsonObject jsonConfig( "[{\"name\" : \"BPR\" , \"size\" : 100, \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\"}]}]");
-    
+
     BOOST_CHECK_THROW(parser->loadKeywords( jsonConfig ) , std::invalid_argument);
 }
 
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(loadKeywordsJSON_noSectionsItem_throw) {
 BOOST_AUTO_TEST_CASE(loadKeywordsJSON_isRecognizedKeyword_returnstrue) {
     ParserPtr parser(new Parser());
     Json::JsonObject jsonConfig( "[{\"name\" : \"BPR\" , \"size\" : 100, \"sections\":[\"SUMMARY\"], \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\"}]}]");
-    
+
     parser->loadKeywords( jsonConfig );
     BOOST_CHECK(parser->isRecognizedKeyword("BPR"));
 }
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE(empty_sizeReturns0) {
 BOOST_AUTO_TEST_CASE(loadKeywordsJSON_manyKeywords_returnstrue) {
     ParserPtr parser(new Parser( false ));
     Json::JsonObject jsonConfig( "[{\"name\" : \"BPR\" , \"size\" : 100, \"sections\":[\"SUMMARY\"] ,  \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\"}]}, {\"name\" : \"WWCT\", \"sections\":[\"SUMMARY\"], \"size\" : 0} , {\"name\" : \"EQUIL\", \"sections\":[\"PROPS\"], \"size\" : 0}]");
-    
+
     parser->loadKeywords( jsonConfig );
     BOOST_CHECK(parser->isRecognizedKeyword("BPR"));
     BOOST_CHECK(parser->isRecognizedKeyword("WWCT"));
@@ -262,7 +262,7 @@ BOOST_AUTO_TEST_CASE(ReplaceKeyword) {
 
     BOOST_CHECK_EQUAL( 5U , eqldims->numItems());
     BOOST_CHECK( parser->loadKeywordFromFile( "testdata/parser/EQLDIMS2" ) );
-    
+
 
     eqldims = parser->getParserKeywordFromDeckName("EQLDIMS");
     BOOST_CHECK_EQUAL( 1U , eqldims->numItems());

--- a/opm/parser/eclipse/Parser/tests/createInlineItemTest.cpp
+++ b/opm/parser/eclipse/Parser/tests/createInlineItemTest.cpp
@@ -164,7 +164,7 @@ int main(int /* argc */ , char ** argv) {
     const char * test_module = argv[2];
     std::ofstream of( test_src );
     createHeader(of , test_module);
-    
+
     intItem( of );
     intItemWithDefault( of );
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -96,7 +96,7 @@ namespace Opm {
                 RawRecordPtr record(new RawRecord(m_partialRecordString, m_filename, m_name));
                 m_records.push_back(record);
                 m_partialRecordString.clear();
-                
+
                 if (m_sizeType == Raw::FIXED && (m_records.size() == m_fixedSize))
                     m_isFinished = true;
             }
@@ -117,7 +117,7 @@ namespace Opm {
         if (index < m_records.size()) {
             return m_records[index];
         }
-        else 
+        else
             throw std::range_error("Index out of range");
     }
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -45,12 +45,12 @@ namespace Opm {
         size_t size() const;
         Raw::KeywordSizeEnum getSizeType() const;
         RawRecordPtr getRecord(size_t index) const;
-        
+
         static bool isKeywordPrefix(const std::string& line, std::string& keywordName);
         static bool isTerminator(std::string line);
         static bool useLine(std::string line);
-        
-        
+
+
         bool isPartialRecordStringEmpty() const;
         bool isFinished() const;
         bool unKnownSize() const;
@@ -58,7 +58,7 @@ namespace Opm {
 
         const std::string& getFilename() const;
         size_t getLineNR() const;
-        
+
 
     private:
         Raw::KeywordSizeEnum m_sizeType;

--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -32,10 +32,10 @@ namespace Opm {
      * It is assumed that after a record is terminated, there is no quote marks
      * in the subsequent comment. This is in accordance with the Eclipse user
      * manual.
-     * 
+     *
      * If a "non-complete" record string is supplied, an invalid_argument
      * exception is thrown.
-     * 
+     *
      */
     RawRecord::RawRecord(const std::string& singleRecordString, const std::string& fileName, const std::string& keywordName) : m_fileName(fileName), m_keywordName(keywordName){
         if (isTerminatedRecordString(singleRecordString)) {
@@ -46,15 +46,15 @@ namespace Opm {
                     " offending string: " + singleRecordString);
         }
     }
-    
+
     const std::string& RawRecord::getFileName() const {
         return m_fileName;
     }
-    
+
     const std::string& RawRecord::getKeywordName() const {
         return m_keywordName;
     }
-    
+
 
     std::string RawRecord::pop_front() {
         std::string front = m_recordItems.front();
@@ -151,8 +151,8 @@ namespace Opm {
         unsigned int terminatingSlash = singleRecordString.find_first_of(RawConsts::slash);
         unsigned int lastQuotePosition = singleRecordString.find_last_of(RawConsts::quote);
 
-        // Checks lastQuotePosition vs terminatingSlashPosition, 
-        // since specifications of WELLS, FILENAMES etc can include slash, but 
+        // Checks lastQuotePosition vs terminatingSlashPosition,
+        // since specifications of WELLS, FILENAMES etc can include slash, but
         // these are always in quotes (and there are no quotes after record-end).
         if (terminatingSlash < lastQuotePosition && lastQuotePosition < singleRecordString.size()) {
             terminatingSlash = singleRecordString.find_first_of(RawConsts::slash, lastQuotePosition);

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -33,7 +33,7 @@ namespace Opm {
     class RawRecord {
     public:
         RawRecord(const std::string& singleRecordString, const std::string& fileName = "", const std::string& keywordName = "");
-        
+
         std::string pop_front();
         void push_front(std::string token);
         size_t size() const;
@@ -46,13 +46,13 @@ namespace Opm {
         static bool isTerminatedRecordString(const std::string& candidateRecordString);
         virtual ~RawRecord();
         void dump() const;
-        
+
     private:
         std::string m_sanitizedRecordString;
         std::deque<std::string> m_recordItems;
         const std::string m_fileName;
         const std::string m_keywordName;
-        
+
         void setRecordString(const std::string& singleRecordString);
         void splitSingleRecordString();
         void processSeparatorCharacter(std::string& currentToken, const char& currentChar, char& tokenStarter);

--- a/opm/parser/eclipse/RawDeck/tests/RawKeywordTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/RawKeywordTests.cpp
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(isFinished_undef_size) {
 
 BOOST_AUTO_TEST_CASE(isFinished_Fixedsize0) {
     RawKeyword keyword("TEST" , "FILE" , 10U , 0U);
-    
+
     BOOST_CHECK(  keyword.isFinished() );
 }
 
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(isFinished_FixedsizeMulti) {
     BOOST_CHECK(  !keyword.isFinished() );
     keyword.addRawRecordString("1 2 3 3 /");
     BOOST_CHECK(  keyword.isFinished() );
-    
+
     RawRecordConstPtr record = keyword.getRecord(3);
     BOOST_CHECK_EQUAL( 4U , record->size() );
 

--- a/opm/parser/eclipse/RawDeck/tests/StarTokenTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/StarTokenTests.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE( ContainsStar_WithStar_ReturnsTrue ) {
     BOOST_CHECK_EQUAL( true , Opm::isStarToken("*1", countString, valueString) );
     BOOST_CHECK_EQUAL( true , Opm::isStarToken("1*", countString, valueString) );
     BOOST_CHECK_EQUAL( true , Opm::isStarToken("1*2", countString, valueString) );
-    
+
     BOOST_CHECK_EQUAL( false , Opm::isStarToken("12", countString, valueString) );
     BOOST_CHECK_EQUAL( false , Opm::isStarToken("'12*34'", countString, valueString) );
 }

--- a/opm/parser/eclipse/Units/ConversionFactors.hpp
+++ b/opm/parser/eclipse/Units/ConversionFactors.hpp
@@ -15,7 +15,7 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/ 
+*/
 
 #ifndef CONVERSION_FACTORS_HPP
 #define CONVERSION_FACTORS_HPP
@@ -40,7 +40,7 @@
    number of such examples is long.
 */
 
-      
+
 
 
 namespace Opm {

--- a/opm/parser/eclipse/Units/Dimension.cpp
+++ b/opm/parser/eclipse/Units/Dimension.cpp
@@ -26,7 +26,7 @@
 namespace Opm {
 
     Dimension::Dimension() {
-        
+
     }
 
     Dimension::Dimension(const std::string& name, double SIfactor, double SIoffset)

--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -15,7 +15,7 @@
 
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
-*/ 
+*/
 
 
 #include <iostream>
@@ -31,10 +31,10 @@
 
 namespace Opm {
 
-    UnitSystem::UnitSystem(const std::string& unitSystem) : 
+    UnitSystem::UnitSystem(const std::string& unitSystem) :
         m_name( unitSystem )
     {
-        
+
     }
 
     bool UnitSystem::hasDimension(const std::string& dimension) const {
@@ -52,17 +52,17 @@ namespace Opm {
 
 
     std::shared_ptr<const Dimension> UnitSystem::getDimension(const std::string& dimension) const {
-        if (hasDimension( dimension )) 
+        if (hasDimension( dimension ))
             return m_dimensions.at( dimension );
         else
             throw std::invalid_argument("Dimension: " + dimension + " not recognized ");
     }
 
-    
+
     void UnitSystem::addDimension(std::shared_ptr<const Dimension> dimension) {
         if (hasDimension(dimension->getName()))
             m_dimensions.erase( dimension->getName() );
-        
+
         m_dimensions.insert( std::make_pair(dimension->getName() , dimension));
     }
 
@@ -93,7 +93,7 @@ namespace Opm {
         }
         return std::shared_ptr<Dimension>(Dimension::newComposite( dimension , SIfactor ));
     }
-    
+
 
 
     std::shared_ptr<const Dimension> UnitSystem::parse(const std::string& dimension) const {
@@ -116,7 +116,7 @@ namespace Opm {
 
             if (dividend->getSIOffset() != 0.0 || divisor->getSIOffset() != 0.0)
                 throw std::invalid_argument("Composite dimensions cannot currently require a conversion offset");
-        
+
             return std::shared_ptr<Dimension>( Dimension::newComposite( dimension , dividend->getSIScaling() / divisor->getSIScaling() ));
         } else {
             return parseFactor( dimension );
@@ -126,7 +126,7 @@ namespace Opm {
 
     bool UnitSystem::equal(const UnitSystem& other) const {
         bool equal_ = (m_dimensions.size() == other.m_dimensions.size());
-        
+
         if (equal_) {
             for (auto iter = m_dimensions.begin(); iter != m_dimensions.end(); ++iter) {
                 std::shared_ptr<const Dimension> dim = getDimension( iter->first );
@@ -137,7 +137,7 @@ namespace Opm {
                         equal_ = false;
                 } else
                     equal_ = false;
-                
+
             }
         }
         return equal_;
@@ -146,7 +146,7 @@ namespace Opm {
 
     UnitSystem * UnitSystem::newMETRIC() {
         UnitSystem * system = new UnitSystem("Metric");
-        
+
         system->addDimension("1"         , 1.0);
         system->addDimension("Pressure"  , Metric::Pressure );
         system->addDimension("Temperature", Metric::Temperature, Metric::TemperatureOffset);
@@ -167,10 +167,10 @@ namespace Opm {
     }
 
 
-    
+
     UnitSystem * UnitSystem::newFIELD() {
         UnitSystem * system = new UnitSystem("Field");
-        
+
         system->addDimension("1"    , 1.0);
         system->addDimension("Pressure", Field::Pressure );
         system->addDimension("Temperature", Field::Temperature, Field::TemperatureOffset);

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -39,14 +39,14 @@ namespace Opm {
         std::shared_ptr<const Dimension> getDimension(const std::string& dimension) const;
         bool hasDimension(const std::string& dimension) const;
         bool equal(const UnitSystem& other) const;
-        
+
         std::shared_ptr<const Dimension> parse(const std::string& dimension) const;
 
         static UnitSystem * newMETRIC();
         static UnitSystem * newFIELD();
     private:
         std::shared_ptr<const Dimension> parseFactor(const std::string& dimension) const;
-        
+
         const std::string m_name;
         std::map<std::string , std::shared_ptr<const Dimension> > m_dimensions;
     };

--- a/opm/parser/eclipse/Units/tests/UnitTests.cpp
+++ b/opm/parser/eclipse/Units/tests/UnitTests.cpp
@@ -117,11 +117,11 @@ BOOST_AUTO_TEST_CASE(UnitSystemParseInvalidThrows) {
 
     system.addDimension("Length" , 3.00 );
     system.addDimension("Time" , 9.0 );
-    
+
     std::shared_ptr<const Dimension> volumePerTime = system.parse("Length*Length*Length/Time");
     BOOST_CHECK_EQUAL("Length*Length*Length/Time" , volumePerTime->getName() );
     BOOST_CHECK_EQUAL(3.0 , volumePerTime->getSIScaling());
-}    
+}
 
 
 

--- a/opm/parser/share/keywords/000_Eclipse100/T/TSTEP
+++ b/opm/parser/share/keywords/000_Eclipse100/T/TSTEP
@@ -1,5 +1,5 @@
 {"name" : "TSTEP" ,
- "sections" : ["SCHEDULE"], 
+ "sections" : ["SCHEDULE"],
  "size" : 1,
  "items" : [{
    "name" : "step_list" ,

--- a/opm/parser/share/keywords/000_Eclipse100/W/WPOLYMER
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WPOLYMER
@@ -1,7 +1,7 @@
 {
   "name" : "WPOLYMER",
   "sections" : [ "SPECIAL", "SCHEDULE" ],
-  "items" : 
+  "items" :
     [{"name" : "WELL"                        , "value_type" : "STRING"},
      {"name" : "POLYMER_CONCENTRATION"       , "value_type" : "DOUBLE" , "dimension" : "PolymerDensity"},
      {"name" : "SALT_CONCENTRATION"          , "value_type" : "DOUBLE" , "dimension" : "PolymerDensity"},


### PR DESCRIPTION
this is just the result of

```
find -iname "*.[ch]pp" | xargs sed -i "s/ *$//"
find opm/parser/share/keywords -type f |  xargs sed -i "s/ *$//"
```

so if it causes conflicts with other patches, the others should get
priority. The rationale behind this patch is that some people tell
their editor to remove white space which leads to larger than
necessary patches...
