### PR TITLE
Open well shut completions

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -481,14 +481,8 @@ namespace Opm {
                 }
                 else if(!haveCompletionData) {
                     WellCommon::StatusEnum status = WellCommon::StatusFromString( record->getItem("STATUS")->getTrimmedString(0));
+                    well->setStatus(currentStep, status);
 
-                    if ((WellCommon::StatusEnum::OPEN == status) && well->getCompletions(currentStep)->allCompletionsShut()) {
-                      std::cerr << "ERROR when handling WELOPEN for well "<< well->name()  << ": Cannot open a well where all completions are shut" << std::endl;
-                      throw std::exception();
-                    } else
-                    {
-                      well->setStatus(currentStep, status);
-                    }
                 }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -129,7 +129,13 @@ namespace Opm {
     }
 
     void Well::setStatus(size_t timeStep, WellCommon::StatusEnum status) {
-        m_status->add( timeStep , status );
+        if ((WellCommon::StatusEnum::OPEN == status) && this->getCompletions(timeStep)->allCompletionsShut()) {
+            std::cerr << "ERROR when handling WELOPEN for well "<< this->name()  << ": Cannot open a well where all completions are shut" << std::endl;
+        } else
+        {
+            m_status->add( timeStep , status );
+        }
+
     }
 
     bool Well::isProducer(size_t timeStep) const {

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
 
 
 
-BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_OpenWellWithShutCompletionsThrowsExcpetion) {
+BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompletionsDoNotOpenWell) {
   Opm::Parser parser;
   std::string input =
           "START             -- 0 \n"
@@ -439,7 +439,13 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_OpenWellWithShutCompletionsTh
 
 
   DeckPtr deck = parser.parseString(input);
-  BOOST_CHECK_THROW(Schedule schedule(deck), std::exception);
+  Schedule schedule(deck);
+  WellPtr well;
+  well = schedule.getWell("OP_1");
+  size_t currentStep = 3;
+  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
+  currentStep = 3;
+  BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -444,7 +444,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
   well = schedule.getWell("OP_1");
   size_t currentStep = 3;
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
-  currentStep = 3;
+  currentStep = 4;
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
 }
 


### PR DESCRIPTION
Change so that the status of a well do not change to open if there is no open completions.

Fredrik Gundersen
fgun@statoil.com