### PR TITLE
Record vector

### DIFF
--- a/opm/parser/eclipse/Applications/opm-eclkw.cpp
+++ b/opm/parser/eclipse/Applications/opm-eclkw.cpp
@@ -71,7 +71,7 @@ static void printItems(Opm::ParserKeywordConstPtr keyword)
     std::string indent = "  ";
     std::cout << std::endl;
     std::cout << indent << "List of items:" << std::endl;
-    Opm::ParserRecordPtr parserRecord = keyword->getRecord();
+    Opm::ParserRecordPtr parserRecord = keyword->getRecord(0);
     for (auto iterator = parserRecord->begin(); iterator != parserRecord->end(); ++iterator) {
         Opm::ParserItemConstPtr item = *iterator;
         printItem(item, indent);

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -153,6 +153,7 @@ EclipseState/Schedule/ScheduleEnums.hpp
 EclipseState/Schedule/GroupTreeNode.hpp 
 EclipseState/Schedule/GroupTree.hpp
 #
+EclipseState/Util/ElasticVector.hpp 
 EclipseState/Util/OrderedMap.hpp 
 EclipseState/Util/Value.hpp 
 #

--- a/opm/parser/eclipse/EclipseState/Util/ElasticVector.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/ElasticVector.hpp
@@ -1,0 +1,61 @@
+/*
+  Copyright 2014 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+#ifndef _ELASTIC_VECTOR_
+#define _ELASTIC_VECTOR_
+
+#include <vector>
+#include <stdexcept>
+
+/*
+  A vector like container which will return the last valid element
+  when the lookup index is out of range.
+*/
+
+namespace Opm {
+
+template <typename T>
+class ElasticVector {
+private:
+    std::vector<T> m_data;
+public:
+    size_t size() const {
+        return m_data.size();
+    }
+
+    T get(size_t index) const {
+        if (m_data.size() > 0) {
+            if (index >= m_data.size())
+                return m_data.back();
+            else
+                return m_data[index];
+        } else
+            throw std::invalid_argument("Trying to get from empty ElasticVector");
+    }
+
+
+    void push_back(T value) {
+        m_data.push_back(value);
+    }
+
+};
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Util/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/Util/tests/CMakeLists.txt
@@ -8,3 +8,8 @@ target_link_libraries(runValueTests Parser ${Boost_LIBRARIES})
 add_test(NAME runValueTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${TEST_MEMCHECK_TOOL} ${EXECUTABLE_OUTPUT_PATH}/runValueTests )
 
 
+add_executable(runElasticVectorTests ElasticVectorTests.cpp)
+target_link_libraries(runElasticVectorTests Parser ${Boost_LIBRARIES})
+add_test(NAME runElasticVectorTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${TEST_MEMCHECK_TOOL} ${EXECUTABLE_OUTPUT_PATH}/runElasticVectorTests )
+
+

--- a/opm/parser/eclipse/EclipseState/Util/tests/ElasticVectorTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Util/tests/ElasticVectorTests.cpp
@@ -1,0 +1,49 @@
+/*
+  Copyright 2014 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
+#include <iostream>
+#include <boost/filesystem.hpp>
+
+#define BOOST_TEST_MODULE ScheduleTests
+#include <boost/test/unit_test.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Util/ElasticVector.hpp>
+
+BOOST_AUTO_TEST_CASE( check_empty) {
+    Opm::ElasticVector<int> vector;
+    BOOST_CHECK_EQUAL( 0U , vector.size());
+    BOOST_CHECK_THROW( vector.get(0) , std::invalid_argument );
+}
+
+
+BOOST_AUTO_TEST_CASE( check_add ) {
+    Opm::ElasticVector<int> vector;
+    vector.push_back(10);
+    BOOST_CHECK_EQUAL( 1U , vector.size());
+    BOOST_CHECK_EQUAL( 10 , vector.get(0));
+    BOOST_CHECK_EQUAL( 10 , vector.get(10));
+
+    vector.push_back(20);
+    BOOST_CHECK_EQUAL( 2U , vector.size());
+    BOOST_CHECK_EQUAL( 10 , vector.get(0));
+    BOOST_CHECK_EQUAL( 20 , vector.get(1));
+    BOOST_CHECK_EQUAL( 20 , vector.get(10));
+}

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -35,7 +35,7 @@ using namespace Opm;
 static ParserPtr createWWCTParser() {
     ParserKeywordPtr parserKeyword = ParserKeyword::createDynamicSized("WWCT");
     {
-        ParserRecordPtr wwctRecord = parserKeyword->getRecord();
+        ParserRecordPtr wwctRecord = parserKeyword->getRecord(0);
         wwctRecord->addItem(ParserStringItemConstPtr(new ParserStringItem("WELL", ALL)));
     }
     ParserKeywordPtr summaryKeyword = ParserKeyword::createFixedSized("SUMMARY" , (size_t) 0);
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE(parser_internal_name_vs_deck_name) {
 static ParserPtr createBPRParser() {
     ParserKeywordPtr parserKeyword = ParserKeyword::createDynamicSized("BPR");
     {
-        ParserRecordPtr bprRecord = parserKeyword->getRecord();
+        ParserRecordPtr bprRecord = parserKeyword->getRecord(0);
         bprRecord->addItem(ParserIntItemConstPtr(new ParserIntItem("I", SINGLE)));
         bprRecord->addItem(ParserIntItemConstPtr(new ParserIntItem("J", SINGLE)));
         bprRecord->addItem(ParserIntItemConstPtr(new ParserIntItem("K", SINGLE)));
@@ -239,7 +239,7 @@ BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {
     BOOST_CHECK_EQUAL(lastItem_1->getInt(0), 1);
 
     ParserKeywordConstPtr parserKeyword = parser->getParserKeywordFromDeckName("RADFIN4");
-    ParserRecordConstPtr parserRecord = parserKeyword->getRecord();
+    ParserRecordConstPtr parserRecord = parserKeyword->getRecord(0);
     ParserItemConstPtr nwmaxItem = parserRecord->get("NWMAX");
     ParserIntItemConstPtr intItem = std::static_pointer_cast<const ParserIntItem>(nwmaxItem);
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -372,7 +372,7 @@ namespace Opm {
                         targetSize = sizeDefinitionItem->getInt(0);
                     } else {
                         auto keyword = getKeyword( sizeKeyword.first );
-                        auto record = keyword->getRecord();
+                        auto record = keyword->getRecord(0);
                         auto int_item = std::dynamic_pointer_cast<const ParserIntItem>( record->get( sizeKeyword.second ) );
 
                         targetSize = int_item->getDefault( );

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Util/ElasticVector.hpp>
 
 
 namespace Opm {
@@ -105,7 +106,7 @@ namespace Opm {
         void setMatchRegex(const std::string& deckNameRegexp);
         bool matches(const std::string& deckKeywordName) const;
         bool hasDimension() const;
-        ParserRecordPtr getRecord() const;
+        ParserRecordPtr getRecord(size_t recordIndex) const;
         const std::string& getName() const;
         size_t getFixedSize() const;
         bool hasFixedSize() const;
@@ -147,7 +148,7 @@ namespace Opm {
 #else
         boost::regex m_matchRegex;
 #endif
-        ParserRecordPtr m_record;
+        ElasticVector<ParserRecordPtr> m_records;
         enum ParserKeywordSizeEnum m_keywordSizeType;
         size_t m_fixedSize;
         bool m_isDataKeyword;

--- a/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
+++ b/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
@@ -121,7 +121,7 @@ static void testKeyword(ParserKeywordConstPtr parserKeyword , const std::string&
     of << "BOOST_CHECK( parserKeyword->equal( *inlineKeyword));" << std::endl;
     if (parserKeyword->hasDimension()) {
         of << "{" << std::endl;
-        of << "    ParserRecordConstPtr parserRecord = parserKeyword->getRecord();" << std::endl;
+        of << "    ParserRecordConstPtr parserRecord = parserKeyword->getRecord(0);" << std::endl;
         of << "    for (size_t i=0; i < parserRecord->size(); i++) { " << std::endl;
         of << "        ParserItemConstPtr item = parserRecord->get( i );" << std::endl;
         of << "        for (size_t j=0; j < item->numDimensions(); j++) {" << std::endl;

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_ItemInvalidEnum_throws) {
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObjectItemsOK) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" : [{\"name\" : \"I\", \"value_type\" : \"INT\"}]}");
     ParserKeywordConstPtr parserKeyword = ParserKeyword::createFromJson(jsonObject);
-    ParserRecordConstPtr record = parserKeyword->getRecord();
+    ParserRecordConstPtr record = parserKeyword->getRecord(0);
     ParserItemConstPtr item = record->get( 0 );
     BOOST_CHECK_EQUAL( 1U , record->size( ) );
     BOOST_CHECK_EQUAL( "I" , item->name( ) );
@@ -279,7 +279,7 @@ BOOST_AUTO_TEST_CASE(AddDataKeywordFromJson_defaultThrows) {
 BOOST_AUTO_TEST_CASE(AddDataKeywordFromJson_correctlyConfigured) {
     Json::JsonObject jsonConfig("{\"name\": \"ACTNUM\", \"sections\":[\"GRID\"], \"data\" : {\"value_type\": \"INT\"}}");
     ParserKeywordConstPtr parserKeyword = ParserKeyword::createFromJson(jsonConfig);
-    ParserRecordConstPtr parserRecord = parserKeyword->getRecord();
+    ParserRecordConstPtr parserRecord = parserKeyword->getRecord(0);
     ParserItemConstPtr item = parserRecord->get(0);
 
 
@@ -300,7 +300,7 @@ BOOST_AUTO_TEST_CASE(AddkeywordFromJson_numTables_incoorect_throw) {
 BOOST_AUTO_TEST_CASE(AddkeywordFromJson_isTableCollection) {
     Json::JsonObject jsonConfig("{\"name\": \"PVTG\", \"sections\":[\"PROPS\"], \"num_tables\" : {\"keyword\": \"TABDIMS\" , \"item\" : \"NTPVT\"} , \"items\" : [{\"name\" : \"data\", \"value_type\" : \"DOUBLE\"}]}");
     ParserKeywordConstPtr parserKeyword = ParserKeyword::createFromJson(jsonConfig);
-    ParserRecordConstPtr parserRecord = parserKeyword->getRecord();
+    ParserRecordConstPtr parserRecord = parserKeyword->getRecord(0);
 
 
     BOOST_CHECK_EQUAL( true , parserKeyword->isTableCollection() );
@@ -422,7 +422,7 @@ BOOST_AUTO_TEST_CASE(ParseKeywordHasDimensionCorrect) {
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_withDimension) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\" , \"dimension\" : \"Length*Length/Time\"}]}");
     ParserKeywordPtr parserKeyword = ParserKeyword::createFromJson(jsonObject);
-    ParserRecordConstPtr record = parserKeyword->getRecord();
+    ParserRecordConstPtr record = parserKeyword->getRecord(0);
     ParserItemConstPtr item = record->get("ItemX");
 
     BOOST_CHECK_EQUAL("BPR" , parserKeyword->getName());
@@ -438,7 +438,7 @@ BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_withDimension) {
 BOOST_AUTO_TEST_CASE(ConstructFromJsonObject_withDimensionList) {
     Json::JsonObject jsonObject("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 , \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"ALL\" , \"value_type\" : \"DOUBLE\" , \"dimension\" : [\"Length*Length/Time\" , \"Time\", \"1\"]}]}");
     ParserKeywordPtr parserKeyword = ParserKeyword::createFromJson(jsonObject);
-    ParserRecordConstPtr record = parserKeyword->getRecord();
+    ParserRecordConstPtr record = parserKeyword->getRecord(0);
     ParserItemConstPtr item = record->get("ItemX");
 
     BOOST_CHECK_EQUAL("BPR" , parserKeyword->getName());

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -293,7 +293,7 @@ BOOST_AUTO_TEST_CASE(WildCardTest) {
 
 static ParserKeywordPtr __attribute__((unused)) setupParserKeywordInt(std::string name, int numberOfItems) {
     ParserKeywordPtr parserKeyword = ParserKeyword::createDynamicSized(name);
-    ParserRecordPtr parserRecord = parserKeyword->getRecord();
+    ParserRecordPtr parserRecord = parserKeyword->getRecord(0);
 
     for (int i = 0; i < numberOfItems; i++) {
         std::string another_name = "ITEM_" + boost::lexical_cast<std::string>(i);


### PR DESCRIPTION
Small first step towards supporting multi record keyword configuration; required for the VFP keywords.

1. Added small utility class ElasticVector<T> which will return the last valid  value when index >= size().
2. Stored ParserRecords in ElasticVector<>.