### PR TITLE
allow the schedule object to be immutable

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -49,13 +49,16 @@ namespace Opm
         TimeMapConstPtr getTimeMap() const;
 
         size_t numWells() const;
-        size_t numWells(size_t timestep);
-        size_t getMaxNumCompletionsForWells(size_t timestep);
+        size_t numWells(size_t timestep) const;
+        size_t getMaxNumCompletionsForWells(size_t timestep) const;
         bool hasWell(const std::string& wellName) const;
         WellPtr getWell(const std::string& wellName) const;
         std::vector<WellPtr> getWells();
         std::vector<WellPtr> getWells(size_t timeStep);
         std::vector<WellPtr> getWells(const std::string& wellNamePattern);
+        std::vector<WellConstPtr> getWells() const;
+        std::vector<WellConstPtr> getWells(size_t timeStep) const;
+        std::vector<WellConstPtr> getWells(const std::string& wellNamePattern) const;
 
         GroupTreePtr getGroupTree(size_t t) const;
         size_t numGroups() const;


### PR DESCRIPTION
quite a few important methods (e.g., getWells()) missed the variants
which are marked as 'const'. this leads to the problem that these methods
can't be called on the object returned by EclipseState::getSchedule()
because it returns a ScheduleConstPtr. (this issue can possibly also be
worked-around by creating a new mutable copy of the schedule object
from the one returned by EclipseState::getSchedule(), but to me, this
seems to be a strikingly inelegant and inefficient hack...)

this fixes the compilation of the ECL blackoil simulator of eWoms...