### PR TITLE
Remove some warnings when compiling the parser module.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -623,7 +623,7 @@ namespace Opm {
             for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
                 WellPtr well = *wellIter;
                 well->setRFTActive(currentStep, true);
-                int numStep = m_timeMap->numTimesteps();
+                size_t numStep = m_timeMap->numTimesteps();
                 if(currentStep<numStep){
                     well->setRFTActive(currentStep+1, false);
                 }

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -530,7 +530,7 @@ namespace Opm {
                 return NO;
             else
                 throw std::invalid_argument("Unknown enum state string: " + stringValue);
-        };
+        }
 
     }
     namespace PLTConnections {
@@ -563,7 +563,7 @@ namespace Opm {
                 return NO;
             else
                 throw std::invalid_argument("Unknown enum state string: " + stringValue );
-        };
+        }
     }
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -261,7 +261,7 @@ namespace Opm {
             }
         }
         return -1;
-    };
+    }
 
     void Well::setRFTForWellWhenFirstOpen(int numSteps,size_t currentStep){
         int time;

--- a/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserDoubleItem.cpp
@@ -31,8 +31,8 @@ namespace Opm
 {
 
     ParserDoubleItem::ParserDoubleItem(const std::string& itemName,
-            ParserItemSizeEnum sizeType_) :
-            ParserItem(itemName, sizeType_)
+            ParserItemSizeEnum p_sizeType) :
+            ParserItem(itemName, p_sizeType)
     {
         // use NaN as 'default default'. (Keep in mind that in the deck it can be queried
         // using deckItem->defaultApplied(idx) if an item was defaulted or not...
@@ -54,8 +54,8 @@ namespace Opm
     }
 
 
-    ParserDoubleItem::ParserDoubleItem(const std::string& itemName, ParserItemSizeEnum sizeType, double defaultValue)
-        : ParserItem(itemName, sizeType)
+    ParserDoubleItem::ParserDoubleItem(const std::string& itemName, ParserItemSizeEnum p_sizeType, double defaultValue)
+        : ParserItem(itemName, p_sizeType)
     {
         setDefault( defaultValue );
     }

--- a/opm/parser/eclipse/Parser/ParserIntItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserIntItem.cpp
@@ -37,8 +37,8 @@ namespace Opm {
         m_defaultSet = false;
     }
 
-    ParserIntItem::ParserIntItem(const std::string& itemName, ParserItemSizeEnum sizeType)
-        : ParserItem(itemName, sizeType)
+    ParserIntItem::ParserIntItem(const std::string& itemName, ParserItemSizeEnum p_sizeType)
+        : ParserItem(itemName, p_sizeType)
     {
         m_default = -1;
         m_defaultSet = false;

--- a/opm/parser/eclipse/Parser/ParserItem.cpp
+++ b/opm/parser/eclipse/Parser/ParserItem.cpp
@@ -25,9 +25,9 @@
 
 namespace Opm {
 
-    ParserItem::ParserItem(const std::string& itemName, ParserItemSizeEnum sizeType) {
+    ParserItem::ParserItem(const std::string& itemName, ParserItemSizeEnum p_sizeType) {
         m_name.assign(itemName);
-        m_sizeType = sizeType;
+        m_sizeType = p_sizeType;
         m_defaultSet = false;
         m_description = "";
     }


### PR DESCRIPTION
The warnings are:

sizeType --> p_sizeType since it shadows a member method
trailing ;
comparison of signed and unsigned int