### PR TITLE
added: build ERT in source tree if not found

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 include("cmake/Modules/CheckCaseSensitiveFileSystem.cmake")
 add_definitions("-DHAVE_CASE_SENSITIVE_FILESYSTEM=${HAVE_CASE_SENSITIVE_FILESYSTEM}")
 
-find_package(ERT)
+find_package(ERT REQUIRED)
 include_directories( ${ERT_INCLUDE_DIRS} )   
 
 set(LIBRARY_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR})

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -240,6 +240,8 @@ add_custom_target( keywordlist ALL COMMAND createDefaultKeywordList
 #-----------------------------------------------------------------
 
 add_library(Parser ${rawdeck_source} ${parser_source} ${deck_source} ${state_source} ${unit_source} ${log_source})
+add_dependencies(Parser ${LIBRARY_DEPS})
+
 add_dependencies(Parser keywordlist)
 target_link_libraries(Parser opm-json ${Boost_LIBRARIES}  ${ERT_LIBRARIES})
 


### PR DESCRIPTION
This is a POC of what was discussed at the opm seminar. This will build ERT in the opm-parser build tree if it is not found externally.

Note that I made ERT REQUIRED. i think it actually is and that the statement in CMakeLists.txt is wrong.

also 
```
if (condition)
else(condition)
endif(condition)
```
is evil, as highlighted by the unnecessary diff lines ;)