### PR TITLE
Schedule: fix handling of the RESV item of the WCONINE keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -293,7 +293,7 @@ namespace Opm {
 
 
                 if (!record->getItem("RESV")->defaultApplied(0)) {
-                    properties.reservoirInjectionRate = convertInjectionRateToSI(record->getItem("RESV")->getRawDouble(0) , injectorType, *deck->getActiveUnitSystem());
+                    properties.reservoirInjectionRate = record->getItem("RESV")->getSIDouble(0);
                     properties.addInjectionControl(WellInjector::RESV);
                 } else
                     properties.dropInjectionControl(WellInjector::RESV);

--- a/opm/parser/share/keywords/000_Eclipse100/W/WCONINJE
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WCONINJE
@@ -4,7 +4,7 @@
     {"name" : "STATUS"       , "value_type" : "STRING" , "default" : "OPEN"},
     {"name" : "CMODE"        , "value_type" : "STRING" },
     {"name" : "RATE" , "value_type" : "DOUBLE" , "dimension" : "ContextDependent"},
-    {"name" : "RESV" , "value_type" : "DOUBLE" , "dimension" : "ContextDependent"},
+    {"name" : "RESV" , "value_type" : "DOUBLE" , "dimension" : "LiquidVolume/Time"},
     {"name" : "BHP"  , "value_type" : "DOUBLE" , "dimension" : "Pressure" , "default" : 6891},
     {"name" : "THP"  , "value_type" : "DOUBLE" , "dimension" : "Pressure"},
     {"name" : "VFP_TABLE" , "value_type" : "INT" , "default" : 0},


### PR DESCRIPTION
it turns out that, in contrast to the RATE item, this item is always a
liquid rate (-> bbl/day in FIELD units), i.e., the dimension is always
"LiquidVolume/Time" irrespectibly of the fluid phase.