### PR TITLE
use UNKNOWN as size type for table-like keywords

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.cpp
@@ -38,10 +38,6 @@ size_t MultiRecordTable::numTables(Opm::DeckKeywordConstPtr keyword)
             ++ result;
     }
 
-    // the last empty record of a keyword seems to go MIA for some
-    // strange reason...
-    ++result;
-
     return result;
 }
 

--- a/opm/parser/eclipse/EclipseState/checkDeck.cpp
+++ b/opm/parser/eclipse/EclipseState/checkDeck.cpp
@@ -18,6 +18,7 @@
  */
 #include "checkDeck.hpp"
 
+#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 
 namespace Opm {
@@ -28,13 +29,71 @@ bool checkDeck(DeckConstPtr deck, LoggerPtr logger, size_t enabledChecks) {
     if (enabledChecks & UnknownKeywords) {
         size_t keywordIdx = 0;
         for (; keywordIdx < deck->size(); keywordIdx++) {
-            const auto& keyword = deck->getKeyword(keywordIdx);
+            const auto keyword = deck->getKeyword(keywordIdx);
             if (!keyword->hasParserKeyword()) {
                 std::string msg("Keyword '" + keyword->name() + "' is unknown.");
                 logger->addWarning(keyword->getFileName(), keyword->getLineNumber(), msg);
                 deckValid = false;
             }
         }
+    }
+
+    // make sure that the sizes of the tables have been specified correctly
+    if (enabledChecks & TableSizes) {
+        size_t keywordIdx = 0;
+        for (; keywordIdx < deck->size(); keywordIdx++) {
+            const auto keyword = deck->getKeyword(keywordIdx);
+            if (!keyword->hasParserKeyword())
+                continue;
+
+            const auto parserKeyword = keyword->getParserKeyword();
+            if (parserKeyword->getSizeType() != OTHER_KEYWORD_IN_DECK)
+                continue;
+
+            const auto& sizeDefPair = parserKeyword->getSizeDefinitionPair();
+            const std::string& sizeKeywordName = sizeDefPair.first;
+            if (!deck->hasKeyword(sizeKeywordName)) {
+                std::string msg("Deck does not feature the keyword '" + sizeKeywordName +
+                                "' which specifies the size of keyword " + keyword->name() + ".");
+                logger->addWarning(keyword->getFileName(), keyword->getLineNumber(), msg);
+                deckValid = false;
+                continue;
+            }
+
+            const auto sizeKeyword = deck->getKeyword(sizeKeywordName);
+            const std::string& sizeItemName = sizeDefPair.second;
+            DeckItemConstPtr deckItem;
+            try {
+                deckItem = sizeKeyword->getRecord(0)->getItem(sizeItemName);
+            }
+            catch (const std::invalid_argument& e) {
+                // this error is quite bad: it is an incorrect (or at least inconsistent)
+                // keyword definition. throwing an exception here does not seem
+                // appropriate, though...
+                std::string msg("Keyword '" + sizeKeywordName +
+                                "' does not contain an item named '" + sizeItemName +
+                                "' which is specified as the size of keyword " + keyword->name() + ".");
+                logger->addError(keyword->getFileName(), keyword->getLineNumber(), msg);
+                logger->addError(keyword->getFileName(), keyword->getLineNumber(),
+                                 "(this is an error in opm-parser, please create send a bug "
+                                 "report to opm@opm-project.org)" );
+                deckValid = false;
+                continue;
+            }
+
+            int kwMaxSize = sizeKeyword->getRecord(0)->getItem(sizeItemName)->getInt(0);
+            if (static_cast<int>(keyword->size()) > kwMaxSize) {
+                std::string msg("Keyword '" + keyword->name() +
+                                "' has " + std::to_string((long long) keyword->size()) +
+                                " items but at most " + std::to_string((long long) kwMaxSize) +
+                                " are allowed by the " + sizeItemName + " item of keyword " +
+                                sizeKeywordName + ".");
+                logger->addWarning(keyword->getFileName(), keyword->getLineNumber(), msg);
+                deckValid = false;
+                continue;
+            }
+        }
+
     }
 
     // make sure all mandatory sections are present and that their order is correct

--- a/opm/parser/eclipse/EclipseState/checkDeck.hpp
+++ b/opm/parser/eclipse/EclipseState/checkDeck.hpp
@@ -32,6 +32,8 @@ enum DeckChecks {
 
     UnknownKeywords = 0x0004,
 
+    TableSizes = 0x0008,
+
     AllChecks = 0xffff
 };
 

--- a/opm/parser/eclipse/IntegrationTests/ParseDATAWithDefault.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseDATAWithDefault.cpp
@@ -23,6 +23,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
 
+#include <opm/parser/eclipse/EclipseState/checkDeck.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -45,17 +46,38 @@ ENDSCALE\n\
      1*     1*     2 /\n\
 \n\
 ENKRVD\n\
-100 1   2  3  4  5  6  7   200 11 22 33 44 55 66 77 /\n\
+100 1   2  3  4  5  6  7\n\
+200 11 22 33 44 55 66 77 /\n\
 ";
 
 
 
-BOOST_AUTO_TEST_CASE( ParseMissingRECORD_THrows) {
+BOOST_AUTO_TEST_CASE( ParseMissingRECORD) {
     ParserPtr parser(new Parser());
-    BOOST_CHECK_THROW( parser->parseString( dataMissingRecord ) , std::invalid_argument);
+    const auto deck = parser->parseString(dataMissingRecord);
+
+    Opm::LoggerPtr logger(new Opm::Logger());
+    BOOST_CHECK( Opm::checkDeck(deck, logger, Opm::TableSizes));
 }
 
+const char *dataWrongTableSize = "\n\
+ENDSCALE\n\
+     1*     1*     1 /\n\
+\n\
+ENKRVD\n\
+100 1   2  3  4  5  6  7 /\n\
+200 11 22 33 44 55 66 77 /\n\
+";
 
+
+
+BOOST_AUTO_TEST_CASE( ParseWrongTableSize) {
+    ParserPtr parser(new Parser());
+    const auto deck = parser->parseString(dataWrongTableSize);
+
+    Opm::LoggerPtr logger(new Opm::Logger());
+    BOOST_CHECK(!Opm::checkDeck(deck, logger, Opm::TableSizes));
+}
 
 
 const char *data = "\n\

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
@@ -64,7 +64,7 @@ PVTG\n\
 static void check_parser(ParserPtr parser) {
     DeckPtr deck =  parser->parseString(pvtgData);
     DeckKeywordConstPtr kw1 = deck->getKeyword("PVTG" , 0);
-    BOOST_CHECK_EQUAL(5U , kw1->size());
+    BOOST_CHECK_EQUAL(6U , kw1->size());
 
     DeckRecordConstPtr record0 = kw1->getRecord(0);
     DeckRecordConstPtr record1 = kw1->getRecord(1);

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
@@ -64,7 +64,7 @@ PVTO\n\
 static void check_parser(ParserPtr parser) {
     DeckPtr deck =  parser->parseString(pvtoData);
     DeckKeywordConstPtr kw1 = deck->getKeyword("PVTO" , 0);
-    BOOST_CHECK_EQUAL(5U , kw1->size());
+    BOOST_CHECK_EQUAL(6U , kw1->size());
 
     DeckRecordConstPtr record0 = kw1->getRecord(0);
     DeckRecordConstPtr record1 = kw1->getRecord(1);

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -352,21 +352,14 @@ namespace Opm {
 
                 return RawKeywordPtr(new RawKeyword(keywordString , rawSizeType , parserState->dataFile.string(), parserState->lineNR));
             } else {
-                size_t targetSize;
-
                 if (parserKeyword->hasFixedSize())
-                    targetSize = parserKeyword->getFixedSize();
+                    return RawKeywordPtr(new RawKeyword(keywordString, parserState->dataFile.string() , parserState->lineNR , parserKeyword->getFixedSize(), parserKeyword->isTableCollection()));
                 else {
-                    const std::pair<std::string, std::string> sizeKeyword = parserKeyword->getSizeDefinitionPair();
-                    DeckKeywordConstPtr sizeDefinitionKeyword = parserState->deck->getKeyword(sizeKeyword.first);
-                    DeckItemPtr sizeDefinitionItem;
-                    {
-                        DeckRecordConstPtr record = sizeDefinitionKeyword->getRecord(0);
-                        sizeDefinitionItem = record->getItem(sizeKeyword.second);
-                    }
-                    targetSize = sizeDefinitionItem->getInt(0);
+                    // we do not require the presence and correctness of the
+                    // size-definition keyword here (e.g. TABDIMS for the saturation
+                    // tables). Instead, this can be deteced by Opm::checkDeck()
+                    return RawKeywordPtr(new RawKeyword(keywordString, Raw::UNKNOWN, parserState->dataFile.string(), parserState->lineNR));
                 }
-                return RawKeywordPtr(new RawKeyword(keywordString, parserState->dataFile.string() , parserState->lineNR , targetSize , parserKeyword->isTableCollection()));
             }
         } else
            throw std::invalid_argument("Keyword " + keywordString + " not recognized ");
@@ -398,7 +391,6 @@ namespace Opm {
 
             boost::algorithm::trim_right(line); // Removing garbage (eg. \r)
             line = doSpecialHandlingForTitleKeyword(line, parserState);
-            std::string keywordString;
             parserState->lineNR++;
 
             // skip empty lines
@@ -406,12 +398,42 @@ namespace Opm {
                 continue;
 
             if (parserState->rawKeyword == NULL) {
-                if (RawKeyword::isKeywordPrefix(line, keywordString)) {
-                    parserState->rawKeyword = createRawKeyword(keywordString, parserState);
+                // else try to create a new keyword
+                std::string keywordName;
+                if (RawKeyword::isKeywordPrefix(line, keywordName))
+                    parserState->rawKeyword = createRawKeyword(keywordName, parserState);
+                else {
+                    // to prevent the user from being flooded by warnings, only add a
+                    // warning for the first unparsable line if the unparsable lines are
+                    // consecutive...
+                    static std::string lastWarningFile = parserState->dataFile.string();
+                    static int lastWarningLine = -100;
+
+                    int curLine = parserState->lineNR;
+                    if (parserState->rawKeyword)
+                        curLine = parserState->rawKeyword->getLineNR();
+
+                    if (lastWarningFile == parserState->dataFile.string()
+                        && lastWarningLine < curLine - 1)
+                    {
+                        parserState->logger.addWarning(parserState->dataFile.string(),
+                                                       parserState->lineNR,
+                                                       "Can't parse line: Expected beginning of keyword");
+                    }
+
+                    lastWarningFile = parserState->dataFile.string();
+                    lastWarningLine = curLine;
                 }
             } else {
                 if (parserState->rawKeyword->getSizeType() == Raw::UNKNOWN) {
-                    if (isRecognizedKeyword(line)) {
+                    // for unknown keywords we can't know if the first item of the next
+                    // line is a string or a keyword name which we don't know. We thus
+                    // assume that all records of keywords with an unknown number of
+                    // records start with an item which is not a valid keyword string 
+                    // (e.g. a number)...
+                    std::string keywordName = ParserKeyword::getDeckName(line);
+                    if (ParserKeyword::validDeckName(keywordName))
+                    {
                         parserState->rawKeyword->finalizeUnknownSize();
                         parserState->nextKeyword = line;
                         return true;


### PR DESCRIPTION
this allows the parser not to rely on the user-specified table
dimension which is demoted to a semantic check that, produces a
warning in the log if a mistake is detected.

The prime motivation for this is that it is a way to specify tables in decks which do not feature the TABDIMS keyword.

The reason why this is a separate PR is that github prevented Joakim from reopening #346. As an alternative to setting all keywords which determine their size using a different keyword to sizeType UNKNOWN, a new size type for tables could be introduced. since this solution requires more extensive changes to the low level code and probably also some additions to the JSON keyword descriptions of table keywords, it is a thing for after the holidays. (if it is decided to be the way to go.)