### PR TITLE
make the build fail if a JSON keyword definition file could not be parsed

### DIFF
--- a/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
+++ b/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
@@ -215,9 +215,10 @@ static void scanKeyword(const boost::filesystem::path& file , KeywordMapType& ke
     Json::JsonObject * jsonKeyword;
     try {
         jsonKeyword = new Json::JsonObject(file);
-    } catch(...) {
-        std::cerr << "Parsing json config file: " << file.string() << " failed - keyword skipped." << std::endl;
-        return;
+    } catch(const std::exception& e) {
+        std::cerr << "Parsing JSON keyword definition from file '" << file.string() << "' failed: "
+                  << e.what() << "\n";
+        std::exit(1);
     }
 
     {


### PR DESCRIPTION
this makes adding or modifying keywords more fool-proof because parse errors can no longer so easily be overlooked.
