### PR TITLE
Getwells const

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -727,10 +727,6 @@ namespace Opm {
         return m_wells.hasKey( wellName );
     }
 
-    WellPtr Schedule::getWell(const std::string& wellName) const {
-        return m_wells.get( wellName );
-    }
-
 
     std::vector<WellConstPtr> Schedule::getWells() const {
         return getWells(m_timeMap->size()-1);
@@ -751,6 +747,10 @@ namespace Opm {
         return wells;
     }
 
+
+    WellPtr Schedule::getWell(const std::string& wellName) const {
+        return m_wells.get( wellName );
+    }
 
     std::vector<WellPtr> Schedule::getWells(const std::string& wellNamePattern) const {
         std::vector<WellPtr> wells;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -752,22 +752,6 @@ namespace Opm {
         return wells;
     }
 
-    std::vector<WellPtr> Schedule::getWells(const std::string& wellNamePattern) {
-        std::vector<WellPtr> wells;
-        size_t wildcard_pos = wellNamePattern.find("*");
-        if (wildcard_pos == wellNamePattern.length()-1) {
-            for (auto wellIter = m_wells.begin(); wellIter != m_wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
-                if (wellNamePattern.compare (0, wildcard_pos, well->name(), 0, wildcard_pos) == 0) {
-                    wells.push_back (well);
-                }
-            }
-        }
-        else {
-            wells.push_back(getWell(wellNamePattern));
-        }
-        return wells;
-    }
 
     std::vector<WellConstPtr> Schedule::getWells() const {
         return getWells(m_timeMap->size()-1);
@@ -788,12 +772,13 @@ namespace Opm {
         return wells;
     }
 
-    std::vector<WellConstPtr> Schedule::getWells(const std::string& wellNamePattern) const {
-        std::vector<WellConstPtr> wells;
+
+    std::vector<WellPtr> Schedule::getWells(const std::string& wellNamePattern) {
+        std::vector<WellPtr> wells;
         size_t wildcard_pos = wellNamePattern.find("*");
         if (wildcard_pos == wellNamePattern.length()-1) {
             for (auto wellIter = m_wells.begin(); wellIter != m_wells.end(); ++wellIter) {
-                WellConstPtr well = *wellIter;
+                WellPtr well = *wellIter;
                 if (wellNamePattern.compare (0, wildcard_pos, well->name(), 0, wildcard_pos) == 0) {
                     wells.push_back (well);
                 }
@@ -804,6 +789,8 @@ namespace Opm {
         }
         return wells;
     }
+
+
 
     void Schedule::addGroup(const std::string& groupName, size_t timeStep) {
         if (!m_timeMap) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -124,7 +124,7 @@ namespace Opm {
             if (keyword->name() == "WRFTPLT"){
                 rftProperties.push_back( std::make_pair( keyword , currentStep ));
             }
-                
+
         }
         for (auto rftPair = rftProperties.begin(); rftPair != rftProperties.end(); ++rftPair) {
             DeckKeywordConstPtr keyword = rftPair->first;
@@ -630,12 +630,10 @@ namespace Opm {
             }
         }
 
-        const std::vector<WellPtr> wells = getWells();
-        for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-            WellPtr well = *wellIter;
+        for (auto iter = m_wells.begin(); iter != m_wells.end(); ++iter) {
+            WellPtr well = *iter;
             well->setRFTForWellWhenFirstOpen(m_timeMap->numTimesteps(), currentStep);
         }
-
     }
 
 
@@ -733,25 +731,6 @@ namespace Opm {
         return m_wells.get( wellName );
     }
 
-    std::vector<WellPtr> Schedule::getWells() {
-        return getWells(m_timeMap->size()-1);
-    }
-
-    std::vector<WellPtr> Schedule::getWells(size_t timeStep) {
-        if (timeStep >= m_timeMap->size()) {
-            throw std::invalid_argument("Timestep to large");
-        }
-
-        std::vector<WellPtr> wells;
-        for (auto iter = m_wells.begin(); iter != m_wells.end(); ++iter) {
-            WellPtr well = *iter;
-            if (well->hasBeenDefined(timeStep)) {
-                wells.push_back(well);
-            }
-        }
-        return wells;
-    }
-
 
     std::vector<WellConstPtr> Schedule::getWells() const {
         return getWells(m_timeMap->size()-1);
@@ -773,7 +752,7 @@ namespace Opm {
     }
 
 
-    std::vector<WellPtr> Schedule::getWells(const std::string& wellNamePattern) {
+    std::vector<WellPtr> Schedule::getWells(const std::string& wellNamePattern) const {
         std::vector<WellPtr> wells;
         size_t wildcard_pos = wellNamePattern.find("*");
         if (wildcard_pos == wellNamePattern.length()-1) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -58,7 +58,6 @@ namespace Opm
         std::vector<WellPtr> getWells(const std::string& wellNamePattern);
         std::vector<WellConstPtr> getWells() const;
         std::vector<WellConstPtr> getWells(size_t timeStep) const;
-        std::vector<WellConstPtr> getWells(const std::string& wellNamePattern) const;
 
         GroupTreePtr getGroupTree(size_t t) const;
         size_t numGroups() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -53,11 +53,9 @@ namespace Opm
         size_t getMaxNumCompletionsForWells(size_t timestep) const;
         bool hasWell(const std::string& wellName) const;
         WellPtr getWell(const std::string& wellName) const;
-        std::vector<WellPtr> getWells();
-        std::vector<WellPtr> getWells(size_t timeStep);
-        std::vector<WellPtr> getWells(const std::string& wellNamePattern);
         std::vector<WellConstPtr> getWells() const;
         std::vector<WellConstPtr> getWells(size_t timeStep) const;
+        std::vector<WellPtr> getWells(const std::string& wellNamePattern) const;
 
         GroupTreePtr getGroupTree(size_t t) const;
         size_t numGroups() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     DeckPtr deck = createDeckWithWellsOrdered();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(100,100,100);
     Schedule schedule(grid , deck);
-    std::vector<WellPtr> wells = schedule.getWells();
+    std::vector<WellConstPtr> wells = schedule.getWells();
 
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
     BOOST_CHECK_EQUAL( "BW_2" , wells[1]->name());
@@ -221,9 +221,9 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
     DeckPtr deck = createDeck();
     Schedule schedule(grid , deck);
 
-    std::vector<WellPtr> wells_alltimesteps = schedule.getWells();
+    std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(0U, wells_alltimesteps.size());
-    std::vector<WellPtr> wells_t0 = schedule.getWells(0);
+    std::vector<WellConstPtr> wells_t0 = schedule.getWells(0);
     BOOST_CHECK_EQUAL(0U, wells_t0.size());
 
     BOOST_CHECK_THROW(schedule.getWells(1), std::invalid_argument);
@@ -234,11 +234,11 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     DeckPtr deck = createDeckWithWells();
     Schedule schedule(grid , deck);
 
-    std::vector<WellPtr> wells_alltimesteps = schedule.getWells();
+    std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(3U, wells_alltimesteps.size());
-    std::vector<WellPtr> wells_t0 = schedule.getWells(0);
+    std::vector<WellConstPtr> wells_t0 = schedule.getWells(0);
     BOOST_CHECK_EQUAL(1U, wells_t0.size());
-    std::vector<WellPtr> wells_t3 = schedule.getWells(3);
+    std::vector<WellConstPtr> wells_t3 = schedule.getWells(3);
     BOOST_CHECK_EQUAL(3U, wells_t3.size());
 }
 

--- a/opm/parser/share/keywords/000_Eclipse100/S/SAVE
+++ b/opm/parser/share/keywords/000_Eclipse100/S/SAVE
@@ -1,0 +1,1 @@
+{"name" : "SAVE" , "sections" : ["RUNSPEC" , "SCHEDULE"] , "items" : [{"name" : "FILE_TYPE" , "value_type" : "STRING" , "default" : "UNFORMATTED"}]}


### PR DESCRIPTION
Changed the implementation which prompted the removal of `const` in the first place, and removed some not needed non `const methods`