### PR TITLE
Add the "COMPS" E300 keyword

### DIFF
--- a/opm/parser/share/keywords/001_Eclipse300/C/COMPS
+++ b/opm/parser/share/keywords/001_Eclipse300/C/COMPS
@@ -1,0 +1,7 @@
+{
+  "name": "COMPS",
+  "sections": ["RUNSPEC"],
+  "items": [
+    {"name" : "NUM_COMPS" , "value_type" : "INT"}
+  ]
+}


### PR DESCRIPTION
during #406, I noticed that the "COMPS" keyword was missing. this patch fixes that. Note that current code should not be affected at all because currently it only does E100 stuff and the parser will throw uppon encountering COMPS in a deck. (if I did not miss something recently, which may very well be.)