### PR TITLE
OPM-166: Internalized tresholdPressure in EclipseState

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -5,6 +5,7 @@ if (BUILD_TESTING)
    add_subdirectory(IntegrationTests)
    add_subdirectory(EclipseState/tests)
    add_subdirectory(EclipseState/Schedule/tests)
+   add_subdirectory(EclipseState/SimulationConfig/tests)
    add_subdirectory(EclipseState/Tables/tests)
    add_subdirectory(EclipseState/Grid/tests)
    add_subdirectory(EclipseState/Util/tests)
@@ -94,7 +95,10 @@ EclipseState/Grid/MULTREGTScanner.cpp
 EclipseState/Grid/EclipseGrid.cpp
 EclipseState/Grid/FaultFace.cpp
 EclipseState/Grid/Fault.cpp
-EclipseState/Grid/FaultCollection.cpp)
+EclipseState/Grid/FaultCollection.cpp
+#
+EclipseState/SimulationConfig/SimulationConfig.cpp
+EclipseState/SimulationConfig/ThresholdPressure.cpp)
 
 set( HEADER_FILES
 Log/Logger.hpp
@@ -165,6 +169,9 @@ EclipseState/Grid/TransMult.hpp
 EclipseState/Grid/FaultFace.hpp
 EclipseState/Grid/Fault.hpp
 EclipseState/Grid/FaultCollection.hpp
+#
+EclipseState/SimulationConfig/SimulationConfig.hpp
+EclipseState/SimulationConfig/ThresholdPressure.hpp
 #
 EclipseState/Tables/PlyadsTable.hpp
 EclipseState/Tables/PvtoOuterTable.hpp

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -130,8 +130,8 @@ namespace Opm {
         initEclipseGrid(deck, logger);
         initSchedule(deck, logger);
         initTitle(deck, logger);
-
         initProperties(deck, logger);
+        initSimulationConfig(deck);
         initTransMult(logger);
         initFaults(deck, logger);
         initMULTREGT(deck, logger);
@@ -246,6 +246,10 @@ namespace Opm {
         return schedule;
     }
 
+    SimulationConfigConstPtr EclipseState::getSimulationConfig() const {
+        return m_simulationConfig;
+    }
+
     std::shared_ptr<const FaultCollection> EclipseState::getFaults() const {
         return m_faults;
     }
@@ -303,6 +307,10 @@ namespace Opm {
 
     void EclipseState::initSchedule(DeckConstPtr deck, LoggerPtr logger) {
         schedule = ScheduleConstPtr( new Schedule(getEclipseGrid() , deck, logger) );
+    }
+
+    void EclipseState::initSimulationConfig(DeckConstPtr deck) {
+        m_simulationConfig = std::make_shared<const SimulationConfig>(deck , m_intGridProperties);
     }
 
     void EclipseState::initTransMult(LoggerPtr /*logger*/) {

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -56,6 +56,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+
 #include <set>
 #include <memory>
 #include <iostream>
@@ -73,6 +75,7 @@ namespace Opm {
         EclipseState(DeckConstPtr deck, LoggerPtr logger = std::make_shared<Logger>(&std::cout));
 
         ScheduleConstPtr getSchedule() const;
+        SimulationConfigConstPtr getSimulationConfig() const;
         EclipseGridConstPtr getEclipseGrid() const;
         EclipseGridPtr getEclipseGridCopy() const;
         bool hasPhase(enum Phase::PhaseEnum phase) const;
@@ -127,6 +130,7 @@ namespace Opm {
     private:
         void initTables(DeckConstPtr deck, LoggerPtr logger);
         void initSchedule(DeckConstPtr deck, LoggerPtr logger);
+        void initSimulationConfig(DeckConstPtr deck);
         void initEclipseGrid(DeckConstPtr deck, LoggerPtr logger);
         void initPhases(DeckConstPtr deck, LoggerPtr logger);
         void initTitle(DeckConstPtr deck, LoggerPtr logger);
@@ -224,6 +228,7 @@ namespace Opm {
 
         EclipseGridConstPtr m_eclipseGrid;
         ScheduleConstPtr schedule;
+        SimulationConfigConstPtr m_simulationConfig;
 
         std::vector<EnkrvdTable> m_enkrvdTables;
         std::vector<EnptvdTable> m_enptvdTables;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -1,0 +1,41 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+
+namespace Opm {
+
+    SimulationConfig::SimulationConfig(DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
+        initThresholdPressure(deck, gridProperties);
+    }
+
+
+    void SimulationConfig::initThresholdPressure(DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
+        mThresholdPressure = std::make_shared<const ThresholdPressure>(deck, gridProperties);
+    }
+
+
+    const std::vector<double>& SimulationConfig::getThresholdPressureTable() const {
+        return mThresholdPressure->getThresholdPressureTable();
+    }
+
+} //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -1,0 +1,53 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_SIMULATION_CONFIG_HPP
+#define OPM_SIMULATION_CONFIG_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+
+
+namespace Opm {
+
+    class SimulationConfig {
+
+    public:
+
+        SimulationConfig(DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
+
+        const std::vector<double>& getThresholdPressureTable() const;
+
+
+    private:
+
+        void initThresholdPressure(DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
+
+        ThresholdPressureConstPtr mThresholdPressure;
+    };
+
+
+    typedef std::shared_ptr<SimulationConfig> SimulationConfigPtr;
+    typedef std::shared_ptr<const SimulationConfig> SimulationConfigConstPtr;
+
+} //namespace Opm
+
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -1,0 +1,126 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
+#include <opm/parser/eclipse/Log/Logger.hpp>
+
+
+namespace Opm {
+
+    ThresholdPressure::ThresholdPressure(DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
+
+        if (Section::hasRUNSPEC(deck) && Section::hasSOLUTION(deck)) {
+            std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(deck);
+            std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>(deck);
+            initThresholdPressure(runspecSection, solutionSection, gridProperties);
+        }
+    }
+
+
+    void ThresholdPressure::initThresholdPressure(std::shared_ptr<const RUNSPECSection> runspecSection,
+                                                  std::shared_ptr<const SOLUTIONSection> solutionSection,
+                                                  std::shared_ptr<GridProperties<int>> gridProperties) {
+
+        bool       thpresOption     = false;
+        const bool thpresKeyword    = solutionSection->hasKeyword("THPRES");
+        const bool hasEqlnumKeyword = gridProperties->hasKeyword("EQLNUM");
+        int        maxEqlnum        = 0;
+
+
+        //Is THPRES option set?
+        if (runspecSection->hasKeyword("EQLOPTS")) {
+            auto eqlopts = runspecSection->getKeyword("EQLOPTS");
+            auto rec = eqlopts->getRecord(0);
+            for (size_t i = 0; i < rec->size(); ++i) {
+                auto item = rec->getItem(i);
+                if (item->hasValue(0)) {
+                    if (item->getString(0) == "THPRES") {
+                        thpresOption = true;
+                    } else if (item->getString(0) == "IRREVERS") {
+                        throw std::runtime_error("Cannot use IRREVERS version of THPRES option, not implemented");
+                    }
+                }
+            }
+        }
+
+
+        //Option is set and keyword is found
+        if (thpresOption && thpresKeyword)
+        {
+            //Find max of eqlnum
+            if (hasEqlnumKeyword) {
+              auto eqlnumKeyword = gridProperties->getKeyword( "EQLNUM" );
+              auto eqlnum = eqlnumKeyword->getData();
+              maxEqlnum = *std::max_element(eqlnum.begin(), eqlnum.end());
+
+              if (0 == maxEqlnum) {
+                  throw std::runtime_error("Error in EQLNUM data: all values are 0");
+              }
+            } else {
+                throw std::runtime_error("Error when internalizing THPRES: EQLNUM keyword not found in deck");
+            }
+
+
+            // Fill threshold pressure table.
+            auto thpres = solutionSection->getKeyword("THPRES");
+
+            m_thresholdPressureTable.resize(maxEqlnum * maxEqlnum, 0.0);
+
+            const int numRecords = thpres->size();
+            for (int rec_ix = 0; rec_ix < numRecords; ++rec_ix) {
+                auto rec = thpres->getRecord(rec_ix);
+                auto region1Item = rec->getItem("REGION1");
+                auto region2Item = rec->getItem("REGION2");
+                auto thpressItem = rec->getItem("THPRES");
+
+                if (region1Item->hasValue(0) && region2Item->hasValue(0) && thpressItem->hasValue(0)) {
+                    const int r1 = region1Item->getInt(0) - 1;
+                    const int r2 = region2Item->getInt(0) - 1;
+                    const double p = thpressItem->getSIDouble(0);
+
+                    if (r1 >= maxEqlnum || r2 >= maxEqlnum) {
+                        throw std::runtime_error("Too high region numbers in THPRES keyword");
+                    }
+                    m_thresholdPressureTable[r1 + maxEqlnum*r2] = p;
+                    m_thresholdPressureTable[r2 + maxEqlnum*r1] = p;
+                } else {
+                    throw std::runtime_error("Missing data for use of the THPRES keyword");
+                }
+            }
+        } else if (thpresOption && !thpresKeyword) {
+            throw std::runtime_error("Invalid solution section; the EQLOPTS THPRES option is set in RUNSPEC, but no THPRES keyword is found in SOLUTION");
+
+        }
+    }
+
+
+
+    const std::vector<double>& ThresholdPressure::getThresholdPressureTable() const {
+        return m_thresholdPressureTable;
+    }
+
+
+} //namespace Opm
+
+
+
+
+

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -1,0 +1,59 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_TRESHOLD_PRESSURES_HPP
+#define OPM_TRESHOLD_PRESSURES_HPP
+
+#include <vector>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
+#include <opm/parser/eclipse/Log/Logger.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
+
+
+
+namespace Opm {
+
+    class ThresholdPressure {
+
+    public:
+
+        ThresholdPressure(DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
+
+        const std::vector<double>& getThresholdPressureTable() const;
+
+
+    private:
+
+        void initThresholdPressure(std::shared_ptr<const RUNSPECSection> runspecSection,
+                                   std::shared_ptr<const SOLUTIONSection> solutionSection,
+                                   std::shared_ptr<GridProperties<int>> gridProperties);
+
+
+        std::vector<double> m_thresholdPressureTable;
+    };
+
+
+    typedef std::shared_ptr<ThresholdPressure> ThresholdPressurePtr;
+    typedef std::shared_ptr<const ThresholdPressure> ThresholdPressureConstPtr;
+
+} //namespace Opm
+
+#endif

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_executable(runThresholdPressureTests ThresholdPressureTest.cpp)
+target_link_libraries(runThresholdPressureTests Parser ${Boost_LIBRARIES})
+add_test(NAME runThresholdPressureTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${TEST_MEMCHECK_TOOL} ${EXECUTABLE_OUTPUT_PATH}/runThresholdPressureTests )
+
+
+add_executable(runSimulationConfigTests SimulationConfigTest.cpp)
+target_link_libraries(runSimulationConfigTests Parser ${Boost_LIBRARIES})
+add_test(NAME runSimulationConfigTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${TEST_MEMCHECK_TOOL} ${EXECUTABLE_OUTPUT_PATH}/runSimulationConfigTests )

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -1,0 +1,82 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#define BOOST_TEST_MODULE SimulationConfigTests
+
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+
+
+using namespace Opm;
+
+const std::string& inputStr = "RUNSPEC\n"
+                              "EQLOPTS\n"
+                              "THPRES /\n "
+                              "DIMENS\n"
+                              "10 3 4 /\n"
+                              "\n"
+                              "GRID\n"
+                              "REGIONS\n"
+                              "EQLNUM\n"
+                              "10*1 10*2 100*3 /\n "
+                              "\n"
+
+                              "SOLUTION\n"
+                              "THPRES\n"
+                              "1 2 12.0/\n"
+                              "1 3 5.0/\n"
+                              "2 3 7.0/\n"
+                              "/\n"
+                              "\n";
+
+
+static DeckPtr createDeck(const std::string& input) {
+    Opm::Parser parser;
+    return parser.parseString(input);
+}
+
+
+static std::shared_ptr<GridProperties<int>> getGridProperties() {
+    GridPropertySupportedKeywordInfo<int> kwInfo = GridPropertySupportedKeywordInfo<int>("EQLNUM", 3, "");
+    std::shared_ptr<std::vector<GridPropertySupportedKeywordInfo<int>>> supportedKeywordsVec = std::make_shared<std::vector<GridPropertySupportedKeywordInfo<int>>>();
+    supportedKeywordsVec->push_back(kwInfo);
+    EclipseGridConstPtr eclipseGrid = std::make_shared<const EclipseGrid>(3, 3, 3);
+    std::shared_ptr<GridProperties<int>> gridProperties = std::make_shared<GridProperties<int>>(eclipseGrid, supportedKeywordsVec);
+    gridProperties->addKeyword("EQLNUM");
+    return gridProperties;
+}
+
+
+BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
+
+    DeckPtr deck = createDeck(inputStr);
+    SimulationConfigConstPtr simulationConfigPtr;
+    BOOST_CHECK_NO_THROW(simulationConfigPtr = std::make_shared<const SimulationConfig>(deck, getGridProperties()));
+    const std::vector<double>& thresholdPressureTable = simulationConfigPtr->getThresholdPressureTable();
+    BOOST_CHECK(thresholdPressureTable.size() > 0);
+}
+
+
+

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -1,0 +1,203 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#define BOOST_TEST_MODULE ThresholdPressureTests
+
+#include <algorithm>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/filesystem.hpp>
+
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
+
+
+using namespace Opm;
+
+const std::string& inputStr = "RUNSPEC\n"
+                              "EQLOPTS\n"
+                              "THPRES /\n "
+                              "\n"
+
+                              "SOLUTION\n"
+                              "THPRES\n"
+                              "1 2 12.0/\n"
+                              "1 3 5.0/\n"
+                              "2 3 7.0/\n"
+                              "/\n"
+                              "\n";
+
+const std::string& inputStrNoSolutionSection =  "RUNSPEC\n"
+                                                "EQLOPTS\n"
+                                                "THPRES /\n "
+                                                "\n";
+
+
+const std::string& inputStrNoTHPRESinSolutionNorRUNSPEC = "RUNSPEC\n"
+                                                          "\n"
+                                                          "SOLUTION\n"
+                                                          "\n"
+                                                          "SCHEDULE\n";
+
+const std::string& inputStrTHPRESinRUNSPECnotSoultion = "RUNSPEC\n"
+                                                        "EQLOPTS\n"
+                                                        "ss /\n "
+                                                        "\n"
+                                                        "SOLUTION\n"
+                                                        "\n";
+
+
+const std::string& inputStrIrrevers = "RUNSPEC\n"
+                                      "EQLOPTS\n"
+                                      "THPRES IRREVERS/\n "
+                                      "\n"
+
+                                      "SOLUTION\n"
+                                      "THPRES\n"
+                                      "/\n"
+                                      "\n";
+
+const std::string& inputStrInconsistency =  "RUNSPEC\n"
+                                            "EQLOPTS\n"
+                                            "THPRES /\n "
+                                            "\n"
+
+                                            "SOLUTION\n"
+                                            "\n";
+
+const std::string& inputStrTooHighRegionNumbers = "RUNSPEC\n"
+                                                  "EQLOPTS\n"
+                                                  "THPRES /\n "
+                                                  "\n"
+
+                                                  "SOLUTION\n"
+                                                  "THPRES\n"
+                                                  "1 2 12.0/\n"
+                                                  "4 3 5.0/\n"
+                                                  "2 3 7.0/\n"
+                                                  "/\n"
+                                                  "\n";
+
+
+const std::string& inputStrMissingData = "RUNSPEC\n"
+                                         "EQLOPTS\n"
+                                         "THPRES /\n "
+                                         "\n"
+
+                                         "SOLUTION\n"
+                                         "THPRES\n"
+                                         "1 2 12.0/\n"
+                                         "4 3 5.0/\n"
+                                         "2 3 /\n"
+                                         "/\n"
+                                         "\n";
+
+
+
+
+static DeckPtr createDeck(const std::string& input) {
+    Opm::Parser parser;
+    return parser.parseString(input);
+}
+
+
+static std::shared_ptr<GridProperties<int>> getGridProperties(int defaultEqlnum = 3, bool addKeyword = true) {
+    GridPropertySupportedKeywordInfo<int> kwInfo = GridPropertySupportedKeywordInfo<int>("EQLNUM", defaultEqlnum, "");
+    std::shared_ptr<std::vector<GridPropertySupportedKeywordInfo<int>>> supportedKeywordsVec = std::make_shared<std::vector<GridPropertySupportedKeywordInfo<int>>>();
+    supportedKeywordsVec->push_back(kwInfo);
+    EclipseGridConstPtr eclipseGrid = std::make_shared<const EclipseGrid>(3, 3, 3);
+    std::shared_ptr<GridProperties<int>> gridProperties = std::make_shared<GridProperties<int>>(eclipseGrid, supportedKeywordsVec);
+    if (addKeyword) {
+        gridProperties->addKeyword("EQLNUM");
+    }
+    return gridProperties;
+}
+
+
+BOOST_AUTO_TEST_CASE(ThresholdPressureTest) {
+
+    DeckPtr deck = createDeck(inputStr);
+    static std::shared_ptr<GridProperties<int>> gridProperties = getGridProperties();
+    ThresholdPressureConstPtr tresholdPressurePtr = std::make_shared<ThresholdPressure>(deck, gridProperties);
+
+    const std::vector<double>& thresholdPressureTable = tresholdPressurePtr->getThresholdPressureTable();
+
+    double pressureList[] = {0.0, 1200000.0, 500000.0, 1200000.0, 0.0, 700000.0, 500000.0, 700000.0, 0.0};
+    std::vector<double> wantedResultVec(pressureList, pressureList + sizeof(pressureList) / sizeof(double));
+
+    BOOST_CHECK_EQUAL(thresholdPressureTable.size(), wantedResultVec.size());
+    BOOST_CHECK(std::equal(thresholdPressureTable.begin(), thresholdPressureTable.end(), wantedResultVec.begin()));
+}
+
+
+BOOST_AUTO_TEST_CASE(ThresholdPressureEmptyTest) {
+
+    DeckPtr deck = createDeck(inputStrNoSolutionSection);
+    static std::shared_ptr<GridProperties<int>> gridProperties = getGridProperties();
+    ThresholdPressureConstPtr tresholdPressurePtr = std::make_shared<ThresholdPressure>(deck, gridProperties);
+    const std::vector<double>& thresholdPressureTable = tresholdPressurePtr->getThresholdPressureTable();
+
+    BOOST_CHECK_EQUAL(0, thresholdPressureTable.size());
+}
+
+
+BOOST_AUTO_TEST_CASE(ThresholdPressureNoTHPREStest) {
+
+    DeckPtr deck_no_thpres = createDeck(inputStrNoTHPRESinSolutionNorRUNSPEC);
+    DeckPtr deck_no_thpres2 = createDeck(inputStrTHPRESinRUNSPECnotSoultion);
+    static std::shared_ptr<GridProperties<int>> gridProperties = getGridProperties();
+
+    ThresholdPressureConstPtr tresholdPressurePtr;
+    BOOST_CHECK_NO_THROW(tresholdPressurePtr = std::make_shared<ThresholdPressure>(deck_no_thpres, gridProperties));
+    ThresholdPressureConstPtr tresholdPressurePtr2;
+    BOOST_CHECK_NO_THROW(tresholdPressurePtr2 = std::make_shared<ThresholdPressure>(deck_no_thpres2, gridProperties));
+
+    const std::vector<double>& thresholdPressureTable = tresholdPressurePtr->getThresholdPressureTable();
+    BOOST_CHECK_EQUAL(0, thresholdPressureTable.size());
+
+    const std::vector<double>& thresholdPressureTable2 = tresholdPressurePtr2->getThresholdPressureTable();
+    BOOST_CHECK_EQUAL(0, thresholdPressureTable2.size());
+}
+
+
+BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
+
+    DeckPtr deck               = createDeck(inputStr);
+    DeckPtr deck_irrevers      = createDeck(inputStrIrrevers);
+    DeckPtr deck_inconsistency = createDeck(inputStrInconsistency);
+    DeckPtr deck_highRegNum    = createDeck(inputStrTooHighRegionNumbers);
+    DeckPtr deck_missingData   = createDeck(inputStrMissingData);
+    static std::shared_ptr<GridProperties<int>> gridProperties = getGridProperties();
+
+    BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(deck_irrevers, gridProperties), std::runtime_error);
+    BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(deck_inconsistency, gridProperties), std::runtime_error);
+    BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(deck_highRegNum, gridProperties), std::runtime_error);
+    BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(deck_missingData, gridProperties), std::runtime_error);
+
+    static std::shared_ptr<GridProperties<int>> gridPropertiesEQLNUMkeywordNotAdded = getGridProperties(3, false);
+    BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(deck, gridPropertiesEQLNUMkeywordNotAdded), std::runtime_error);
+
+    static std::shared_ptr<GridProperties<int>> gridPropertiesEQLNUMall0 = getGridProperties(0);
+    BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(deck, gridPropertiesEQLNUMall0), std::runtime_error);
+}
+

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -84,7 +84,6 @@ static DeckPtr createDeckTOP() {
 
 
 
-
 BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     DeckPtr deck = createDeckTOP();
     LoggerPtr logger(new Logger());
@@ -101,7 +100,6 @@ BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     }
 
 }
-
 
 
 static DeckPtr createDeck() {
@@ -145,6 +143,7 @@ static DeckPtr createDeck() {
     return parser->parseString(deckData) ;
 }
 
+
 static DeckPtr createDeckNoFaults() {
     const char *deckData =
         "RUNSPEC\n"
@@ -172,6 +171,7 @@ static DeckPtr createDeckNoFaults() {
     return parser->parseString(deckData) ;
 }
 
+
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
     DeckPtr deck = createDeck();
     EclipseState state(deck);
@@ -179,6 +179,44 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
     EclipseGridConstPtr eclipseGrid = state.getEclipseGrid();
 
     BOOST_CHECK_EQUAL( schedule->getStartTime() , boost::posix_time::ptime(boost::gregorian::date(1998 , 3 , 8 )));
+}
+
+
+
+static DeckPtr createDeckSimConfig() {
+    const std::string& inputStr = "RUNSPEC\n"
+                                  "EQLOPTS\n"
+                                  "THPRES /\n "
+                                  "DIMENS\n"
+                                  "10 3 4 /\n"
+                                  "\n"
+                                  "GRID\n"
+                                  "REGIONS\n"
+                                  "EQLNUM\n"
+                                  "10*1 10*2 100*3 /\n "
+                                  "\n"
+
+                                  "SOLUTION\n"
+                                  "THPRES\n"
+                                  "1 2 12.0/\n"
+                                  "1 3 5.0/\n"
+                                  "2 3 7.0/\n"
+                                  "/\n"
+                                  "\n";
+
+
+    ParserPtr parser(new Parser());
+    return parser->parseString(inputStr) ;
+}
+
+
+BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
+
+    DeckPtr deck = createDeckSimConfig();
+    EclipseState state(deck);
+    SimulationConfigConstPtr simulationConfig = state.getSimulationConfig();
+    const std::vector<double> thresholdPressureTable = simulationConfig->getThresholdPressureTable();
+    BOOST_CHECK_EQUAL(thresholdPressureTable.size(), 9);
 }
 
 


### PR DESCRIPTION
Extended EclipseState with threshold pressure values:

Added new classes SimulationConfig and ThresholdPressure.

EclipseState has a new member, - an instance of the new SimulationConfig class. 
A get method for fetching this object is added to EclipseState.

From this SimulationConfig object a thresholdpressure vector can be fetched. 
The internalizing of the THPRES values are located in a separate class ThresholdPressure. 
SimulationConfig has got a member object of type ThresholdPressure.

Added tests for new class SimulationConfig and new class ThresholdPressure.

