### PR TITLE
Default region

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -403,10 +403,7 @@ namespace Opm {
         if (deck->hasKeyword("MULTREGT"))
             multregtKeywords = deck->getKeywordList("MULTREGT");
 
-        std::shared_ptr<MULTREGTScanner> scanner =
-            std::make_shared<MULTREGTScanner>(m_intGridProperties,
-                                              multregtKeywords);
-
+        std::shared_ptr<MULTREGTScanner> scanner = std::make_shared<MULTREGTScanner>(m_intGridProperties, multregtKeywords , m_defaultRegion);
         m_transMult->setMultregtScanner( scanner );
     }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -612,6 +612,16 @@ namespace Opm {
         return m_intGridProperties->getInitializedKeyword( m_defaultRegion );
     }
 
+    std::shared_ptr<GridProperty<int> > EclipseState::getRegion(DeckItemConstPtr regionItem) const {
+        if (regionItem->defaultApplied(0))
+            return getDefaultRegion();
+        else {
+            const std::string regionArray = MULTREGT::RegionNameFromDeckValue( regionItem->getString(0) );
+            return m_intGridProperties->getInitializedKeyword( regionArray );
+        }
+    }
+
+
 
     /*
        Due to the post processor which might be applied to the
@@ -970,8 +980,7 @@ namespace Opm {
             if (supportsGridProperty( targetArray , enabledTypes)) {
                 double doubleValue = record->getItem("VALUE")->getRawDouble(0);
                 int regionValue = record->getItem("REGION_NUMBER")->getInt(0);
-                const std::string regionArray = MULTREGT::RegionNameFromDeckValue( record->getItem("REGION_NAME")->getString(0) );
-                std::shared_ptr<Opm::GridProperty<int> > regionProperty = m_intGridProperties->getInitializedKeyword(regionArray);
+                std::shared_ptr<Opm::GridProperty<int> > regionProperty = getRegion( record->getItem("REGION_NAME") );
                 std::vector<bool> mask;
 
                 regionProperty->initMask( regionValue , mask);
@@ -1014,8 +1023,7 @@ namespace Opm {
             if (supportsGridProperty( targetArray , enabledTypes)) {
                 double doubleValue = record->getItem("SHIFT")->getRawDouble(0);
                 int regionValue = record->getItem("REGION_NUMBER")->getInt(0);
-                const std::string regionArray = MULTREGT::RegionNameFromDeckValue( record->getItem("REGION_NAME")->getString(0) );
-                std::shared_ptr<Opm::GridProperty<int> > regionProperty = m_intGridProperties->getInitializedKeyword(regionArray);
+                std::shared_ptr<Opm::GridProperty<int> > regionProperty = getRegion( record->getItem("REGION_NAME") );
                 std::vector<bool> mask;
 
                 regionProperty->initMask( regionValue , mask);
@@ -1060,8 +1068,7 @@ namespace Opm {
             if (supportsGridProperty( targetArray , enabledTypes)) {
                 double doubleValue = record->getItem("FACTOR")->getRawDouble(0);
                 int regionValue = record->getItem("REGION_NUMBER")->getInt(0);
-                const std::string regionArray = MULTREGT::RegionNameFromDeckValue( record->getItem("REGION_NAME")->getString(0) );
-                std::shared_ptr<Opm::GridProperty<int> > regionProperty = m_intGridProperties->getInitializedKeyword( regionArray );
+                std::shared_ptr<Opm::GridProperty<int> > regionProperty = getRegion( record->getItem("REGION_NAME") );
                 std::vector<bool> mask;
 
                 regionProperty->initMask( regionValue , mask);
@@ -1105,8 +1112,7 @@ namespace Opm {
 
             if (supportsGridProperty( srcArray , enabledTypes)) {
                 int regionValue = record->getItem("REGION_NUMBER")->getInt(0);
-                const std::string regionArray = MULTREGT::RegionNameFromDeckValue( record->getItem("REGION_NAME")->getString(0) );
-                std::shared_ptr<Opm::GridProperty<int> > regionProperty = m_intGridProperties->getInitializedKeyword( regionArray );
+                std::shared_ptr<Opm::GridProperty<int> > regionProperty = getRegion( record->getItem("REGION_NAME") );
                 std::vector<bool> mask;
 
                 regionProperty->initMask( regionValue , mask );

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -82,6 +82,7 @@ namespace Opm {
         std::string getTitle() const;
         bool supportsGridProperty(const std::string& keyword, int enabledTypes=AllProperties) const;
 
+        std::shared_ptr<GridProperty<int> > getRegion(DeckItemConstPtr regionItem) const;
         std::shared_ptr<GridProperty<int> > getDefaultRegion() const;
         std::shared_ptr<GridProperty<int> > getIntGridProperty( const std::string& keyword ) const;
         std::shared_ptr<GridProperty<double> > getDoubleGridProperty( const std::string& keyword ) const;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -82,6 +82,7 @@ namespace Opm {
         std::string getTitle() const;
         bool supportsGridProperty(const std::string& keyword, int enabledTypes=AllProperties) const;
 
+        std::shared_ptr<GridProperty<int> > getDefaultRegion() const;
         std::shared_ptr<GridProperty<int> > getIntGridProperty( const std::string& keyword ) const;
         std::shared_ptr<GridProperty<double> > getDoubleGridProperty( const std::string& keyword ) const;
         bool hasIntGridProperty(const std::string& keyword) const;
@@ -132,6 +133,7 @@ namespace Opm {
         void initSchedule(DeckConstPtr deck, LoggerPtr logger);
         void initSimulationConfig(DeckConstPtr deck);
         void initEclipseGrid(DeckConstPtr deck, LoggerPtr logger);
+        void initGridopts(DeckConstPtr deck);
         void initPhases(DeckConstPtr deck, LoggerPtr logger);
         void initTitle(DeckConstPtr deck, LoggerPtr logger);
         void initProperties(DeckConstPtr deck, LoggerPtr logger);
@@ -261,6 +263,7 @@ namespace Opm {
         std::shared_ptr<GridProperties<double> > m_doubleGridProperties;
         std::shared_ptr<TransMult> m_transMult;
         std::shared_ptr<FaultCollection> m_faults;
+        std::string m_defaultRegion;
     };
 
     typedef std::shared_ptr<EclipseState> EclipseStatePtr;

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -65,10 +65,10 @@ namespace Opm {
 
 
 
-    MULTREGTRecord::MULTREGTRecord(DeckRecordConstPtr deckRecord) :
+    MULTREGTRecord::MULTREGTRecord(DeckRecordConstPtr deckRecord , const std::string& defaultRegion) :
         m_srcRegion("SRC_REGION"),
         m_targetRegion("TARGET_REGION"),
-        m_region("REGION")
+        m_region("REGION" , defaultRegion)
     {
         DeckItemConstPtr srcItem = deckRecord->getItem("SRC_REGION");
         DeckItemConstPtr targetItem = deckRecord->getItem("TARGET_REGION");
@@ -122,11 +122,11 @@ namespace Opm {
       Then it will go through the different regions and looking for
       interface with the wanted region values.
     */
-    MULTREGTScanner::MULTREGTScanner(std::shared_ptr<GridProperties<int> > cellRegionNumbers, const std::vector<DeckKeywordConstPtr>& keywords ) :
+    MULTREGTScanner::MULTREGTScanner(std::shared_ptr<GridProperties<int> > cellRegionNumbers, const std::vector<DeckKeywordConstPtr>& keywords , const std::string& defaultRegion ) :
         m_cellRegionNumbers(cellRegionNumbers) {
 
         for (size_t idx = 0; idx < keywords.size(); idx++)
-            addKeyword(keywords[idx]);
+            addKeyword(keywords[idx] , defaultRegion);
 
         MULTREGTSearchMap searchPairs;
         for (std::vector<MULTREGTRecord>::const_iterator record = m_records.begin(); record != m_records.end(); ++record) {
@@ -159,9 +159,9 @@ namespace Opm {
     }
 
 
-    void MULTREGTScanner::assertKeywordSupported(DeckKeywordConstPtr deckKeyword) {
+    void MULTREGTScanner::assertKeywordSupported(DeckKeywordConstPtr deckKeyword, const std::string& defaultRegion) {
         for (auto iter = deckKeyword->begin(); iter != deckKeyword->end(); ++iter) {
-            MULTREGTRecord record( *iter );
+            MULTREGTRecord record( *iter , defaultRegion);
 
             if (record.m_nncBehaviour == MULTREGT::NOAQUNNC)
                 throw std::invalid_argument("Sorry - currently we do not support \'NOAQUNNC\' for MULTREGT.");
@@ -180,11 +180,11 @@ namespace Opm {
 
 
 
-    void MULTREGTScanner::addKeyword(DeckKeywordConstPtr deckKeyword) {
-        assertKeywordSupported( deckKeyword );
+    void MULTREGTScanner::addKeyword(DeckKeywordConstPtr deckKeyword , const std::string& defaultRegion) {
+        assertKeywordSupported( deckKeyword , defaultRegion );
 
         for (auto iter = deckKeyword->begin(); iter != deckKeyword->end(); ++iter) {
-            MULTREGTRecord record( *iter );
+            MULTREGTRecord record( *iter , defaultRegion );
             /*
               The default value for the region item is to use the
               region item on the previous record, or alternatively

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -48,7 +48,7 @@ namespace Opm {
 
     class MULTREGTRecord {
     public:
-        MULTREGTRecord(DeckRecordConstPtr deckRecord);
+        MULTREGTRecord(DeckRecordConstPtr deckRecord , const std::string& defaultRegion);
 
         Value<int> m_srcRegion;
         Value<int> m_targetRegion;
@@ -66,12 +66,12 @@ namespace Opm {
     class MULTREGTScanner {
 
     public:
-        MULTREGTScanner(std::shared_ptr<GridProperties<int> > cellRegionNumbers, const std::vector<DeckKeywordConstPtr>& keywords);
+        MULTREGTScanner(std::shared_ptr<GridProperties<int> > cellRegionNumbers, const std::vector<DeckKeywordConstPtr>& keywords, const std::string& defaultRegion);
         double getRegionMultiplier(size_t globalCellIdx1, size_t globalCellIdx2, FaceDir::DirEnum faceDir) const;
 
     private:
-        void addKeyword(DeckKeywordConstPtr deckKeyword);
-        void assertKeywordSupported(DeckKeywordConstPtr deckKeyword);
+        void addKeyword(DeckKeywordConstPtr deckKeyword , const std::string& defaultRegion);
+        void assertKeywordSupported(DeckKeywordConstPtr deckKeyword , const std::string& defaultRegion);
         std::vector< MULTREGTRecord > m_records;
         std::map<std::string , MULTREGTSearchMap> m_searchMap;
         std::shared_ptr<GridProperties<int> > m_cellRegionNumbers;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/ADDREGTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/ADDREGTests.cpp
@@ -140,6 +140,8 @@ static Opm::DeckPtr createDeckUnInitializedVector() {
 static Opm::DeckPtr createValidIntDeck() {
     const char *deckData =
         "RUNSPEC\n"
+        "GRIDOPTS\n"
+        "  'YES'  2 /\n"
         "\n"
         "DIMENS\n"
         " 5 5 1 /\n"
@@ -169,6 +171,8 @@ static Opm::DeckPtr createValidIntDeck() {
 static Opm::DeckPtr createValidPERMXDeck() {
     const char *deckData =
         "RUNSPEC\n"
+        "GRIDOPTS\n"
+        "  'YES'  2 /\n"
         "\n"
         "DIMENS\n"
         " 5 5 1 /\n"
@@ -194,7 +198,7 @@ static Opm::DeckPtr createValidPERMXDeck() {
         "25*1 /\n"
         "ADDREG\n"
         "  PERMX 1 1     / \n"
-        "  PERMX 2 2     / \n"
+        "  PERMX 3 2     / \n"
         "/\n"
         "EDIT\n"
         "\n";
@@ -258,14 +262,13 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
 BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::DeckPtr deck = createValidPERMXDeck();
     Opm::EclipseState state(deck);
-    /*std::shared_ptr<Opm::GridProperty<double> > permz = state.getDoubleGridProperty( "PERMZ");
+    std::shared_ptr<Opm::GridProperty<double> > permx = state.getDoubleGridProperty( "PERMX");
 
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
-                BOOST_CHECK_EQUAL( 2 * Opm::Metric::Permeability , permz->iget(i,j,0));
+                BOOST_CHECK_EQUAL( 2 * Opm::Metric::Permeability , permx->iget(i,j,0));
             else
-                BOOST_CHECK_EQUAL( 4 * Opm::Metric::Permeability , permz->iget(i,j,0));
+                BOOST_CHECK_EQUAL( 4 * Opm::Metric::Permeability , permx->iget(i,j,0));
         }
-    */
 }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/CopyRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/CopyRegTests.cpp
@@ -22,7 +22,7 @@
 #include <boost/filesystem.hpp>
 #include <cstdio>
 
-#define BOOST_TEST_MODULE EqualRegTests
+#define BOOST_TEST_MODULE CopyRegTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EqualRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EqualRegTests.cpp
@@ -113,10 +113,19 @@ static Opm::DeckPtr createDeckUnInitialized() {
 static Opm::DeckPtr createValidIntDeck() {
     const char *deckData =
         "RUNSPEC\n"
+        "GRIDOPTS\n"
+        " 'YES'   2 /"
         "\n"
         "DIMENS\n"
         " 5 5 1 /\n"
         "GRID\n"
+        "FLUXNUM \n"
+        "1  1  2  2 2\n"
+        "1  1  2  2 2\n"
+        "1  1  2  2 2\n"
+        "1  1  2  2 2\n"
+        "1  1  2  2 2\n"
+        "/\n"
         "MULTNUM \n"
         "1  1  2  2 2\n"
         "1  1  2  2 2\n"
@@ -139,6 +148,8 @@ static Opm::DeckPtr createValidIntDeck() {
 static Opm::DeckPtr createValidPERMXDeck() {
     const char *deckData =
         "RUNSPEC\n"
+        "GRIDOPTS\n"
+        " 'YES'   2 /"
         "\n"
         "DIMENS\n"
         " 5 5 1 /\n"

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
@@ -116,19 +116,19 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
     std::vector<Opm::DeckKeywordConstPtr> keywords0;
     Opm::DeckKeywordConstPtr multregtKeyword0 = deck->getKeyword("MULTREGT",0);
     keywords0.push_back( multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords0); , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords0,"MULTNUM"); , std::invalid_argument);
 
     // Not supported region
     std::vector<Opm::DeckKeywordConstPtr> keywords1;
     Opm::DeckKeywordConstPtr multregtKeyword1 = deck->getKeyword("MULTREGT",1);
     keywords1.push_back( multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords1); , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords1,"MULTNUM"); , std::invalid_argument);
 
     // The keyword is ok; but it refers to a region which is not in the deck.
     std::vector<Opm::DeckKeywordConstPtr> keywords2;
     Opm::DeckKeywordConstPtr multregtKeyword2 = deck->getKeyword("MULTREGT",2);
     keywords2.push_back( multregtKeyword2 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords2); , std::logic_error);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords2,"MULTNUM"); , std::logic_error);
 }
 
 
@@ -182,26 +182,26 @@ BOOST_AUTO_TEST_CASE(NotSupported) {
     std::vector<Opm::DeckKeywordConstPtr> keywords0;
     Opm::DeckKeywordConstPtr multregtKeyword0 = deck->getKeyword("MULTREGT",0);
     keywords0.push_back( multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords0); , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords0,"MULTNUM"); , std::invalid_argument);
 
     // Defaulted from value - not supported
     std::vector<Opm::DeckKeywordConstPtr> keywords1;
     Opm::DeckKeywordConstPtr multregtKeyword1 = deck->getKeyword("MULTREGT",1);
     keywords1.push_back( multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords1); , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords1,"MULTNUM"); , std::invalid_argument);
 
     // Defaulted to value - not supported
     std::vector<Opm::DeckKeywordConstPtr> keywords2;
     Opm::DeckKeywordConstPtr multregtKeyword2 = deck->getKeyword("MULTREGT",2);
     keywords2.push_back( multregtKeyword2 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords2); , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords2,"MULTNUM"); , std::invalid_argument);
 
 
     // srcValue == targetValue - not supported
     std::vector<Opm::DeckKeywordConstPtr> keywords3;
     Opm::DeckKeywordConstPtr multregtKeyword3 = deck->getKeyword("MULTREGT",3);
     keywords3.push_back( multregtKeyword3 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords3); , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner(gridProperties,keywords3 , "MULTNUM"); , std::invalid_argument);
 
 }
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MultiRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MultiRegTests.cpp
@@ -140,6 +140,8 @@ static Opm::DeckPtr createDeckUnInitialized() {
 static Opm::DeckPtr createValidIntDeck() {
     const char *deckData =
         "RUNSPEC\n"
+        "GRIDOPTS\n"
+        "  'YES'  2 /\n"
         "\n"
         "DIMENS\n"
         " 5 5 1 /\n"

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -349,3 +349,62 @@ BOOST_AUTO_TEST_CASE(FaceTransMults) {
         }
     }
 }
+
+
+static DeckPtr createDeckNoGridOpts() {
+    const char *deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " 10 10 10 /\n"
+        "GRID\n"
+        "FLUXNUM\n"
+        "  1000*1 /\n"
+        "MULTNUM\n"
+        "  1000*1 /\n";
+
+    ParserPtr parser(new Parser());
+    return parser->parseString(deckData) ;
+}
+
+
+static DeckPtr createDeckWithGridOpts() {
+    const char *deckData =
+        "RUNSPEC\n"
+        "GRIDOPTS\n"
+        "  'YES'   10 /"
+        "\n"
+        "DIMENS\n"
+        " 10 10 10 /\n"
+        "GRID\n"
+        "FLUXNUM\n"
+        "  1000*1 /\n"
+        "MULTNUM\n"
+        "  1000*1 /\n";
+
+    ParserPtr parser(new Parser());
+    return parser->parseString(deckData) ;
+}
+
+
+BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
+    DeckPtr deck = createDeckNoGridOpts();
+    EclipseState state(deck);
+    auto multnum = state.getIntGridProperty("MULTNUM");
+    auto fluxnum = state.getIntGridProperty("FLUXNUM");
+    auto def_property = state.getDefaultRegion();
+
+    BOOST_CHECK_EQUAL( fluxnum  , def_property );
+}
+
+
+BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
+    DeckPtr deck = createDeckWithGridOpts();
+    EclipseState state(deck);
+    auto multnum = state.getIntGridProperty("MULTNUM");
+    auto fluxnum = state.getIntGridProperty("FLUXNUM");
+    auto def_property = state.getDefaultRegion();
+
+    BOOST_CHECK_EQUAL( multnum , def_property );
+}
+


### PR DESCRIPTION
The GRIDOPTS keyword has some weird behaviour  - something like this: "If the second item is defaulted the default region for the xxxxREG keywords changes from MULTNUM to FLUXNUM". I think. 

If someone knows for sure that I have misunderstood this weird behaviour I would be very happy for a tip.

See the comment here for more details: https://github.com/joakim-hove/opm-parser/blob/default-region/opm/parser/eclipse/EclipseState/EclipseState.cpp#L417

With this PR applied it should not be necessary to perform the FLUXNUM -> MULTNUM copy.