### PR TITLE
Remove surplus const for return-by-value.

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -89,7 +89,7 @@ namespace Opm {
         return m_name;
     }
 
-    const UnitSystem::UnitType UnitSystem::getType() const {
+    UnitSystem::UnitType UnitSystem::getType() const {
         return m_unittype;
     }
 

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         UnitSystem(UnitType unit);
 
         const std::string& getName() const;
-        const UnitType getType() const;
+        UnitType getType() const;
 
         void addDimension(const std::string& dimension, double SIfactor, double SIoffset = 0.0);
         void addDimension(std::shared_ptr<const Dimension> dimension);


### PR DESCRIPTION
This triggers compiler warnings at high warning levels.