### PR TITLE
Adding member function for plyshlog to the class EclipseState

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -197,6 +197,10 @@ namespace Opm {
         return m_plyviscTables;
     }
 
+    const std::vector<PlyshlogTable>& EclipseState::getPlyshlogTables() const {
+        return m_plyshlogTables;
+    }
+
     const std::vector<PvdgTable>& EclipseState::getPvdgTables() const {
         return m_pvdgTables;
     }

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -112,6 +112,7 @@ namespace Opm {
         const std::vector<PlymaxTable>& getPlymaxTables() const;
         const std::vector<PlyrockTable>& getPlyrockTables() const;
         const std::vector<PlyviscTable>& getPlyviscTables() const;
+        const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PvdgTable>& getPvdgTables() const;
         const std::vector<PvdoTable>& getPvdoTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -81,6 +81,7 @@ namespace Opm {
 
         }
 
+    public:
 
         double getRefPolymerConcentration() const {
             return m_refPolymerConcentration;
@@ -105,11 +106,11 @@ namespace Opm {
             m_refTemperature = refTemperature;
         }
 
-        bool hasRefSalinity() {
+        bool hasRefSalinity() const {
             return m_hasRefSalinity;
         }
 
-        bool hasRefTemperature() {
+        bool hasRefTemperature() const {
             return m_hasRefTemperature;
         }
 


### PR DESCRIPTION
Summary:

  1.  Adding the member functions for PlyshlogTable in class EclipseState, which is forgotten when adding the support for keyword PLYSHLOG.
  2. Making the member functions of PLyshlogTable public and adding const to two functions to solving compiling error in opm-polymer. 