### PR TITLE
Implement temperature dependent density

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -49,7 +49,7 @@ namespace Opm {
             ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
 
             ParentType::checkNonDefaultable("Viscosity");
-            ParentType::checkMonotonic("Viscosity", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            ParentType::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
     public:

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         {
             ParentType::init(keyword,
                              std::vector<std::string>{
-                                 "Temperature"
+                                 "Temperature",
                                  "Viscosity"
                              },
                              recordIdx,
@@ -49,7 +49,7 @@ namespace Opm {
             ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
 
             ParentType::checkNonDefaultable("Viscosity");
-            ParentType::checkMonotonic("Viscosity", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            ParentType::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
     public:

--- a/opm/parser/eclipse/Units/ConversionFactors.hpp
+++ b/opm/parser/eclipse/Units/ConversionFactors.hpp
@@ -194,6 +194,7 @@ namespace Opm {
         const double Pressure             = barsa;
         const double Temperature          = degCelsius;
         const double TemperatureOffset    = degCelsiusOffset;
+        const double AbsoluteTemperature  = degCelsius; // actually [K], but the these two are identical
         const double Length               = meter;
         const double Time                 = day;
         const double Mass                 = kilogram;
@@ -217,6 +218,7 @@ namespace Opm {
         const double Pressure             = psia;
         const double Temperature          = degFahrenheit;
         const double TemperatureOffset    = degFahrenheitOffset;
+        const double AbsoluteTemperature  = degFahrenheit; // actually [°R], but the these two are identical
         const double Length               = feet;
         const double Time                 = day;
         const double Mass                 = pound;

--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -150,6 +150,7 @@ namespace Opm {
         system->addDimension("1"         , 1.0);
         system->addDimension("Pressure"  , Metric::Pressure );
         system->addDimension("Temperature", Metric::Temperature, Metric::TemperatureOffset);
+        system->addDimension("AbsoluteTemperature", Metric::AbsoluteTemperature);
         system->addDimension("Length"    , Metric::Length);
         system->addDimension("Time"      , Metric::Time );
         system->addDimension("Mass"         , Metric::Mass );
@@ -176,6 +177,7 @@ namespace Opm {
         system->addDimension("1"    , 1.0);
         system->addDimension("Pressure", Field::Pressure );
         system->addDimension("Temperature", Field::Temperature, Field::TemperatureOffset);
+        system->addDimension("AbsoluteTemperature", Field::AbsoluteTemperature);
         system->addDimension("Length", Field::Length);
         system->addDimension("Time" , Field::Time);
         system->addDimension("Mass", Field::Mass);

--- a/opm/parser/share/keywords/000_Eclipse100/V/VISCREF
+++ b/opm/parser/share/keywords/000_Eclipse100/V/VISCREF
@@ -1,0 +1,10 @@
+{
+  "name": "VISCREF",
+  "sections" : ["PROPS"],
+  "size" : {"keyword":"TABDIMS" , "item":"NTPVT"},
+  "items": [
+    {"name":"REFERENCE_PRESSURE", "value_type" : "DOUBLE", "dimension":"Pressure" },
+    {"name":"REFERENCE_RS", "value_type" : "DOUBLE", "dimension":"GasDissolutionFactor" }
+  ]
+}
+

--- a/opm/parser/share/keywords/001_Eclipse300/C/COMPS
+++ b/opm/parser/share/keywords/001_Eclipse300/C/COMPS
@@ -1,6 +1,7 @@
 {
   "name": "COMPS",
   "sections": ["RUNSPEC"],
+  "size": 1,
   "items": [
     {"name" : "NUM_COMPS" , "value_type" : "INT"}
   ]

--- a/opm/parser/share/keywords/001_Eclipse300/C/CREF
+++ b/opm/parser/share/keywords/001_Eclipse300/C/CREF
@@ -1,0 +1,20 @@
+{
+  "name": "CREF",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that we don't provide a default here because the parser does not allow ",
+  "comment": "to set defaults for items of unspecified size.",
+  "items" : [{
+      "name": "COMPRESSIBILITY",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1/Pressure"]
+    }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/C/CREFS
+++ b/opm/parser/share/keywords/001_Eclipse300/C/CREFS
@@ -1,0 +1,20 @@
+{
+  "name": "CREFS",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that we don't provide a default here because the parser does not allow ",
+  "comment": "to set defaults for items of unspecified size.",
+  "items" : [{
+      "name": "COMPRESSIBILITY",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1/Pressure"]
+    }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/D/DREF
+++ b/opm/parser/share/keywords/001_Eclipse300/D/DREF
@@ -1,0 +1,20 @@
+{
+  "name": "DREF",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "We don't provide a default here because the documented value ('80% the density of water')",
+  "comment": "cannot currently be implemented on a low level in the parser",
+  "comment": "Also note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "items" : [{
+      "name": "DENSITY",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension" : ["Density"]
+    }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/D/DREFS
+++ b/opm/parser/share/keywords/001_Eclipse300/D/DREFS
@@ -1,0 +1,20 @@
+{
+  "name": "DREFS",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "We don't provide a default here because the documented value ('80% the density of water')",
+  "comment": "cannot currently be implemented on a low level in the parser",
+  "comment": "Also note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "items" : [{
+      "name": "DENSITY",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension" : ["Density"]
+    }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/M/MW
+++ b/opm/parser/share/keywords/001_Eclipse300/M/MW
@@ -1,0 +1,18 @@
+{
+  "name": "MW",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no dimension for this item because there is no unit for 'molar weight' yet",
+  "items" : [{
+      "name": "MOLAR_WEIGHT",
+      "value_type": "DOUBLE",
+      "size_type": "ALL"
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/M/MWS
+++ b/opm/parser/share/keywords/001_Eclipse300/M/MWS
@@ -1,0 +1,18 @@
+{
+  "name": "MWS",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no dimension for this item because there is no unit for 'molar weight' yet",
+  "items" : [{
+      "name": "MOLAR_WEIGHT",
+      "value_type": "DOUBLE",
+      "size_type": "ALL"
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/O/OILCOMPR
+++ b/opm/parser/share/keywords/001_Eclipse300/O/OILCOMPR
@@ -1,0 +1,13 @@
+{
+  "name": "OILCOMPR",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NTPVT"
+  },
+  "items" : [
+    {"name" : "COMPRESSIBILITY" , "value_type" : "DOUBLE", "default": 0.0 },
+    {"name" : "EXPANSION_COEFF_LINEAR" , "value_type" : "DOUBLE", "dimension" : "1/AbsoluteTemperature", "default": 0.0},
+    {"name" : "EXPANSION_COEFF_QUADRATIC" , "value_type" : "DOUBLE", "dimension" : "1/AbsoluteTemperature*AbsoluteTemperature", "default": 0.0}
+  ]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/O/OILMW
+++ b/opm/parser/share/keywords/001_Eclipse300/O/OILMW
@@ -1,0 +1,12 @@
+{
+  "name": "OILMW",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NTPVT"
+  },
+
+  "items" : [
+      {"name" : "MOLAR_WEIGHT" , "value_type" : "DOUBLE"}
+   ]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/P/PREF
+++ b/opm/parser/share/keywords/001_Eclipse300/P/PREF
@@ -1,0 +1,19 @@
+{
+  "name": "PREF",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the default is specified by STCOND",
+  "items" : [{
+      "name": "PRESSURE",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["Pressure"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/P/PREFS
+++ b/opm/parser/share/keywords/001_Eclipse300/P/PREFS
@@ -1,0 +1,19 @@
+{
+  "name": "PREFS",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the default is specified by STCOND",
+  "items" : [{
+      "name": "PRESSURE",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["Pressure"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/S/STCOND
+++ b/opm/parser/share/keywords/001_Eclipse300/S/STCOND
@@ -1,0 +1,8 @@
+{
+  "name": "STCOND",
+  "sections": ["PROPS"],
+  "size": 1,
+  "items": [
+    {"name": "TEMPERATURE", "value_type": "DOUBLE", "dimension": "Temperature", "default": 60},
+    {"name": "PRESSURE", "value_type": "DOUBLE", "dimension": "Pressure", "default": 14.6959}
+]}

--- a/opm/parser/share/keywords/001_Eclipse300/T/THERMAL
+++ b/opm/parser/share/keywords/001_Eclipse300/T/THERMAL
@@ -1,0 +1,1 @@
+{"name" : "THERMAL", "sections" : ["RUNSPEC"]}

--- a/opm/parser/share/keywords/001_Eclipse300/T/THERMEX1
+++ b/opm/parser/share/keywords/001_Eclipse300/T/THERMEX1
@@ -1,0 +1,19 @@
+{
+  "name": "THERMEX1",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "items" : [{
+      "name": "EXPANSION_COEFF",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1/AbsoluteTemperature"],
+      "default": 0.0
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/T/TREF
+++ b/opm/parser/share/keywords/001_Eclipse300/T/TREF
@@ -1,0 +1,19 @@
+{
+  "name": "TREF",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the default is specified by STCOND",
+  "items" : [{
+      "name": "TEMPERATURE",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["AbsoluteTemperature"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/T/TREFS
+++ b/opm/parser/share/keywords/001_Eclipse300/T/TREFS
@@ -1,0 +1,19 @@
+{
+  "name": "TREFS",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the default is specified by STCOND",
+  "items" : [{
+      "name": "TEMPERATURE",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["AbsoluteTemperature"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/W/WATDENT
+++ b/opm/parser/share/keywords/001_Eclipse300/W/WATDENT
@@ -1,0 +1,17 @@
+{
+  "name": "WATDENT",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NTPVT"
+  },
+
+  "comment": "The default for the second item is different from the value given by the Eclipse RM, but for this",
+  "comment": "item, the RM is _very_ inconsistent. (it says that the default for the second item is 1.67/degR in",
+  "comment": "FIELD units which is the same the 3e-4/K for METRIC but four orders of magnitude off!)",
+  "items" : [
+    {"name" : "REFERENCE_TEMPERATURE" , "value_type" : "DOUBLE", "dimension" : "AbsoluteTemperature", "default": 527.67 },
+    {"name" : "EXPANSION_COEFF_LINEAR" , "value_type" : "DOUBLE", "dimension" : "1/AbsoluteTemperature", "default": 1.67e-4 },
+    {"name" : "EXPANSION_COEFF_QUADRATIC" , "value_type" : "DOUBLE", "dimension" : "1/AbsoluteTemperature*AbsoluteTemperature", "default": 9.26e-7 }
+  ]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/Z/ZFACT1
+++ b/opm/parser/share/keywords/001_Eclipse300/Z/ZFACT1
@@ -1,0 +1,20 @@
+{
+  "name": "ZFACT1",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the parser does not (yet?)",
+  "comment": "support default values for items of unknown size",
+  "items" : [{
+      "name": "Z0",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/Z/ZFACT1S
+++ b/opm/parser/share/keywords/001_Eclipse300/Z/ZFACT1S
@@ -1,0 +1,20 @@
+{
+  "name": "ZFACT1S",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the parser does not (yet?)",
+  "comment": "support default values for items of unknown size",
+  "items" : [{
+      "name": "Z0",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/Z/ZFACTOR
+++ b/opm/parser/share/keywords/001_Eclipse300/Z/ZFACTOR
@@ -1,0 +1,20 @@
+{
+  "name": "ZFACTOR",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the parser does not (yet?)",
+  "comment": "support default values for items of unknown size",
+  "items" : [{
+      "name": "Z0",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1"]
+  }]
+}

--- a/opm/parser/share/keywords/001_Eclipse300/Z/ZFACTORS
+++ b/opm/parser/share/keywords/001_Eclipse300/Z/ZFACTORS
@@ -1,0 +1,20 @@
+{
+  "name": "ZFACTORS",
+  "sections": ["PROPS"],
+  "size" : {
+    "keyword": "TABDIMS",
+    "item" : "NUM_STATE_EQ"
+  },
+
+  "comment": "Note that the size of the records of this keyword is unknown. That's because",
+  "comment": "the keyword specifies one value per component (as determined by the COMPS keyword)",
+  "comment": "and this also cannot (yet?) be specified.",
+  "comment": "Also note that there is no default for this item because the parser does not (yet?)",
+  "comment": "support default values for items of unknown size",
+  "items" : [{
+      "name": "Z0",
+      "value_type": "DOUBLE",
+      "size_type": "ALL",
+      "dimension": ["1"]
+  }]
+}

--- a/opm/parser/share/keywords/900_OPM/G/GCOMPIDX
+++ b/opm/parser/share/keywords/900_OPM/G/GCOMPIDX
@@ -1,0 +1,8 @@
+{
+  "name": "GCOMPIDX",
+  "sections": ["RUNSPEC"],
+  "size": 1,
+  "items": [
+    {"name" : "GAS_COMPONENT_INDEX" , "value_type" : "INT"}
+  ]
+}

--- a/opm/parser/share/keywords/900_OPM/O/OCOMPIDX
+++ b/opm/parser/share/keywords/900_OPM/O/OCOMPIDX
@@ -1,0 +1,8 @@
+{
+  "name": "OCOMPIDX",
+  "sections": ["RUNSPEC"],
+  "size": 1,
+  "items": [
+    {"name" : "OIL_COMPONENT_INDEX" , "value_type" : "INT"}
+  ]
+}


### PR DESCRIPTION
this adds the stuff which is required to implement a "pseudo-thermal" black oil simulator. The main thing to be noted is that some Eclipse keywords use thermodynamic temperatures (Rankine or Kelvin) instead of "ordinary" ones (Fahrenheit or Celsius). This makes it necessary to introduce an "AbsoluteTemperature" unit...