### PR TITLE
OPM-157: Added method getGlobalIndex to EclipseGrid

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -211,6 +211,10 @@ namespace Opm {
     }
 
 
+    size_t EclipseGrid::getGlobalIndex(size_t i, size_t j, size_t k) const {
+        return (i + j * getNX() + k * getNX() * getNY());
+    }
+
     void EclipseGrid::assertGlobalIndex(size_t globalIndex) const {
         if (globalIndex >= getCartesianSize())
             throw std::invalid_argument("input index above valid range");

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -87,6 +87,7 @@ namespace Opm {
         
         bool hasCellInfo() const;
 
+        size_t getGlobalIndex(size_t i, size_t j, size_t k) const;
         void assertGlobalIndex(size_t globalIndex) const;
         void assertIJK(size_t i , size_t j , size_t k) const;
         std::tuple<double,double,double> getCellCenter(size_t i,size_t j, size_t k) const;


### PR DESCRIPTION
Added method getGlobalIndex to EclipseGrid, needed from opm-core EclipseWriter