### PR TITLE
Temperature dependent viscosity v2

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -191,6 +191,9 @@ EclipseState/Tables/RsvdTable.hpp
 EclipseState/Tables/PvtoInnerTable.hpp
 EclipseState/Tables/RvvdTable.hpp
 EclipseState/Tables/RtempvdTable.hpp
+EclipseState/Tables/OilvisctTable.hpp
+EclipseState/Tables/GasvisctTable.hpp
+EclipseState/Tables/WatvisctTable.hpp
 EclipseState/Tables/PvtgOuterTable.hpp
 #
 Utility/WconinjeWrapper.hpp

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -158,12 +158,20 @@ namespace Opm {
         return m_enptvdTables;
     }
 
+    const std::vector<GasvisctTable>& EclipseState::getGasvisctTables() const {
+        return m_gasvisctTables;
+    }
+
     const std::vector<ImkrvdTable>& EclipseState::getImkrvdTables() const {
         return m_imkrvdTables;
     }
 
     const std::vector<ImptvdTable>& EclipseState::getImptvdTables() const {
         return m_imptvdTables;
+    }
+
+    const std::vector<OilvisctTable>& EclipseState::getOilvisctTables() const {
+        return m_oilvisctTables;
     }
 
     const std::vector<PlyadsTable>& EclipseState::getPlyadsTables() const {
@@ -214,6 +222,10 @@ namespace Opm {
         return m_rtempvdTables;
     }
 
+    const std::vector<WatvisctTable>& EclipseState::getWatvisctTables() const {
+        return m_watvisctTables;
+    }
+
     const std::vector<SgofTable>& EclipseState::getSgofTables() const {
         return m_sgofTables;
     }
@@ -249,8 +261,10 @@ namespace Opm {
     void EclipseState::initTables(DeckConstPtr deck, LoggerPtr logger) {
         initSimpleTables(deck, logger, "ENKRVD", m_enkrvdTables);
         initSimpleTables(deck, logger, "ENPTVD", m_enptvdTables);
+        initSimpleTables(deck, logger, "GASVISCT", m_gasvisctTables);
         initSimpleTables(deck, logger, "IMKRVD", m_imkrvdTables);
         initSimpleTables(deck, logger, "IMPTVD", m_imptvdTables);
+        initSimpleTables(deck, logger, "OILVISCT", m_oilvisctTables);
         initSimpleTables(deck, logger, "PLYADS", m_plyadsTables);
         initSimpleTables(deck, logger, "PLYMAX", m_plymaxTables);
         initSimpleTables(deck, logger, "PLYROCK", m_plyrockTables);
@@ -263,6 +277,7 @@ namespace Opm {
         initSimpleTables(deck, logger, "SOF2", m_sof2Tables);
         initSimpleTables(deck, logger, "SWOF", m_swofTables);
         initSimpleTables(deck, logger, "SWFN", m_swfnTables);
+        initSimpleTables(deck, logger, "WATVISCT", m_watvisctTables);
 
         // the ROCKTAB table comes with additional fun because the number of columns
         //depends on the presence of the RKTRMDIR keyword...

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -34,8 +34,10 @@
 
 #include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
@@ -48,6 +50,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
@@ -94,8 +97,10 @@ namespace Opm {
         // not present in the deck, the corresponding vector is of size zero.
         const std::vector<EnkrvdTable>& getEnkrvdTables() const;
         const std::vector<EnptvdTable>& getEnptvdTables() const;
+        const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<ImkrvdTable>& getImkrvdTables() const;
         const std::vector<ImptvdTable>& getImptvdTables() const;
+        const std::vector<OilvisctTable>& getOilvisctTables() const;
         const std::vector<PlyadsTable>& getPlyadsTables() const;
         const std::vector<PlymaxTable>& getPlymaxTables() const;
         const std::vector<PlyrockTable>& getPlyrockTables() const;
@@ -112,6 +117,7 @@ namespace Opm {
         const std::vector<Sof2Table>& getSof2Tables() const;
         const std::vector<SwofTable>& getSwofTables() const;
         const std::vector<SwfnTable>& getSwfnTables() const;
+        const std::vector<WatvisctTable>& getWatvisctTables() const;
 
         // the unit system used by the deck. note that it is rarely needed to convert
         // units because internally to opm-parser everything is represented by SI
@@ -217,8 +223,10 @@ namespace Opm {
 
         std::vector<EnkrvdTable> m_enkrvdTables;
         std::vector<EnptvdTable> m_enptvdTables;
+        std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<ImkrvdTable> m_imkrvdTables;
         std::vector<ImptvdTable> m_imptvdTables;
+        std::vector<OilvisctTable> m_oilvisctTables;
         std::vector<PlyadsTable> m_plyadsTables;
         std::vector<PlymaxTable> m_plymaxTables;
         std::vector<PlyrockTable> m_plyrockTables;
@@ -235,6 +243,7 @@ namespace Opm {
         std::vector<Sof2Table> m_sof2Tables;
         std::vector<SwofTable> m_swofTables;
         std::vector<SwfnTable> m_swfnTables;
+        std::vector<WatvisctTable> m_watvisctTables;
 
         std::set<enum Phase::PhaseEnum> phases;
         std::string m_title;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -191,6 +191,10 @@ namespace Opm {
         }
 
         void initRocktabTables(DeckConstPtr deck, LoggerPtr logger);
+        void initGasvisctTables(DeckConstPtr deck,
+                                LoggerPtr logger,
+                                const std::string& keywordName,
+                                std::vector<GasvisctTable>& tableVector);
 
         void setMULTFLT(std::shared_ptr<const Section> section, LoggerPtr logger) const;
         void initMULTREGT(DeckConstPtr deck, LoggerPtr logger);

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -35,22 +35,72 @@ namespace Opm {
          * \brief Read the GASVISCT keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckConstPtr deck, Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
-                             std::vector<std::string>{
-                                 "Temperature",
-                                 "Viscosity",
-                                 "Unknown" // the RM mentions a third in the example but nowhere else. WTF?
-                             },
-                             recordIdx,
-                             /*firstEntityOffset=*/0);
+            int numComponents = deck->getKeyword("COMPS")->getRecord(0)->getItem(0)->getInt(0);
 
+            auto temperatureDimension = deck->getActiveUnitSystem()->getDimension("Temperature");
+            auto viscosityDimension = deck->getActiveUnitSystem()->getDimension("Viscosity");
+
+            // create the columns: temperature plus one viscosity column per component
+            std::vector<std::string> columnNames;
+            columnNames.push_back("Temperature");
+
+            for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
+                columnNames.push_back("Viscosity" + std::to_string(compIdx));
+
+            ParentType::createColumns(columnNames);
+
+            // extract the actual data from the deck
+            Opm::DeckRecordConstPtr deckRecord =
+                keyword->getRecord(recordIdx);
+
+            size_t numFlatItems = getNumFlatItems(deckRecord);
+            if ( numFlatItems % numColumns() != 0)
+                throw std::runtime_error("Number of columns in the data file is inconsistent "
+                                         "with the expected number for keyword GASVISCT");
+
+            for (size_t rowIdx = 0; rowIdx*numColumns() < numFlatItems; ++rowIdx) {
+                // add the current temperature
+                int deckItemIdx = rowIdx*numColumns();
+
+                bool isDefaulted = this->getFlatIsDefaulted(deckRecord, deckItemIdx);
+                this->m_valueDefaulted[0].push_back(isDefaulted);
+
+                if (!isDefaulted) {
+                    double T = this->getFlatRawDoubleData(deckRecord, deckItemIdx);
+                    this->m_columns[0].push_back(temperatureDimension->convertRawToSi(T));
+                }
+
+                // deal with the component viscosities
+                for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                    deckItemIdx = rowIdx*numColumns() + compIdx + 1;
+                    size_t columnIdx = compIdx + 1;
+
+                    isDefaulted = this->getFlatIsDefaulted(deckRecord, deckItemIdx);
+                    this->m_valueDefaulted[columnIdx].push_back(isDefaulted);
+
+                    if (!isDefaulted) {
+                        double mu = this->getFlatRawDoubleData(deckRecord, deckItemIdx);
+                        this->m_columns[columnIdx].push_back(viscosityDimension->convertRawToSi(mu));
+                    }
+                }
+            }
+
+            // make sure that the columns agree with the keyword specification of the
+            // reference manual. (actually, the documentation does not say anyting about
+            // whether items of these columns are defaultable or not, so we assume here
+            // that they are not.)
             ParentType::checkNonDefaultable("Temperature");
             ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
 
-            ParentType::checkNonDefaultable("Viscosity");
-            ParentType::checkMonotonic("Viscosity", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
+                std::string columnName = "Viscosity" + std::to_string(compIdx);
+                ParentType::checkNonDefaultable(columnName);
+                ParentType::checkMonotonic(columnName,
+                                           /*isAscending=*/true,
+                                           /*strictlyMonotonic=*/false);
+            }
         }
 
     public:
@@ -62,8 +112,8 @@ namespace Opm {
         const std::vector<double> &getTemperatureColumn() const
         { return ParentType::getColumn(0); }
 
-        const std::vector<double> &getGasViscosityColumn() const
-        { return ParentType::getColumn(1); }
+        const std::vector<double> &getGasViscosityColumn(size_t compIdx) const
+        { return ParentType::getColumn(1 + compIdx); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -1,0 +1,70 @@
+/*
+  Copyright (C) 2015 by Andreas Lauser
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_GASVISCT_TABLE_HPP
+#define	OPM_PARSER_GASVISCT_TABLE_HPP
+
+#include "SingleRecordTable.hpp"
+
+namespace Opm {
+    // forward declaration
+    class EclipseState;
+
+    class GasvisctTable : protected SingleRecordTable {
+        typedef SingleRecordTable ParentType;
+
+        friend class EclipseState;
+        GasvisctTable() = default;
+
+        /*!
+         * \brief Read the GASVISCT keyword and provide some convenience
+         *        methods for it.
+         */
+        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        {
+            ParentType::init(keyword,
+                             std::vector<std::string>{
+                                 "Temperature",
+                                 "Viscosity",
+                                 "Unknown" // the RM mentions a third in the example but nowhere else. WTF?
+                             },
+                             recordIdx,
+                             /*firstEntityOffset=*/0);
+
+            ParentType::checkNonDefaultable("Temperature");
+            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
+
+            ParentType::checkNonDefaultable("Viscosity");
+            ParentType::checkMonotonic("Viscosity", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+        }
+
+    public:
+        using ParentType::numTables;
+        using ParentType::numRows;
+        using ParentType::numColumns;
+        using ParentType::evaluate;
+
+        const std::vector<double> &getTemperatureColumn() const
+        { return ParentType::getColumn(0); }
+
+        const std::vector<double> &getGasViscosityColumn() const
+        { return ParentType::getColumn(1); }
+    };
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -1,0 +1,69 @@
+/*
+  Copyright (C) 2015 by Andreas Lauser
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_OILVISCT_TABLE_HPP
+#define	OPM_PARSER_OILVISCT_TABLE_HPP
+
+#include "SingleRecordTable.hpp"
+
+namespace Opm {
+    // forward declaration
+    class EclipseState;
+
+    class OilvisctTable : protected SingleRecordTable {
+        typedef SingleRecordTable ParentType;
+
+        friend class EclipseState;
+        OilvisctTable() = default;
+
+        /*!
+         * \brief Read the OILVISCT keyword and provide some convenience
+         *        methods for it.
+         */
+        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        {
+            ParentType::init(keyword,
+                             std::vector<std::string>{
+                                 "Temperature",
+                                 "Viscosity"
+                             },
+                             recordIdx,
+                             /*firstEntityOffset=*/0);
+
+            ParentType::checkNonDefaultable("Temperature");
+            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
+
+            ParentType::checkNonDefaultable("Viscosity");
+            ParentType::checkMonotonic("Viscosity", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+        }
+
+    public:
+        using ParentType::numTables;
+        using ParentType::numRows;
+        using ParentType::numColumns;
+        using ParentType::evaluate;
+
+        const std::vector<double> &getTemperatureColumn() const
+        { return ParentType::getColumn(0); }
+
+        const std::vector<double> &getOilViscosityColumn() const
+        { return ParentType::getColumn(1); }
+    };
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.cpp
@@ -243,6 +243,20 @@ size_t SingleRecordTable::getNumFlatItems(Opm::DeckRecordConstPtr deckRecord) co
     return result;
 }
 
+double SingleRecordTable::getFlatRawDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
+{
+    size_t itemFirstFlatIdx = 0;
+    for (unsigned i = 0; i < deckRecord->size(); ++ i) {
+        Opm::DeckItemConstPtr item = deckRecord->getItem(i);
+        if (itemFirstFlatIdx + item->size() > flatItemIdx)
+            return item->getRawDouble(flatItemIdx - itemFirstFlatIdx);
+        else
+            itemFirstFlatIdx += item->size();
+    }
+
+    throw std::range_error("Tried to access out-of-range flat item");
+}
+
 double SingleRecordTable::getFlatSiDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
 {
     size_t itemFirstFlatIdx = 0;

--- a/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp
@@ -75,6 +75,7 @@ namespace Opm {
          * X coordinate.
          */
         double evaluate(const std::string& columnName, double xPos) const;
+
     protected:
         void checkNonDefaultable(const std::string& columnName);
         void checkMonotonic(const std::string& columnName,
@@ -84,6 +85,7 @@ namespace Opm {
         void applyDefaultsLinear(const std::string& columnName);
         void createColumns(const std::vector<std::string> &columnNames);
         size_t getNumFlatItems(Opm::DeckRecordConstPtr deckRecord) const;
+        double getFlatRawDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const;
         double getFlatSiDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const;
         bool getFlatIsDefaulted(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const;
 

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -1,0 +1,69 @@
+/*
+  Copyright (C) 2015 by Andreas Lauser
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_WATVISCT_TABLE_HPP
+#define	OPM_PARSER_WATVISCT_TABLE_HPP
+
+#include "SingleRecordTable.hpp"
+
+namespace Opm {
+    // forward declaration
+    class EclipseState;
+
+    class WatvisctTable : protected SingleRecordTable {
+        typedef SingleRecordTable ParentType;
+
+        friend class EclipseState;
+        WatvisctTable() = default;
+
+        /*!
+         * \brief Read the WATVISCT keyword and provide some convenience
+         *        methods for it.
+         */
+        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        {
+            ParentType::init(keyword,
+                             std::vector<std::string>{
+                                 "Temperature"
+                                 "Viscosity"
+                             },
+                             recordIdx,
+                             /*firstEntityOffset=*/0);
+
+            ParentType::checkNonDefaultable("Temperature");
+            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
+
+            ParentType::checkNonDefaultable("Viscosity");
+            ParentType::checkMonotonic("Viscosity", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+        }
+
+    public:
+        using ParentType::numTables;
+        using ParentType::numRows;
+        using ParentType::numColumns;
+        using ParentType::evaluate;
+
+        const std::vector<double> &getTemperatureColumn() const
+        { return ParentType::getColumn(0); }
+
+        const std::vector<double> &getWaterViscosityColumn() const
+        { return ParentType::getColumn(1); }
+    };
+}
+
+#endif

--- a/opm/parser/share/keywords/000_Eclipse100/O/OILVISCT
+++ b/opm/parser/share/keywords/000_Eclipse100/O/OILVISCT
@@ -1,0 +1,15 @@
+{
+  "name": "OILVISCT",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NTPVT"
+  },
+  "items" : [{
+    "name":"DATA",
+    "value_type": "DOUBLE",
+    "size_type": "ALL",
+
+    "dimension" : ["Temperature", "Viscosity"]
+  }]
+}

--- a/opm/parser/share/keywords/000_Eclipse100/W/WATVISCT
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WATVISCT
@@ -1,0 +1,15 @@
+{
+  "name": "WATVISCT",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NTPVT"
+  },
+  "items" : [{
+    "name":"DATA",
+    "value_type": "DOUBLE",
+    "size_type": "ALL",
+
+    "dimension" : ["Temperature", "Viscosity"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/G/GASVISCT
+++ b/opm/parser/share/keywords/001_Eclipse300/G/GASVISCT
@@ -1,0 +1,17 @@
+{
+  "name": "GASVISCT",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NTPVT"
+  },
+  "items" : [{
+    "name":"DATA",
+    "value_type": "DOUBLE",
+    "size_type": "ALL",
+
+    "comment":"The RM says that the table has two columns, (and documents only those) but at the ",
+    "comment":"same time, the example given specifies three columns. WTF?",
+    "dimension" : ["Temperature", "Viscosity", "Viscosity"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/G/GASVISCT
+++ b/opm/parser/share/keywords/001_Eclipse300/G/GASVISCT
@@ -10,8 +10,8 @@
     "value_type": "DOUBLE",
     "size_type": "ALL",
 
-    "comment":"The RM says that the table has two columns, (and documents only those) but at the ",
-    "comment":"same time, the example given specifies three columns. WTF?",
-    "dimension" : ["Temperature", "Viscosity", "Viscosity"]
+    "comment":"The number of columns in this table depends on the number of gas components",
+    "comment":"(given by the COMPS keyword). Fun!",
+    "dimension" : ["ContextDependent"]
   }]
 }

--- a/opm/parser/share/keywords/001_Eclipse300/O/OILVTIM
+++ b/opm/parser/share/keywords/001_Eclipse300/O/OILVTIM
@@ -1,0 +1,8 @@
+{
+ "name" : "OILVTIM" ,
+ "sections" : ["PROPS"],
+
+ "items" : [
+  {"name": "INTERPOLATION_METHOD" , "value_type" : "STRING"}
+ ]
+}


### PR DESCRIPTION
this is the second go at the temperature dependent viscosity stuff for the parser. IMO #405 was done a bit prematurely because the error it contained did not regress anything and it only affected the GASVISCT keyword which is E300 only and is not (cannot be?) used by the current versions opm-core and opm-autdiff... (at least it is not useful for them as long as those modules do not handle compositional flow.)