### PR TITLE
make it possible to copy them

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        EnkrvdTable() = default;
 
         /*!
          * \brief Read the ENKRVD keyword and provide some convenience
@@ -62,6 +61,8 @@ namespace Opm {
         }
 
     public:
+        EnkrvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
@@ -70,6 +71,10 @@ namespace Opm {
         // using this method is strongly discouraged but the current endpoint scaling
         // code makes it hard to avoid
         using ParentType::getColumn;
+
+        void assignFrom(const EnkrvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         /*!
          * \brief The datum depth for the remaining columns

--- a/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        EnptvdTable() = default;
 
         /*!
          * \brief Read the ENPTVD keyword and provide some convenience
@@ -64,6 +63,8 @@ namespace Opm {
         }
 
     public:
+        EnptvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
@@ -72,6 +73,10 @@ namespace Opm {
         // using this method is strongly discouraged but the current endpoint scaling
         // code makes it hard to avoid
         using ParentType::getColumn;
+
+        void assignFrom(const EnptvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getDepthColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/FullTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/FullTable.hpp
@@ -63,7 +63,7 @@ namespace Opm {
                 InnerTable *curRow = new InnerTable;
                 curRow->init(keyword,
                              /*recordIdx=*/m_outerTable->firstRecordIndex() + rowIdx);
-                m_innerTables.push_back(std::shared_ptr<const InnerTable>(curRow));
+                m_innerTables.push_back(std::shared_ptr<InnerTable>(curRow));
             }
         }
 
@@ -85,9 +85,17 @@ namespace Opm {
             return m_innerTables[rowIdx];
         }
 
+        void assignFrom(const FullTable& other) {
+            m_outerTable->assignFrom(*other.m_outerTable);
+            m_innerTables.resize(other.m_innerTables.size());
+
+            for (size_t i = 0; i < other.m_innerTables.size(); ++i)
+                m_innerTables[i]->assignFrom(*other.m_innerTables[i]);
+        }
+
     protected:
-        std::shared_ptr<const OuterTable> m_outerTable;
-        std::vector<std::shared_ptr<const InnerTable> > m_innerTables;
+        std::shared_ptr<OuterTable> m_outerTable;
+        std::vector<std::shared_ptr<InnerTable> > m_innerTables;
 
     };
 

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        GasvisctTable() = default;
 
         /*!
          * \brief Read the GASVISCT keyword and provide some convenience
@@ -104,10 +103,16 @@ namespace Opm {
         }
 
     public:
+        GasvisctTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const GasvisctTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getTemperatureColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        ImkrvdTable() = default;
 
         /*!
          * \brief Read the IMKRVD keyword and provide some convenience
@@ -62,10 +61,16 @@ namespace Opm {
         }
 
     public:
+        ImkrvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const ImkrvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         /*!
          * \brief The datum depth for the remaining columns

--- a/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        ImptvdTable() = default;
 
         /*!
          * \brief Read the IMPTVD keyword and provide some convenience
@@ -63,10 +62,16 @@ namespace Opm {
         }
 
     public:
+        ImptvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const ImptvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getDepthColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp
@@ -59,6 +59,13 @@ namespace Opm {
         { init(keyword, columnNames, tableIndex, firstEntityOffset); }
 #endif
 
+        void assignFrom(const MultiRecordTable& other) {
+            SingleRecordTable::assignFrom(other);
+
+            m_firstRecordIdx = other.m_firstRecordIdx;
+            m_numRecords = other.m_numRecords;
+        }
+
         /*!
          * \brief Returns the number of tables which can be found in a
          *        given keyword.

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        OilvisctTable() = default;
 
         /*!
          * \brief Read the OILVISCT keyword and provide some convenience
@@ -53,10 +52,16 @@ namespace Opm {
         }
 
     public:
+        OilvisctTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const OilvisctTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getTemperatureColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
@@ -64,6 +64,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const PlyadsTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getPolymerConcentrationColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        PlymaxTable() = default;
 
         /*!
          * \brief Read the PLYMAX keyword and provide some convenience
@@ -49,10 +48,16 @@ namespace Opm {
         }
 
     public:
+        PlymaxTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const PlymaxTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getPolymerConcentrationColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        PlyrockTable() = default;
 
         /*!
          * \brief Read the PLYROCK keyword and provide some convenience
@@ -67,12 +66,18 @@ namespace Opm {
         }
 
     public:
+        PlyrockTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
 
         // since this keyword is not necessarily monotonic, it cannot be evaluated!
         //using ParentType::evaluate;
+
+        void assignFrom(const PlyrockTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getDeadPoreVolumeColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        PlyviscTable() = default;
 
         /*!
          * \brief Read the PLYVISC keyword and provide some convenience
@@ -52,10 +51,16 @@ namespace Opm {
         }
 
     public:
+        PlyviscTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const PlyviscTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getPolymerConcentrationColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
@@ -30,8 +30,6 @@ namespace Opm {
 
         friend class EclipseState;
 
-        PvdgTable() = default;
-
         /*!
          * \brief Read the PVDG keyword and provide some convenience
          *        methods for it.
@@ -55,10 +53,16 @@ namespace Opm {
         }
 
     public:
+        PvdgTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const PvdgTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getPressureColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        PvdoTable() = default;
 
         /*!
          * \brief Read the PVDO keyword and provide some convenience
@@ -54,10 +53,16 @@ namespace Opm {
         }
 
     public:
+        PvdoTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const PvdoTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getPressureColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
@@ -60,6 +60,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const PvtgInnerTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getOilSolubilityColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgOuterTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgOuterTable.hpp
@@ -62,6 +62,10 @@ namespace Opm {
         using ParentType::firstRecordIndex;
         using ParentType::numRecords;
 
+        void assignFrom(const PvtgOuterTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getPressureColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp
@@ -46,6 +46,10 @@ namespace Opm {
         void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
         { init(keyword, tableIdx); }
 #endif
+
+        void assignFrom(const PvtgTable& other) {
+            ParentType::assignFrom(other);
+        }
     };
 
     typedef std::shared_ptr<PvtgTable> PvtgTablePtr;

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
@@ -61,6 +61,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const PvtoInnerTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getPressureColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoOuterTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoOuterTable.hpp
@@ -64,6 +64,10 @@ namespace Opm {
         using ParentType::firstRecordIndex;
         using ParentType::numRecords;
 
+        void assignFrom(const PvtoOuterTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getGasSolubilityColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
@@ -45,6 +45,9 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
+        void assignFrom(const PvtoTable& other) {
+            ParentType::assignFrom(other);
+        }
     };
 
     typedef std::shared_ptr<PvtoTable> PvtoTablePtr;

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        RocktabTable() = default;
 
         /*!
          * \brief Read the ROCKTAB keyword and provide some convenience
@@ -61,10 +60,16 @@ namespace Opm {
         }
 
     public:
+        RocktabTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const RocktabTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getPressureColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        RsvdTable() = default;
 
         /*!
          * \brief Read the RSVD keyword and provide some convenience
@@ -48,10 +47,16 @@ namespace Opm {
         }
 
     public:
+        RsvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const RsvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getDepthColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        RtempvdTable() = default;
 
         /*!
          * \brief Read the RTEMPVD keyword and provide some convenience
@@ -52,10 +51,16 @@ namespace Opm {
         }
 
     public:
+        RtempvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const RtempvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getDepthColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
@@ -30,8 +30,6 @@ namespace Opm {
 
         friend class EclipseState;
 
-        RvvdTable() = default;
-
         /*!
          * \brief Read the RSVD keyword and provide some convenience
          *        methods for it.
@@ -49,10 +47,16 @@ namespace Opm {
         }
 
     public:
+        RvvdTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const RvvdTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getDepthColumn() const
         { return ParentType::getColumn(0); }

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -63,6 +63,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const SgofTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getSgColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp
@@ -30,6 +30,11 @@
 namespace Opm {
     class SingleRecordTable {
     protected:
+#ifdef BOOST_TEST_MODULE
+    public:
+#endif
+        SingleRecordTable() = default;
+    protected:
         SingleRecordTable(const SingleRecordTable&) = default;
 
         /*!
@@ -44,8 +49,6 @@ namespace Opm {
                   size_t firstEntityOffset);
 
     public:
-        SingleRecordTable() = default;
-
         /*!
          * \brief Returns the number of tables in a keyword.
          *
@@ -67,6 +70,12 @@ namespace Opm {
         size_t numRows() const;
         const std::vector<double> &getColumn(const std::string &name) const;
         const std::vector<double> &getColumn(size_t colIdx) const;
+
+        void assignFrom(const SingleRecordTable& other) {
+            m_columnNames = other.m_columnNames;
+            m_columns = other.m_columns;
+            m_valueDefaulted = other.m_valueDefaulted;
+        }
 
         /*!
          * \brief Evaluate a column of the table at a given position.

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -62,6 +62,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const Sof2Table& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getSoColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -64,6 +64,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const SwfnTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getSwColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -63,6 +63,10 @@ namespace Opm {
         using ParentType::numColumns;
         using ParentType::evaluate;
 
+        void assignFrom(const SwofTable& other) {
+            ParentType::assignFrom(other);
+        }
+
         const std::vector<double> &getSwColumn() const
         { return ParentType::getColumn(0); }
 

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -29,7 +29,6 @@ namespace Opm {
         typedef SingleRecordTable ParentType;
 
         friend class EclipseState;
-        WatvisctTable() = default;
 
         /*!
          * \brief Read the WATVISCT keyword and provide some convenience
@@ -53,10 +52,16 @@ namespace Opm {
         }
 
     public:
+        WatvisctTable() = default;
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;
         using ParentType::evaluate;
+
+        void assignFrom(const WatvisctTable& other) {
+            ParentType::assignFrom(other);
+        }
 
         const std::vector<double> &getTemperatureColumn() const
         { return ParentType::getColumn(0); }


### PR DESCRIPTION
during OPM/opm-core#740 @atgeirr and me figured that it is the best solution to copy the tables from opm-parser in order to avoid object lifetime issues. This PR implements just that possibility.

to prevent accidential passing of table objects by value this is done
by makeing all "end user visible" table classes default-constructible
and adding an assignFrom() method...