### PR TITLE
quick fix: set soversion for installed objects

### DIFF
--- a/opm/json/CMakeLists.txt
+++ b/opm/json/CMakeLists.txt
@@ -7,7 +7,9 @@ if (NOT HAVE_CJSON)
 endif()
 add_library(opm-json ${json_source})
 target_link_libraries( opm-json ${CJSON_LIBRARY} ${Boost_LIBRARIES} )
-
+set_target_properties (opm-json PROPERTIES
+                       SOVERSION 1.0
+                       VERSION 2015.04)
 
 install( TARGETS opm-json DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 foreach ( header ${json_headers} ) 

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -255,6 +255,9 @@ add_custom_target( keywordlist ALL COMMAND createDefaultKeywordList
 add_library(Parser ${rawdeck_source} ${parser_source} ${deck_source} ${state_source} ${unit_source} ${log_source})
 add_dependencies(Parser keywordlist)
 target_link_libraries(Parser opm-json ${Boost_LIBRARIES}  ${ERT_LIBRARIES})
+set_target_properties (Parser PROPERTIES
+                       SOVERSION 1.0
+                       VERSION 2015.04)
 
 include( ${PROJECT_SOURCE_DIR}/cmake/Modules/install_headers.cmake )   
 install_headers( "${HEADER_FILES}" "${CMAKE_INSTALL_PREFIX}" )


### PR DESCRIPTION
installed objects needs to be versioned. this is a quick fix for the release branch, should be fixed by using the shared build system in later releases.