### PR TITLE
OPM-87, added code for handling keyword WELTARG.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -507,7 +507,7 @@ namespace Opm {
 
             const std::string& wellNamePattern = record->getItem("WELL")->getTrimmedString(0);
             const std::string& cMode = record->getItem("CMODE")->getTrimmedString(0);
-            double newValue = getNewValue(record);
+            double newValue = record->getItem("NEW_VALUE")->getRawDouble(0);
             const std::vector<WellPtr>& wells = getWells(wellNamePattern);
 
             for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
@@ -548,20 +548,6 @@ namespace Opm {
                 well->setProductionProperties(currentStep, prop);
             }
         }
-    }
-
-    double Schedule::getNewValue(DeckRecordConstPtr record) {
-        double newValue = 0.0;
-        auto item = record->getItem("NEW_VALUE");
-
-        if (!item->hasValue(0)){
-            throw std::invalid_argument("Sorry - the value item in WELTARG can not be defaulted");
-        }
-        else{
-            newValue = item->getRawDouble(0);
-        }
-
-        return newValue;
     }
 
     void Schedule::handleGCONINJE(DeckConstPtr deck, DeckKeywordConstPtr keyword, size_t currentStep) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -99,7 +99,6 @@ namespace Opm
 
         static double convertInjectionRateToSI(double rawRate, WellInjector::TypeEnum wellType, const Opm::UnitSystem &unitSystem);
         static double convertInjectionRateToSI(double rawRate, Phase::PhaseEnum wellPhase, const Opm::UnitSystem &unitSystem);
-        double getNewValue(DeckRecordConstPtr record);
         static bool convertEclipseStringToBool(const std::string& eclipseString);
 
     };

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -86,7 +86,7 @@ namespace Opm
         void handleWPOLYMER(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleWCONINJH(DeckConstPtr deck, DeckKeywordConstPtr keyword, size_t currentStep);
         void handleWELOPEN(DeckKeywordConstPtr keyword, size_t currentStep, bool hascomplump);
-        void handleWELTARG(DeckKeywordConstPtr keyword, size_t currentStep);
+        void handleWELTARG(DeckConstPtr deck, DeckKeywordConstPtr keyword, size_t currentStep);
         void handleGCONINJE(DeckConstPtr deck, DeckKeywordConstPtr keyword, size_t currentStep);
         void handleGCONPROD(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleDATES(DeckKeywordConstPtr keyword);
@@ -99,6 +99,7 @@ namespace Opm
 
         static double convertInjectionRateToSI(double rawRate, WellInjector::TypeEnum wellType, const Opm::UnitSystem &unitSystem);
         static double convertInjectionRateToSI(double rawRate, Phase::PhaseEnum wellPhase, const Opm::UnitSystem &unitSystem);
+        double getNewValue(DeckRecordConstPtr record);
         static bool convertEclipseStringToBool(const std::string& eclipseString);
 
     };

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -86,6 +86,7 @@ namespace Opm
         void handleWPOLYMER(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleWCONINJH(DeckConstPtr deck, DeckKeywordConstPtr keyword, size_t currentStep);
         void handleWELOPEN(DeckKeywordConstPtr keyword, size_t currentStep, bool hascomplump);
+        void handleWELTARG(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleGCONINJE(DeckConstPtr deck, DeckKeywordConstPtr keyword, size_t currentStep);
         void handleGCONPROD(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleDATES(DeckKeywordConstPtr keyword);

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -115,23 +115,13 @@ namespace Opm {
 
     void WellProductionProperties::init() {
         OilRate = 0.0;
-        GasRate = 0.0;
         WaterRate = 0.0;
+        GasRate = 0.0;
         LiquidRate = 0.0;
-        LinearlyCombinedRate = 0.0;
         ResVRate = 0.0;
         BHPLimit = 0.0;
         THPLimit = 0.0;
-        VFPTableNumber = 0.0;
-        ArtificialLiftQuantity = 0.0;
-        GuideRate = 0.0;
-        WetGasRate = 0.0;
-        NGLRate = 0.0;
-        CalorificProductionRate = 0.0;
-        ReinjectionFraction = 0.0;
-        SteamRate = 0.0;
-        SaturationPressureOffset = 0.0;
-        SaturationTemperatureOffset = 0.0;
+        VFPTableNumber = 0;
         controlMode = WellProducer::CMODE_UNDEFINED;
 
         m_productionControls = 0;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -118,9 +118,20 @@ namespace Opm {
         GasRate = 0.0;
         WaterRate = 0.0;
         LiquidRate = 0.0;
+        LinearlyCombinedRate = 0.0;
         ResVRate = 0.0;
         BHPLimit = 0.0;
         THPLimit = 0.0;
+        VFPTableNumber = 0.0;
+        ArtificialLiftQuantity = 0.0;
+        GuideRate = 0.0;
+        WetGasRate = 0.0;
+        NGLRate = 0.0;
+        CalorificProductionRate = 0.0;
+        ReinjectionFraction = 0.0;
+        SteamRate = 0.0;
+        SaturationPressureOffset = 0.0;
+        SaturationTemperatureOffset = 0.0;
         controlMode = WellProducer::CMODE_UNDEFINED;
 
         m_productionControls = 0;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -29,9 +29,20 @@ namespace Opm {
         double  GasRate;
         double  WaterRate;
         double  LiquidRate;
+        double  LinearlyCombinedRate;
         double  ResVRate;
         double  BHPLimit;
         double  THPLimit;
+        double  VFPTableNumber;
+        double  ArtificialLiftQuantity;
+        double  GuideRate;
+        double  WetGasRate;
+        double  NGLRate;
+        double  CalorificProductionRate;
+        double  ReinjectionFraction;
+        double  SteamRate;
+        double  SaturationPressureOffset;
+        double  SaturationTemperatureOffset;
         bool    predictionMode;
 
         WellProducer::ControlModeEnum controlMode;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -26,23 +26,13 @@
 namespace Opm {
     struct WellProductionProperties {
         double  OilRate;
-        double  GasRate;
         double  WaterRate;
+        double  GasRate;
         double  LiquidRate;
-        double  LinearlyCombinedRate;
         double  ResVRate;
         double  BHPLimit;
         double  THPLimit;
-        double  VFPTableNumber;
-        double  ArtificialLiftQuantity;
-        double  GuideRate;
-        double  WetGasRate;
-        double  NGLRate;
-        double  CalorificProductionRate;
-        double  ReinjectionFraction;
-        double  SteamRate;
-        double  SaturationPressureOffset;
-        double  SaturationTemperatureOffset;
+        int  VFPTableNumber;
         bool    predictionMode;
 
         WellProducer::ControlModeEnum controlMode;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -750,3 +750,32 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
     BOOST_CHECK_EQUAL(wpp.VFPTableNumber, 2100);
     BOOST_CHECK_EQUAL(well->getGuideRate(2), 2300.14);
 }
+
+BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
+    Opm::Parser parser;
+    std::string input =
+            "WELTARG\n"
+            " OP_1     GRAT        1500.52 /\n"
+            " OP_1     LRAT        /\n"
+            " OP_1     RESV        1801.05 /\n"
+            "/\n";
+
+    DeckPtr deck = parser.parseString(input);
+    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+
+    BOOST_CHECK_THROW(Schedule (grid , deck), std::invalid_argument);
+}
+
+BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
+    Opm::Parser parser;
+    std::string input =
+            "WELTARG\n"
+            " OP_1     LRAT        /\n"
+            " OP_1     RESV        1801.05 /\n"
+            "/\n";
+
+    DeckPtr deck = parser.parseString(input);
+    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+
+    BOOST_CHECK_THROW(Schedule (grid , deck), std::out_of_range);
+}

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -69,7 +69,6 @@ static DeckPtr createDeckWithWells() {
     return parser.parseString(input);
 }
 
-
 static DeckPtr createDeckWithWellsOrdered() {
     Opm::Parser parser;
     std::string input =
@@ -84,7 +83,6 @@ static DeckPtr createDeckWithWellsOrdered() {
 
     return parser.parseString(input);
 }
-
 
 static DeckPtr createDeckWithWellsAndCompletionData() {
     Opm::Parser parser;
@@ -117,10 +115,8 @@ static DeckPtr createDeckWithWellsAndCompletionData() {
       " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
       "/\n";
 
-
     return parser.parseString(input);
 }
-
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     DeckPtr deck(new Deck());
@@ -130,7 +126,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     Schedule schedule(grid , deck);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1983  , boost::gregorian::Jan , 1)));
 }
-
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     DeckPtr deck = createDeckWithWellsOrdered();
@@ -143,15 +138,12 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     BOOST_CHECK_EQUAL( "AW_3" , wells[2]->name());
 }
 
-
-
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     DeckPtr deck = createDeck();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     Schedule schedule(grid , deck);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1998  , boost::gregorian::Mar , 8)));
 }
-
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     DeckPtr deck(new Deck());
@@ -162,7 +154,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     BOOST_CHECK_NO_THROW(Schedule schedule(grid , deck));
 }
 
-
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
@@ -172,14 +163,12 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     BOOST_CHECK_THROW( schedule.getWell("WELL2") , std::invalid_argument );
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForTimeStepZero) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
     Schedule schedule(grid , deck);
     BOOST_CHECK_EQUAL("FIELD", schedule.getGroupTree(0)->getNode("FIELD")->name());
 }
-
 
 BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTimeStepZero) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
@@ -202,9 +191,6 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
     GroupTreeNodePtr FAREN = fieldNode->getChildGroup("FAREN");
     BOOST_CHECK(FAREN->hasChildGroup("BARNET"));
 }
-
-
-
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
@@ -241,7 +227,6 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     std::vector<WellConstPtr> wells_t3 = schedule.getWells(3);
     BOOST_CHECK_EQUAL(3U, wells_t3.size());
 }
-
 
 BOOST_AUTO_TEST_CASE(WellsIteratorWithRegex_HasWells_WellsReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
@@ -337,8 +322,6 @@ static DeckPtr createDeckWithWellsAndCompletionDataWithWELOPEN() {
     return parser.parseString(input);
 }
 
-
-
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionDataWithWELOPEN();
@@ -406,11 +389,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
 
     currentStep = 5;
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
-
-
 }
-
-
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompletionsDoNotOpenWell) {
   Opm::Parser parser;
@@ -458,7 +437,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
   currentStep = 4;
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
 }
-
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1_ThrowsExcpetion) {
     Opm::Parser parser;
@@ -651,7 +629,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
 
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     Opm::Parser parser;
     std::string input =
@@ -738,26 +715,17 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
             "WELTARG\n"
             " OP_1     ORAT        1300 /\n"
             " OP_1     WRAT        1400 /\n"
-            " OP_1     GRAT        1500 /\n"
+            " OP_1     GRAT        1500.52 /\n"
             " OP_1     LRAT        1600.58 /\n"
-            " OP_1     CRAT        1722.15 /\n"
             " OP_1     RESV        1801.05 /\n"
             " OP_1     BHP         1900 /\n"
             " OP_1     THP         2000 /\n"
-            " OP_1     VFP         2100 /\n"
-            " OP_1     LIFT        2200 /\n"
-            " OP_1     GUID        2300 /\n"
-            " OP_1     WGRA        2490.09 /\n"
-            " OP_1     NGL         2519.51 /\n"
-            " OP_1     CVAL        2600 /\n"
-            " OP_1     REIN        2700 /\n"
-            " OP_1     STRA        2800 /\n"
-            " OP_1     SATP        2900 /\n"
-            " OP_1     SATT        3000 /\n"
+            " OP_1     VFP         2100.09 /\n"
+            " OP_1     GUID        2300.14 /\n"
             "/\n";
 
     DeckPtr deck = parser.parseString(input);
-    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );        
     Schedule schedule(grid , deck);
     WellPtr well = schedule.getWell("OP_1");
 
@@ -765,24 +733,20 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
     WellProductionProperties wpp = well->getProductionProperties(currentStep);
     BOOST_CHECK_EQUAL(wpp.WaterRate,0);
 
+    Opm::UnitSystem unitSystem = *deck->getActiveUnitSystem();
+    double siFactorL = unitSystem.parse("LiquidSurfaceVolume/Time")->getSIScaling();
+    double siFactorG = unitSystem.parse("GasSurfaceVolume/Time")->getSIScaling();
+    double siFactorP = unitSystem.parse("Pressure")->getSIScaling();
+
     currentStep = 2;
     wpp = well->getProductionProperties(currentStep);
-    BOOST_CHECK_EQUAL(wpp.OilRate, 1300);
-    BOOST_CHECK_EQUAL(wpp.WaterRate, 1400);
-    BOOST_CHECK_EQUAL(wpp.GasRate, 1500);
-    BOOST_CHECK_EQUAL(wpp.LiquidRate, 1600.58);
-    BOOST_CHECK_EQUAL(wpp.LinearlyCombinedRate, 1722.15);
-    BOOST_CHECK_EQUAL(wpp.ResVRate, 1801.05);
-    BOOST_CHECK_EQUAL(wpp.BHPLimit, 1900);
-    BOOST_CHECK_EQUAL(wpp.THPLimit, 2000);
+    BOOST_CHECK_EQUAL(wpp.OilRate, 1300 * siFactorL);
+    BOOST_CHECK_EQUAL(wpp.WaterRate, 1400 * siFactorL);
+    BOOST_CHECK_EQUAL(wpp.GasRate, 1500.52 * siFactorG);
+    BOOST_CHECK_EQUAL(wpp.LiquidRate, 1600.58 * siFactorL);
+    BOOST_CHECK_EQUAL(wpp.ResVRate, 1801.05 * siFactorL);
+    BOOST_CHECK_EQUAL(wpp.BHPLimit, 1900 * siFactorP);
+    BOOST_CHECK_EQUAL(wpp.THPLimit, 2000 * siFactorP);
     BOOST_CHECK_EQUAL(wpp.VFPTableNumber, 2100);
-    BOOST_CHECK_EQUAL(wpp.ArtificialLiftQuantity, 2200);
-    BOOST_CHECK_EQUAL(wpp.GuideRate, 2300);
-    BOOST_CHECK_EQUAL(wpp.WetGasRate, 2490.09);
-    BOOST_CHECK_EQUAL(wpp.NGLRate, 2519.51);
-    BOOST_CHECK_EQUAL(wpp.CalorificProductionRate, 2600);
-    BOOST_CHECK_EQUAL(wpp.ReinjectionFraction, 2700);
-    BOOST_CHECK_EQUAL(wpp.SteamRate, 2800);
-    BOOST_CHECK_EQUAL(wpp.SaturationPressureOffset, 2900);
-    BOOST_CHECK_EQUAL(wpp.SaturationTemperatureOffset, 3000);
+    BOOST_CHECK_EQUAL(well->getGuideRate(2), 2300.14);
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -339,7 +339,6 @@ static DeckPtr createDeckWithWellsAndCompletionDataWithWELOPEN() {
 
 
 
-
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionDataWithWELOPEN();
@@ -694,7 +693,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
                     "WELOPEN\n"
                     " 'OP_1' OPEN / \n"
                     "/\n"
-
                     "COMPLUMP\n"
                     " 'OP_1' 0 0 0 0 0 / \n "
                     "/\n"
@@ -708,7 +706,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     WellPtr well;
     well = schedule.getWell("OP_1");
 
-
     size_t currentStep = 3;
     BOOST_CHECK_EQUAL(well->getRFTActive(currentStep),false);
     currentStep = 4;
@@ -718,3 +715,74 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     BOOST_CHECK_EQUAL(well->getRFTActive(currentStep),false);
 }
 
+BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
+    Opm::Parser parser;
+    std::string input =
+            "START             -- 0 \n"
+            "19 JUN 2007 / \n"
+            "SCHEDULE\n"
+            "DATES             -- 1\n"
+            " 10  OKT 2008 / \n"
+            "/\n"
+            "WELSPECS\n"
+            "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "/\n"
+            "COMPDAT\n"
+            " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+            " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            "/\n"
+            "DATES             -- 2\n"
+            " 20  JAN 2010 / \n"
+            "/\n"
+            "WELTARG\n"
+            " OP_1     ORAT        1300 /\n"
+            " OP_1     WRAT        1400 /\n"
+            " OP_1     GRAT        1500 /\n"
+            " OP_1     LRAT        1600.58 /\n"
+            " OP_1     CRAT        1722.15 /\n"
+            " OP_1     RESV        1801.05 /\n"
+            " OP_1     BHP         1900 /\n"
+            " OP_1     THP         2000 /\n"
+            " OP_1     VFP         2100 /\n"
+            " OP_1     LIFT        2200 /\n"
+            " OP_1     GUID        2300 /\n"
+            " OP_1     WGRA        2490.09 /\n"
+            " OP_1     NGL         2519.51 /\n"
+            " OP_1     CVAL        2600 /\n"
+            " OP_1     REIN        2700 /\n"
+            " OP_1     STRA        2800 /\n"
+            " OP_1     SATP        2900 /\n"
+            " OP_1     SATT        3000 /\n"
+            "/\n";
+
+    DeckPtr deck = parser.parseString(input);
+    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+    Schedule schedule(grid , deck);
+    WellPtr well = schedule.getWell("OP_1");
+
+    size_t currentStep = 1;
+    WellProductionProperties wpp = well->getProductionProperties(currentStep);
+    BOOST_CHECK_EQUAL(wpp.WaterRate,0);
+
+    currentStep = 2;
+    wpp = well->getProductionProperties(currentStep);
+    BOOST_CHECK_EQUAL(wpp.OilRate, 1300);
+    BOOST_CHECK_EQUAL(wpp.WaterRate, 1400);
+    BOOST_CHECK_EQUAL(wpp.GasRate, 1500);
+    BOOST_CHECK_EQUAL(wpp.LiquidRate, 1600.58);
+    BOOST_CHECK_EQUAL(wpp.LinearlyCombinedRate, 1722.15);
+    BOOST_CHECK_EQUAL(wpp.ResVRate, 1801.05);
+    BOOST_CHECK_EQUAL(wpp.BHPLimit, 1900);
+    BOOST_CHECK_EQUAL(wpp.THPLimit, 2000);
+    BOOST_CHECK_EQUAL(wpp.VFPTableNumber, 2100);
+    BOOST_CHECK_EQUAL(wpp.ArtificialLiftQuantity, 2200);
+    BOOST_CHECK_EQUAL(wpp.GuideRate, 2300);
+    BOOST_CHECK_EQUAL(wpp.WetGasRate, 2490.09);
+    BOOST_CHECK_EQUAL(wpp.NGLRate, 2519.51);
+    BOOST_CHECK_EQUAL(wpp.CalorificProductionRate, 2600);
+    BOOST_CHECK_EQUAL(wpp.ReinjectionFraction, 2700);
+    BOOST_CHECK_EQUAL(wpp.SteamRate, 2800);
+    BOOST_CHECK_EQUAL(wpp.SaturationPressureOffset, 2900);
+    BOOST_CHECK_EQUAL(wpp.SaturationTemperatureOffset, 3000);
+}


### PR DESCRIPTION
Handling keyword WELTARG. This keyword is used to modify WellProductionProperties for the spesified wells - at the specified timestep. 
Modified files:
WellProductionProperties.cpp,
WellProductionProperties.hpp,
Schedule.cpp,
Schedule.hpp,
ScheduleTests.cpp.