### PR TITLE
Fix warnings

### DIFF
--- a/opm/parser/eclipse/OpmLog/Logger.cpp
+++ b/opm/parser/eclipse/OpmLog/Logger.cpp
@@ -107,7 +107,7 @@ namespace Opm {
     }
 
 
-    void Logger::addMessageType( int64_t messageType , const std::string& prefix) {
+    void Logger::addMessageType( int64_t messageType , const std::string& /* prefix */) {
         if (Log::isPower2( messageType)) {
             m_enabledTypes |= messageType;
         } else

--- a/opm/parser/eclipse/OpmLog/tests/OpmLogTests.cpp
+++ b/opm/parser/eclipse/OpmLog/tests/OpmLogTests.cpp
@@ -131,7 +131,7 @@ public:
         m_specialMessages = 0;
     }
 
-    void addMessage(int64_t messageType , const std::string& message) {
+    void addMessage(int64_t messageType , const std::string& /* message */) {
         if (messageType & Log::DefaultMessageTypes)
             m_defaultMessages +=1;
         else


### PR DESCRIPTION
This suppresses two unused argument warnings. With this, all of opm-parser compiles with no warnings at a very high warning level.