### PR TITLE
Opm 199 IOConfig

### DIFF
--- a/opm/parser/eclipse/Applications/Schedule.cpp
+++ b/opm/parser/eclipse/Applications/Schedule.cpp
@@ -16,7 +16,8 @@ int main(int /* argc */, char** argv) {
     std::string file = argv[1];
     Opm::DeckConstPtr deck = parser->parseFile(file);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( deck );
-    Opm::Schedule sched( grid , deck );
+    Opm::IOConfigPtr ioConfig;
+    Opm::Schedule sched( grid , deck, ioConfig );
 
     std::cout << "Wells: " << sched.numWells() << std::endl;
 

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -10,7 +10,9 @@ if (BUILD_TESTING)
    add_subdirectory(EclipseState/Tables/tests)
    add_subdirectory(EclipseState/Grid/tests)
    add_subdirectory(EclipseState/Util/tests)
+   add_subdirectory(EclipseState/IOConfig/tests)
    add_subdirectory(ert/tests)
+
 endif()
 
 add_subdirectory( Applications )
@@ -108,6 +110,8 @@ EclipseState/Grid/FaultCollection.cpp
 EclipseState/SimulationConfig/SimulationConfig.cpp
 EclipseState/SimulationConfig/ThresholdPressure.cpp
 #
+EclipseState/IOConfig/IOConfig.cpp
+#
 ert/EclKW.cpp
 ert/FortIO.cpp)
 
@@ -192,6 +196,8 @@ EclipseState/Grid/FaultCollection.hpp
 #
 EclipseState/SimulationConfig/SimulationConfig.hpp
 EclipseState/SimulationConfig/ThresholdPressure.hpp
+#
+EclipseState/IOConfig/IOConfig.hpp
 #
 EclipseState/Tables/Tabdims.hpp
 EclipseState/Tables/PlyadsTable.hpp

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -59,6 +59,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
 #include <set>
 #include <memory>
@@ -77,6 +78,7 @@ namespace Opm {
         EclipseState(DeckConstPtr deck);
 
         ScheduleConstPtr getSchedule() const;
+        IOConfigConstPtr getIOConfig() const;
         SimulationConfigConstPtr getSimulationConfig() const;
         EclipseGridConstPtr getEclipseGrid() const;
         EclipseGridPtr getEclipseGridCopy() const;
@@ -135,7 +137,9 @@ namespace Opm {
     private:
         void initTabdims(DeckConstPtr deck);
         void initTables(DeckConstPtr deck);
+        void initIOConfig(DeckConstPtr deck);
         void initSchedule(DeckConstPtr deck);
+        void initIOConfigPostSchedule(DeckConstPtr deck);
         void initSimulationConfig(DeckConstPtr deck);
         void initEclipseGrid(DeckConstPtr deck);
         void initGridopts(DeckConstPtr deck);
@@ -234,9 +238,11 @@ namespace Opm {
 
         void complainAboutAmbiguousKeyword(DeckConstPtr deck, const std::string& keywordName) const;
 
-        EclipseGridConstPtr m_eclipseGrid;
-        ScheduleConstPtr schedule;
+        EclipseGridConstPtr      m_eclipseGrid;
+        IOConfigPtr              m_ioConfig;
+        ScheduleConstPtr         schedule;
         SimulationConfigConstPtr m_simulationConfig;
+
 
         std::shared_ptr<const Tabdims> m_tabdims;
         std::vector<EnkrvdTable> m_enkrvdTables;

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -1,0 +1,244 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iterator>
+
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckIntItem.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
+
+
+namespace Opm {
+
+    IOConfig::IOConfig(DeckConstPtr deck, const std::string& input_path):
+        m_write_INIT_file(false),
+        m_write_EGRID_file(true),
+        m_UNIFIN(false),
+        m_UNIFOUT(false),
+        m_FMTIN(false),
+        m_FMTOUT(false),
+        m_eclipse_input_path(input_path) {
+    }
+
+    bool IOConfig::getWriteEGRIDFile() const {
+        return m_write_EGRID_file;
+    }
+
+    bool IOConfig::getWriteINITFile() const {
+        return m_write_INIT_file;
+    }
+
+    bool IOConfig::getWriteRestartFile(size_t timestep) const {
+        bool write_restart_ts = false;
+
+        if (m_restart_output_config) {
+            restartConfig ts_restart_config = m_restart_output_config->get(timestep);
+
+            switch (ts_restart_config.basic) {
+                case 1: //Write restart file every report time
+                    write_restart_ts = true;
+                    break;
+                case 2: //Write restart file every report time
+                    write_restart_ts = true;
+                    break;
+                case 3: //Every n'th report time
+                    write_restart_ts = getWriteRestartFileFrequency(timestep, ts_restart_config.timestep, ts_restart_config.frequency);
+                    break;
+                case 4: //First reportstep of every year, or if n > 1, n'th years
+                    write_restart_ts = getWriteRestartFileFrequency(timestep, ts_restart_config.timestep, ts_restart_config.frequency, true);
+                    break;
+                case 5: //First reportstep of every month, or if n > 1, n'th months
+                    write_restart_ts = getWriteRestartFileFrequency(timestep, ts_restart_config.timestep, ts_restart_config.frequency, false, true);
+                    break;
+                case 6: //Write restart file every timestep
+                    throw std::runtime_error("OPM does not support the RPTRST BASIC=6 setting (write restart file every timestep)");
+                    break;
+                default:
+                    // do nothing
+                    break;
+            }
+        }
+
+
+        return write_restart_ts;
+    }
+
+
+    bool IOConfig::getWriteRestartFileFrequency(size_t timestep,
+                                                size_t start_index,
+                                                size_t frequency,
+                                                bool   first_timesteps_years,
+                                                bool   first_timesteps_months) const {
+        bool write_restart_file = false;
+        if (!first_timesteps_years && !first_timesteps_months) {
+            write_restart_file = (((timestep-start_index) % frequency) == 0) ? true : false;
+        } else {
+            std::vector<size_t> timesteps;
+            if (first_timesteps_years) {
+                m_timemap->initFirstTimestepsYears(timesteps, start_index);
+            } else {
+                m_timemap->initFirstTimestepsMonths(timesteps, start_index);
+            }
+            std::vector<size_t>::const_iterator ci_timestep = std::find(timesteps.begin(), timesteps.end(), timestep);
+
+            if (ci_timestep != timesteps.end()) {
+                if (1 >= frequency) {
+                    write_restart_file = true;
+                } else {
+                    std::vector<size_t>::const_iterator ci_start = timesteps.begin();
+                    int index = std::distance( ci_start, ci_timestep );
+                    if( (index % frequency) == 0) {
+                        write_restart_file = true;
+                    }
+                 }
+            }
+        }
+        return write_restart_file;
+    }
+
+
+    void IOConfig::handleRPTRSTBasic(TimeMapConstPtr timemap, size_t timestep, size_t basic, size_t frequency, bool update_default) {
+        if (!m_timemap) {
+            initRestartOutputConfig(timemap);
+        }
+
+        restartConfig rs;
+        rs.timestep  = timestep;
+        rs.basic     = basic;
+        rs.frequency = frequency;
+
+        if (!update_default) {
+            m_restart_output_config->add(timestep, rs);
+        } else {
+            m_restart_output_config->updateInitial(rs);
+        }
+    }
+
+
+
+    void IOConfig::initRestartOutputConfig(TimeMapConstPtr timemap) {
+        restartConfig rs;
+        rs.timestep  = 0;
+        rs.basic     = 0;
+        rs.frequency = 1;
+
+        m_timemap = timemap;
+        m_restart_output_config = std::make_shared<DynamicState<restartConfig>>(timemap, rs);
+    }
+
+    void IOConfig::handleSolutionSection(TimeMapConstPtr timemap, std::shared_ptr<const SOLUTIONSection> solutionSection) {
+        if (!m_timemap) {
+            m_timemap = timemap;
+        }
+
+        if (solutionSection->hasKeyword("RPTRST")) {
+            auto rptrstkeyword = solutionSection->getKeyword("RPTRST");
+            size_t currentStep = 0;
+
+            DeckRecordConstPtr record = rptrstkeyword->getRecord(0);
+
+            size_t basic = 1;
+            size_t freq  = 0;
+
+            DeckItemConstPtr item = record->getItem(0);
+
+            for (size_t index = 0; index < item->size(); ++index) {
+
+                if (item->hasValue(index)) {
+                    std::string mnemonics = item->getString(index);
+                    std::size_t found_basic = mnemonics.find("BASIC=");
+                    if (found_basic != std::string::npos) {
+                        std::string basic_no = mnemonics.substr(found_basic+6, found_basic+7);
+                        basic = atoi(basic_no.c_str());
+                    }
+
+                    std::size_t found_freq = mnemonics.find("FREQ=");
+                    if (found_freq != std::string::npos) {
+                        std::string freq_no = mnemonics.substr(found_freq+5, found_freq+6);
+                        freq = atoi(freq_no.c_str());
+                    }
+                }
+            }
+            std::cout << "SOLUTION SECTION; BASIC FREQ IS " << basic << "," << freq << std::endl;
+            handleRPTRSTBasic(m_timemap, currentStep, basic, freq, true);
+        }
+    }
+
+
+
+    void IOConfig::handleGridSection(std::shared_ptr<const GRIDSection> gridSection) {
+        m_write_INIT_file = gridSection->hasKeyword("INIT");
+
+        if (gridSection->hasKeyword("GRIDFILE")) {
+            auto gridfilekeyword = gridSection->getKeyword("GRIDFILE");
+            if (gridfilekeyword->size() > 0) {
+                auto rec = gridfilekeyword->getRecord(0);
+                auto item1 = rec->getItem(0);
+                if ((item1->hasValue(0)) && (item1->getInt(0) !=  0)) {
+                    throw std::runtime_error("IOConfig: Reading GRIDFILE keyword from GRID section: Output of GRID file is not supported") ;
+                }
+                if (rec->size() > 1) {
+                    auto item2 = rec->getItem(1);
+                    if ((item2->hasValue(0)) && (item2->getInt(0) ==  0)) {
+                        m_write_EGRID_file = false;
+                    }
+                }
+            }
+        }
+        if (gridSection->hasKeyword("NOGGF")) {
+            m_write_EGRID_file = false;
+        }
+    }
+
+
+    void IOConfig::handleRunspecSection(std::shared_ptr<const RUNSPECSection> runspecSection) {
+        m_FMTIN   = runspecSection->hasKeyword("FMTIN");   //Input files are formatted
+        m_FMTOUT  = runspecSection->hasKeyword("FMTOUT");  //Output files are to be formatted
+        m_UNIFIN  = runspecSection->hasKeyword("UNIFIN");  //Input files are unified
+        m_UNIFOUT = runspecSection->hasKeyword("UNIFOUT"); //Output files are to be unified
+    }
+
+
+    bool IOConfig::getUNIFIN() const {
+        return m_UNIFIN;
+    }
+
+    bool IOConfig::getUNIFOUT() const {
+        return m_UNIFOUT;
+    }
+
+    bool IOConfig::getFMTIN() const {
+        return m_FMTIN;
+    }
+
+    bool IOConfig::getFMTOUT() const {
+        return m_FMTOUT;
+    }
+
+    void IOConfig::setEclipseInputPath(const std::string& path) {
+        m_eclipse_input_path = path;
+    }
+
+    const std::string& IOConfig::getEclipseInputPath() const {
+        return m_eclipse_input_path;
+    }
+
+
+} //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -1,0 +1,105 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_IO_CONFIG_HPP
+#define OPM_IO_CONFIG_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+
+
+namespace Opm {
+
+    class IOConfig {
+
+    public:
+
+        IOConfig(DeckConstPtr deck, const std::string& input_path = "");
+
+
+        bool getWriteRestartFile(size_t timestep) const;
+        bool getWriteEGRIDFile() const;
+        bool getWriteINITFile() const;
+        bool getUNIFOUT() const;
+        bool getUNIFIN() const;
+        bool getFMTIN() const;
+        bool getFMTOUT() const;
+        const std::string& getEclipseInputPath() const;
+
+
+        void setEclipseInputPath(const std::string& path);
+        void handleRPTRSTBasic(TimeMapConstPtr timemap, size_t timestep, size_t basic, size_t frequency=1, bool update_default=false);
+        void handleSolutionSection(TimeMapConstPtr timemap, std::shared_ptr<const SOLUTIONSection> solutionSection);
+        void handleGridSection(std::shared_ptr<const GRIDSection> gridSection);
+        void handleRunspecSection(std::shared_ptr<const RUNSPECSection> runspecSection);
+
+    private:
+
+
+
+        void initRestartOutputConfig(TimeMapConstPtr timemap);
+        bool getWriteRestartFileFrequency(size_t timestep,
+                                          size_t start_index,
+                                          size_t frequency,
+                                          bool first_timesteps_years  = false,
+                                          bool first_timesteps_months = false) const;
+
+
+        TimeMapConstPtr m_timemap;
+        bool            m_write_INIT_file;
+        bool            m_write_EGRID_file;
+        bool            m_UNIFIN;
+        bool            m_UNIFOUT;
+        bool            m_FMTIN;
+        bool            m_FMTOUT;
+        std::string     m_eclipse_input_path;
+
+
+        struct restartConfig {
+            size_t timestep;
+            size_t basic;
+            size_t frequency;
+
+            bool operator!=(const restartConfig& rhs) {
+                bool ret = true;
+                if ((this->timestep  == rhs.timestep) &&
+                    (this->basic     == rhs.basic) &&
+                    (this->frequency == rhs.frequency)) {
+                        ret = false;
+                }
+                return ret;
+            }
+        };
+
+
+        std::shared_ptr<DynamicState<restartConfig>> m_restart_output_config;
+
+    };
+
+
+    typedef std::shared_ptr<IOConfig> IOConfigPtr;
+    typedef std::shared_ptr<const IOConfig> IOConfigConstPtr;
+
+} //namespace Opm
+
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_executable(runIOConfigTests IOConfigTest.cpp)
+target_link_libraries(runIOConfigTests Parser ${Boost_LIBRARIES})
+add_test(NAME runIOConfigTests WORKING_DIRECTORY ${PROJECT_SOURCE_DIR} COMMAND ${TEST_MEMCHECK_TOOL} ${EXECUTABLE_OUTPUT_PATH}/runIOConfigTests )

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -1,0 +1,315 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#define BOOST_TEST_MODULE IOConfigTests
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+
+
+using namespace Opm;
+
+const std::string& deckStr =  "RUNSPEC\n"
+                              "\n"
+                              "DIMENS\n"
+                              " 10 10 10 /\n"
+                              "GRID\n"
+                              "GRIDFILE\n"
+                              " 0 1 /\n"
+                              "\n"
+                              "START\n"
+                              " 21 MAY 1981 /\n"
+                              "\n"
+                              "TSTEP\n"
+                              " 1 2 3 4 5 /\n"
+                              "\n"
+                              "DATES\n"
+                              " 1 JAN 1982 /\n"
+                              " 1 JAN 1982 13:55:44 /\n"
+                              " 3 JAN 1982 14:56:45.123 /\n"
+                              "/\n"
+                              "TSTEP\n"
+                              " 9 10 /\n"
+                              "\n"
+                              "/\n";
+
+const std::string& deckStr2 =  "RUNSPEC\n"
+                               "\n"
+                               "DIMENS\n"
+                               "10 10 10 /\n"
+                               "GRID\n"
+                               "GRIDFILE\n"
+                               " 1 1 /\n"
+                               "\n";
+
+const std::string& deckStr3 =  "RUNSPEC\n"
+                               "UNIFIN\n"
+                               "UNIFOUT\n"
+                               "FMTIN\n"
+                               "FMTOUT\n"
+                               "\n"
+                               "DIMENS\n"
+                               "10 10 10 /\n"
+                               "GRID\n"
+                               "INIT\n"
+                               "NOGGF\n"
+                               "\n";
+
+const std::string& deckStr4 =  "RUNSPEC\n"
+                               "\n"
+                               "DIMENS\n"
+                              " 10 10 10 /\n"
+                               "GRID\n"
+                               "GRIDFILE\n"
+                               " 0 0 /\n"
+                               "\n";
+
+
+
+
+static DeckPtr createDeck(const std::string& input) {
+    Opm::Parser parser;
+    return parser.parseString(input);
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(IOConfigTest) {
+
+    DeckPtr deck = createDeck(deckStr);
+    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+    IOConfigPtr ioConfigPtr;
+    BOOST_CHECK_NO_THROW(ioConfigPtr = std::make_shared<IOConfig>(deck));
+
+    std::shared_ptr<const GRIDSection> gridSection = std::make_shared<const GRIDSection>(deck);
+    std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(deck);
+    ioConfigPtr->handleGridSection(gridSection);
+    ioConfigPtr->handleRunspecSection(runspecSection);
+
+    Schedule schedule(grid , deck, ioConfigPtr);
+
+    //If no BASIC keyord has been handled, no restart files should be written
+    TimeMapConstPtr timemap = schedule.getTimeMap();
+    for (size_t ts = 0; ts < timemap->numTimesteps(); ++ts) {
+        BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+    }
+
+    /*BASIC=1, write restart file for every timestep*/
+    size_t timestep = 3;
+    int basic       = 1;
+    ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic);
+    for (size_t ts = 0; ts < timemap->numTimesteps(); ++ts) {
+        if (ts < 3) {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+        } else {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
+        }
+    }
+
+    //Add timestep 11, 12, 13, 14, 15, 16
+    const TimeMap* const_tmap = timemap.get();
+    TimeMap* writableTimemap = const_cast<TimeMap*>(const_tmap);
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+
+
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(11));
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(12));
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(13));
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(14));
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(15));
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(16));
+
+
+    /* BASIC=3, restart files are created every nth report time, n=3 */
+    timestep      = 11;
+    basic         = 3;
+    int frequency = 3;
+    ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic, frequency);
+
+    for (size_t ts = timestep ; ts < timemap->numTimesteps(); ++ts) {
+        if (((ts-timestep) % frequency) == 0) {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
+        } else {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+        }
+    }
+
+    //Add timestep 17, 18, 19, 20, 21, 22, 23, 24, 25, 26
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1983
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1984
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1985
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1986
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1987
+
+    /* BASIC=4, restart file is written at the first report step of each year.
+       Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th year*/
+    timestep      = 17;
+    basic         = 4;
+    frequency     = 0;
+    ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic, frequency);
+
+    /*Expected results: Write timestep for timestep 17, 20, 22, 23, 26*/
+
+    for (size_t ts = 17; ts <= 26; ++ts) {
+        if ((17 == ts) || (20 == ts) || (22 == ts) || (23 == ts) || (26 == ts)) {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
+        } else {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+        }
+    }
+
+
+    //Add timestep 27, 28, 29, 30, 31, 32, 33, 34, 35, 36
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1988
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1989
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1990
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1991
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(24));
+    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1992
+
+    /* BASIC=4, FREQ = 2 restart file is written at the first report step of each year.
+       Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th year*/
+    timestep      = 27;
+    basic         = 4;
+    frequency     = 2;
+    ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(), timestep, basic, frequency);
+
+    /*Expected results: Write timestep for timestep 27, 32, 36 */
+
+    for (size_t ts = 27; ts <= 36; ++ts) {
+        if ((27 == ts) || (32 == ts) || (36 == ts)) {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
+        } else {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+        }
+    }
+
+
+
+    //Add timestep 37, 38, 39, 40, 41, 42, 43, 44, 45, 46
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //february
+    writableTimemap->addTStep(boost::posix_time::hours(650)); //march
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //march
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //march
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //march
+    writableTimemap->addTStep(boost::posix_time::hours(650)); //april
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //april
+    writableTimemap->addTStep(boost::posix_time::hours(650)); //may
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //may
+    writableTimemap->addTStep(boost::posix_time::hours(24));  //may
+
+    /* BASIC=5, restart file is written at the first report step of each month.
+       Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th month*/
+    timestep      = 37;
+    basic         = 5;
+    frequency     = 2;
+    ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(), timestep, basic, frequency);
+
+    /*Expected results: Write timestep for timestep 37, 38, 42, 44 */
+
+    for (size_t ts = 37; ts <= 46; ++ts) {
+        if ((37 == ts) || (42 == ts)) {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
+        } else {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+        }
+    }
+
+
+    /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
+    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteEGRIDFile());
+
+    /*If no INIT keyword is specified, verify no write of INIT file*/
+    BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteINITFile());
+
+    /*If no UNIFIN keyword is specified, verify UNIFIN false (default is multiple) */
+    BOOST_CHECK_EQUAL(false, ioConfigPtr->getUNIFIN());
+
+    /*If no UNIFOUT keyword is specified, verify UNIFOUT false (default is multiple) */
+    BOOST_CHECK_EQUAL(false, ioConfigPtr->getUNIFOUT());
+
+    /*If no FMTIN keyword is specified, verify FMTIN false (default is unformatted) */
+    BOOST_CHECK_EQUAL(false, ioConfigPtr->getFMTIN());
+
+    /*If no FMTOUT keyword is specified, verify FMTOUT false (default is unformatted) */
+    BOOST_CHECK_EQUAL(false, ioConfigPtr->getFMTOUT());
+
+    /*Throw exception if write GRID file is specified*/
+    DeckPtr deck2 = createDeck(deckStr2);
+    IOConfigPtr ioConfigPtr2;
+    BOOST_CHECK_NO_THROW(ioConfigPtr2 = std::make_shared<IOConfig>(deck2));
+    std::shared_ptr<const GRIDSection> gridSection2 = std::make_shared<const GRIDSection>(deck2);
+    BOOST_CHECK_THROW(ioConfigPtr2->handleGridSection(gridSection2), std::runtime_error);
+
+    /*If NOGGF keyword is present, no EGRID file is written*/
+    DeckPtr deck3 = createDeck(deckStr3);
+    IOConfigPtr ioConfigPtr3;
+    BOOST_CHECK_NO_THROW(ioConfigPtr3 = std::make_shared<IOConfig>(deck3));
+
+    std::shared_ptr<const GRIDSection> gridSection3 = std::make_shared<const GRIDSection>(deck3);
+    std::shared_ptr<const RUNSPECSection> runspecSection3 = std::make_shared<const RUNSPECSection>(deck3);
+    ioConfigPtr3->handleGridSection(gridSection3);
+    ioConfigPtr3->handleRunspecSection(runspecSection3);
+
+    BOOST_CHECK_EQUAL(false, ioConfigPtr3->getWriteEGRIDFile());
+
+    /*If INIT keyword is specified, verify write of INIT file*/
+    BOOST_CHECK_EQUAL(true, ioConfigPtr3->getWriteINITFile());
+
+    /*If UNIFOUT keyword is specified, verify unified write*/
+    BOOST_CHECK_EQUAL(true, ioConfigPtr3->getUNIFOUT());
+
+    /*If FMTOUT keyword is specified, verify formatted write*/
+    BOOST_CHECK_EQUAL(true, ioConfigPtr3->getFMTOUT());
+
+    /*If GRIDFILE 0 0 is specified, no EGRID file is written */
+    DeckPtr deck4 = createDeck(deckStr4);
+    IOConfigPtr ioConfigPtr4;
+    BOOST_CHECK_NO_THROW(ioConfigPtr4 = std::make_shared<IOConfig>(deck4));
+
+    std::shared_ptr<const GRIDSection> gridSection4 = std::make_shared<const GRIDSection>(deck4);
+    std::shared_ptr<const RUNSPECSection> runspecSection4 = std::make_shared<const RUNSPECSection>(deck4);
+    ioConfigPtr4->handleGridSection(gridSection4);
+    ioConfigPtr4->handleRunspecSection(runspecSection4);
+
+    BOOST_CHECK_EQUAL(false, ioConfigPtr4->getWriteEGRIDFile());
+}
+
+
+

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -25,6 +25,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -41,7 +42,7 @@ namespace Opm
 
     class Schedule {
     public:
-        Schedule(std::shared_ptr<const EclipseGrid> grid , DeckConstPtr deck);
+        Schedule(std::shared_ptr<const EclipseGrid> grid , DeckConstPtr deck, IOConfigPtr ioConfig);
         boost::posix_time::ptime getStartTime() const
         { return m_timeMap->getStartTime(/*timeStepIdx=*/0); }
         TimeMapConstPtr getTimeMap() const;
@@ -73,12 +74,13 @@ namespace Opm
         TuningPtr m_tuning;
         bool nosim;
 
+
         void addWellToGroup( GroupPtr newGroup , WellPtr well , size_t timeStep);
-        void initFromDeck(DeckConstPtr deck);
+        void initFromDeck(DeckConstPtr deck, IOConfigPtr ioConfig);
         void initializeNOSIM(DeckConstPtr deck);
         void createTimeMap(DeckConstPtr deck);
         void initRootGroupTreeNode(TimeMapConstPtr timeMap);
-        void iterateScheduleSection(DeckConstPtr deck);
+        void iterateScheduleSection(DeckConstPtr deck, IOConfigPtr ioConfig);
         bool handleGroupFromWELSPECS(const std::string& groupName, GroupTreePtr newTree) const;
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, DeckRecordConstPtr record, size_t timeStep);
@@ -98,6 +100,7 @@ namespace Opm
         void handleGCONPROD(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleTUNING(DeckKeywordConstPtr keyword, size_t currentStep);
         void handleNOSIM();
+        void handleRPTRST(DeckKeywordConstPtr keyword, size_t currentStep, IOConfigPtr ioConfig);
         void handleDATES(DeckKeywordConstPtr keyword);
         void handleTSTEP(DeckKeywordConstPtr keyword);
         void handleGRUPTREE(DeckKeywordConstPtr keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/Deck/DeckDoubleItem.hpp>
 
+
 namespace Opm {
     TimeMap::TimeMap(boost::posix_time::ptime startDate) {
         if (startDate.is_not_a_date_time())
@@ -223,6 +224,42 @@ namespace Opm {
             = t2 - t1;
         return static_cast<double>(deltaT.total_milliseconds())/1000.0;
     }
+
+
+    void TimeMap::initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t start_timestep) const {
+        boost::gregorian::date prev_date;
+        for (size_t timestepIndex = start_timestep; timestepIndex < m_timeList.size(); ++timestepIndex) {
+            const boost::posix_time::ptime& ptime = getStartTime(timestepIndex);
+            if (start_timestep == timestepIndex) {
+                prev_date = ptime.date();
+                timesteps.push_back(timestepIndex);
+            } else {
+                boost::gregorian::date cur_date = ptime.date();
+                if (cur_date.month() != prev_date.month()) {
+                    timesteps.push_back(timestepIndex);
+                }
+                prev_date = cur_date;
+            }
+        }
+    }
+
+
+    void TimeMap::initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t start_timestep) const {
+        boost::gregorian::date prev_date;
+        for (size_t timestepIndex = start_timestep; timestepIndex < m_timeList.size(); ++timestepIndex) {
+            const boost::posix_time::ptime& ptime = getStartTime(timestepIndex);
+            if (start_timestep == timestepIndex) {
+                prev_date = ptime.date();
+                timesteps.push_back(timestepIndex);
+            } else {
+                boost::gregorian::date cur_date = ptime.date();
+                if (cur_date.year() != prev_date.year()) {
+                    timesteps.push_back(timestepIndex);
+                }
+                prev_date = cur_date;
+            }
+        }
+  }
 
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -21,6 +21,8 @@
 #ifndef TIMEMAP_HPP_
 #define TIMEMAP_HPP_
 
+#include <vector>
+
 #include <boost/date_time.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
@@ -46,6 +48,10 @@ namespace Opm {
         double getTimePassedUntil(size_t tLevelIdx) const;
         /// Return the length of a given time step in seconds.
         double getTimeStepLength(size_t tStepIdx) const;
+        /// Return a list of the first timesteps of each month
+        void initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t timestep=0) const;
+        /// Return a list of the first timesteps of each year
+        void initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t start_timestep=0) const;
         static boost::posix_time::ptime timeFromEclipse(DeckRecordConstPtr dateRecord);
         static boost::posix_time::ptime timeFromEclipse(int day , const std::string& month, int year, const std::string& eclipseTimeString = "00:00:00.000");
         static boost::posix_time::time_duration dayTimeFromEclipse(const std::string& eclipseTimeString);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -123,14 +123,16 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     DeckKeywordPtr keyword(new DeckKeyword("SCHEDULE"));
     deck->addKeyword( keyword );
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1983  , boost::gregorian::Jan , 1)));
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     DeckPtr deck = createDeckWithWellsOrdered();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(100,100,100);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     std::vector<WellConstPtr> wells = schedule.getWells();
 
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
@@ -141,7 +143,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     DeckPtr deck = createDeck();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1998  , boost::gregorian::Mar , 8)));
 }
 
@@ -151,13 +154,15 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     deck->addKeyword( keyword );
 
-    BOOST_CHECK_NO_THROW(Schedule schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_NO_THROW(Schedule schedule(grid , deck, ioConfig));
 }
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( 0U , schedule.numWells() );
     BOOST_CHECK_EQUAL( false , schedule.hasWell("WELL1") );
     BOOST_CHECK_THROW( schedule.getWell("WELL2") , std::invalid_argument );
@@ -166,7 +171,8 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
 BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForTimeStepZero) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     BOOST_CHECK_EQUAL("FIELD", schedule.getGroupTree(0)->getNode("FIELD")->name());
 }
 
@@ -185,7 +191,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
     recordChildOfField->addItem(itemParent1);
     gruptreeKeyword->addRecord(recordChildOfField);
     deck->addKeyword(gruptreeKeyword);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     GroupTreeNodePtr fieldNode = schedule.getGroupTree(0)->getNode("FIELD");
     BOOST_CHECK_EQUAL("FIELD", fieldNode->name());
     GroupTreeNodePtr FAREN = fieldNode->getChildGroup("FAREN");
@@ -195,7 +202,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( 1U , schedule.numGroups() );
     BOOST_CHECK_EQUAL( true , schedule.hasGroup("FIELD") );
     BOOST_CHECK_EQUAL( false , schedule.hasGroup("GROUP") );
@@ -205,7 +213,8 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
 BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
 
     std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(0U, wells_alltimesteps.size());
@@ -218,7 +227,8 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
 BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWells();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
 
     std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(3U, wells_alltimesteps.size());
@@ -231,7 +241,8 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
 BOOST_AUTO_TEST_CASE(WellsIteratorWithRegex_HasWells_WellsReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWells();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     std::string wellNamePattern;
     std::vector<WellPtr> wells;
 
@@ -251,7 +262,8 @@ BOOST_AUTO_TEST_CASE(WellsIteratorWithRegex_HasWells_WellsReturned) {
 BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWells();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(schedule.numWells(0), 1);
     BOOST_CHECK_EQUAL(schedule.numWells(1), 1);
@@ -262,7 +274,8 @@ BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
 BOOST_AUTO_TEST_CASE(ReturnMaxNumCompletionsForWellsInTimestep) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionData();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(schedule.getMaxNumCompletionsForWells(1), 7);
     BOOST_CHECK_EQUAL(schedule.getMaxNumCompletionsForWells(3), 9);
@@ -325,7 +338,8 @@ static DeckPtr createDeckWithWellsAndCompletionDataWithWELOPEN() {
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionDataWithWELOPEN();
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     WellPtr well;
     well = schedule.getWell("OP_1");
     size_t currentStep = 0;
@@ -429,7 +443,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
 
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
   DeckPtr deck = parser.parseString(input);
-  Schedule schedule(grid , deck);
+  IOConfigPtr ioConfig;
+  Schedule schedule(grid , deck, ioConfig);
   WellPtr well;
   well = schedule.getWell("OP_1");
   size_t currentStep = 3;
@@ -471,7 +486,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1_ThrowsExcpetion) {
 
     DeckPtr deck = parser.parseString(input);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-    BOOST_CHECK_THROW(Schedule schedule(grid , deck), std::exception);
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_THROW(Schedule schedule(grid , deck, ioConfig), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1andC2_ThrowsExcpetion) {
@@ -507,7 +523,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1andC2_ThrowsExcpetion) 
 
     DeckPtr deck = parser.parseString(input);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-    BOOST_CHECK_THROW(Schedule schedule(grid , deck), std::exception);
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_THROW(Schedule schedule(grid , deck, ioConfig), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC2_ThrowsExcpetion) {
@@ -543,7 +560,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC2_ThrowsExcpetion) {
 
     DeckPtr deck = parser.parseString(input);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-    BOOST_CHECK_THROW(Schedule schedule(grid , deck), std::exception);
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_THROW(Schedule schedule(grid , deck, ioConfig), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithDefaultValuesInWELOPEN) {
@@ -578,7 +596,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithDefaultValuesInWELOPEN) {
 
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     DeckPtr deck = parser.parseString(input);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     WellPtr well;
     well = schedule.getWell("OP_1");
     size_t currentStep = 3;
@@ -619,7 +638,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
 
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     DeckPtr deck = parser.parseString(input);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     WellPtr well;
     size_t currentStep = 2;
     well = schedule.getWell("OP_1");
@@ -679,7 +699,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
 
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     DeckPtr deck = parser.parseString(input);
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     WellPtr well;
     well = schedule.getWell("OP_1");
 
@@ -726,7 +747,8 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
 
     DeckPtr deck = parser.parseString(input);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );        
-    Schedule schedule(grid , deck);
+    IOConfigPtr ioConfig;
+    Schedule schedule(grid , deck, ioConfig);
     WellPtr well = schedule.getWell("OP_1");
 
     size_t currentStep = 1;
@@ -762,8 +784,9 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException) {
 
     DeckPtr deck = parser.parseString(input);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+    IOConfigPtr ioConfig;
 
-    BOOST_CHECK_THROW(Schedule (grid , deck), std::invalid_argument);
+    BOOST_CHECK_THROW(Schedule (grid , deck, ioConfig), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
@@ -776,6 +799,73 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArgException2) {
 
     DeckPtr deck = parser.parseString(input);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+    IOConfigPtr ioConfig;
 
-    BOOST_CHECK_THROW(Schedule (grid , deck), std::out_of_range);
+    BOOST_CHECK_THROW(Schedule (grid , deck, ioConfig), std::out_of_range);
+}
+
+
+BOOST_AUTO_TEST_CASE(createDeckWithRPTRST) {
+
+    const char *deckData =
+                          "RUNSPEC\n"
+                          "DIMENS\n"
+                          " 10 10 10 /\n"
+                          "GRID\n"
+                          "START             -- 0 \n"
+                          "19 JUN 2007 / \n"
+                          "SCHEDULE\n"
+                          "DATES             -- 1\n"
+                          " 10  OKT 2008 / \n"
+                          "/\n"
+                          "RPTRST\n"
+                          "BASIC=1\n"
+                          "/\n"
+                          "DATES             -- 2\n"
+                          " 20  JAN 2010 / \n"
+                          "/\n"
+                          "/\n";
+
+    const char *deckData2 =
+                          "RUNSPEC\n"
+                          "DIMENS\n"
+                          " 10 10 10 /\n"
+                          "GRID\n"
+                          "START             -- 0 \n"
+                          "19 JUN 2007 / \n"
+                          "SCHEDULE\n"
+                          "DATES             -- 1\n"
+                          " 10  OKT 2008 / \n"
+                          "/\n"
+                          "RPTRST\n"
+                          "BASIC=3 FREQ=2 RUBBISH=5\n"
+                          "/\n"
+                          "DATES             -- 2\n"
+                          " 20  JAN 2010 / \n"
+                          "/\n"
+                          "DATES             -- 3\n"
+                          " 20  JAN 2011 / \n"
+                          "/\n"
+                          "/\n";;
+
+    std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
+    Opm::Parser parser;
+
+    DeckPtr deck = parser.parseString(deckData);
+    IOConfigPtr ioConfig = std::make_shared<IOConfig>(deck);
+    Schedule schedule(grid , deck, ioConfig);
+
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
+
+
+    DeckPtr deck2 = parser.parseString(deckData2) ;
+    IOConfigPtr ioConfig2 = std::make_shared<IOConfig>(deck2);
+    Schedule schedule2(grid , deck2, ioConfig2);
+
+    BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(0));
+    BOOST_CHECK_EQUAL(true, ioConfig2->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(true, ioConfig2->getWriteRestartFile(3));
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
@@ -269,4 +269,29 @@ BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
                                                boost::posix_time::milliseconds(123)));
     BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/8), 6*24*60*60);
     BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/9), 7*24*60*60);
+
+    std::vector<size_t> first_timestep_of_each_month;
+    tmap.initFirstTimestepsMonths(first_timestep_of_each_month);
+    BOOST_CHECK_EQUAL(3, first_timestep_of_each_month.size());
+    int expected_results[3] = {0,5,6};
+    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results, expected_results+3, first_timestep_of_each_month.begin(), first_timestep_of_each_month.end());
+
+    first_timestep_of_each_month.clear();
+    tmap.initFirstTimestepsMonths(first_timestep_of_each_month, 5);
+    BOOST_CHECK_EQUAL(2, first_timestep_of_each_month.size());
+    int expected_results2[2] = {5,6};
+    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results2, expected_results2+2, first_timestep_of_each_month.begin(), first_timestep_of_each_month.end());
+
+    std::vector<size_t> first_timestep_of_each_year;
+    tmap.initFirstTimestepsYears(first_timestep_of_each_year);
+    BOOST_CHECK_EQUAL(2, first_timestep_of_each_year.size());
+    int expected_results_years[2] = {0,6};
+    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results_years, expected_results_years+2, first_timestep_of_each_year.begin(), first_timestep_of_each_year.end());
+
+    first_timestep_of_each_year.clear();
+    tmap.initFirstTimestepsYears(first_timestep_of_each_year, 6);
+    BOOST_CHECK_EQUAL(1, first_timestep_of_each_year.size());
+    BOOST_CHECK_EQUAL(6, first_timestep_of_each_year[0]);
+
+
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TuningTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TuningTests.cpp
@@ -67,7 +67,8 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
 
   DeckPtr deck = createDeck(deckStr);
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-  Schedule schedule(grid , deck);
+  IOConfigPtr ioConfig;
+  Schedule schedule(grid , deck, ioConfig);
   TuningPtr tuning = schedule.getTuning();
 
 
@@ -318,7 +319,8 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
 
   DeckPtr deck = createDeck(deckStr);
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-  Schedule schedule(grid , deck);
+  IOConfigPtr ioConfig;
+  Schedule schedule(grid , deck, ioConfig);
   TuningPtr tuning = schedule.getTuning();
 
 
@@ -346,7 +348,8 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
 
   DeckPtr deck = createDeck(deckStr);
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-  Schedule schedule(grid , deck);
+  IOConfigPtr ioConfig;
+  Schedule schedule(grid , deck, ioConfig);
   TuningPtr tuning = schedule.getTuning();
 
 

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -411,3 +411,91 @@ BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     BOOST_CHECK_EQUAL( multnum , def_property );
 }
 
+
+BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
+    const char * deckData  =
+                          "RUNSPEC\n"
+                          "GRIDOPTS\n"
+                          "  'YES'   10 /"
+                          "\n"
+                          "DIMENS\n"
+                          " 10 10 10 /\n"
+                          "GRID\n"
+                          "START             -- 0 \n"
+                          "19 JUN 2007 / \n"
+                          "SCHEDULE\n"
+                          "DATES             -- 1\n"
+                          " 10  OKT 2008 / \n"
+                          "/\n"
+                          "RPTRST\n"
+                          "BASIC=3 FREQ=2\n"
+                          "/\n"
+                          "DATES             -- 2\n"
+                          " 20  JAN 2010 / \n"
+                          "/\n"
+                          "DATES             -- 3\n"
+                          " 20  JAN 2011 / \n"
+                          "/\n"
+                          "/\n";
+
+
+    ParserPtr parser(new Parser());
+    DeckPtr deck = parser->parseString(deckData) ;
+    EclipseState state(deck);
+
+    IOConfigConstPtr ioConfig = state.getIOConfig();
+
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
+}
+
+
+BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
+    const char * deckData  =
+                          "RUNSPEC\n"
+                          "GRIDOPTS\n"
+                          "  'YES'   10 /"
+                          "\n"
+                          "DIMENS\n"
+                          " 10 10 10 /\n"
+                          "SOLUTION\n"
+                          "RPTRST\n"
+                          "BASIC=1\n"
+                          "/\n"
+                          "RPTRST\n"
+                          "BASIC=3 FREQ=5\n"
+                          "/\n"
+                          "GRID\n"
+                          "START             -- 0 \n"
+                          "19 JUN 2007 / \n"
+                          "SCHEDULE\n"
+                          "DATES             -- 1\n"
+                          " 10  OKT 2008 / \n"
+                          "/\n"
+                          "DATES             -- 2\n"
+                          " 20  JAN 2010 / \n"
+                          "/\n"
+                          "RPTRST\n"
+                          "BASIC=3 FREQ=2\n"
+                          "/\n"
+                          "DATES             -- 3\n"
+                          " 20  JAN 2011 / \n"
+                          "/\n"
+                          "/\n";
+
+
+    ParserPtr parser(new Parser());
+    DeckPtr deck = parser->parseString(deckData) ;
+    EclipseState state(deck);
+
+    IOConfigConstPtr ioConfig = state.getIOConfig();
+
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(0));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
+}
+
+

--- a/opm/parser/eclipse/IntegrationTests/ParseWellWithWildcards.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWellWithWildcards.cpp
@@ -40,7 +40,8 @@ BOOST_AUTO_TEST_CASE( parse_WCONPROD_OK ) {
     boost::filesystem::path wconprodFile("testdata/integration_tests/WellWithWildcards/WCONPROD1");
     DeckPtr deck =  parser->parseFile(wconprodFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 30,30,30);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL(5U, sched->numWells());
     BOOST_CHECK(sched->hasWell("INJE1"));
@@ -74,7 +75,8 @@ BOOST_AUTO_TEST_CASE( parse_WCONINJE_OK ) {
     boost::filesystem::path wconprodFile("testdata/integration_tests/WellWithWildcards/WCONINJE1");
     DeckPtr deck =  parser->parseFile(wconprodFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 30,30,30 );
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL(5U, sched->numWells());
     BOOST_CHECK(sched->hasWell("PROD1"));

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -41,7 +41,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE1");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
     TimeMapConstPtr timeMap = sched->getTimeMap();
     BOOST_CHECK_EQUAL(boost::posix_time::ptime(boost::gregorian::date(2007, boost::gregorian::May, 10)), sched->getStartTime());
     BOOST_CHECK_EQUAL(9U, timeMap->size());
@@ -55,7 +56,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMMENTS_AFTER_KEYWORDS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
     TimeMapConstPtr timeMap = sched->getTimeMap();
     BOOST_CHECK_EQUAL(boost::posix_time::ptime(boost::gregorian::date(2007, boost::gregorian::May, 10)), sched->getStartTime());
     BOOST_CHECK_EQUAL(9U, timeMap->size());
@@ -67,7 +69,8 @@ BOOST_AUTO_TEST_CASE(WCONPROD_MissingCmode) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_MISSING_CMODE");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    BOOST_CHECK_NO_THROW( new Schedule(grid , deck) );
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_NO_THROW( new Schedule(grid , deck, ioConfig) );
 }
 
 
@@ -76,7 +79,8 @@ BOOST_AUTO_TEST_CASE(WCONPROD_Missing_DATA) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_CMODE_MISSING_DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    BOOST_CHECK_THROW( new Schedule(grid , deck) , std::invalid_argument );
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_THROW( new Schedule(grid , deck, ioConfig) , std::invalid_argument );
 }
 
 
@@ -87,7 +91,8 @@ BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(40,60,30);
     BOOST_CHECK_EQUAL(3, 3);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
     BOOST_CHECK_EQUAL(4, 4);
 
     WellPtr well1 = sched->getWell("W_1");
@@ -106,7 +111,8 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS2");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(40,60,30);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL(4U, sched->numWells());
     BOOST_CHECK(sched->hasWell("W_1"));
@@ -221,7 +227,8 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT_DEFAULTED_ITEMS) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMPDAT1");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(40,60,30);
-    ScheduleConstPtr sched(new Schedule(grid, deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid, deck, ioConfig));
 }
 
 
@@ -230,7 +237,8 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS2");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(40,60,30);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL(4U, sched->numWells());
     BOOST_CHECK(sched->hasWell("W_1"));
@@ -261,7 +269,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_with_explicit_L0_parenting) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GRUPTREE_EXPLICIT_PARENTING");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     GroupTreeNodePtr rootNode = sched->getGroupTree(0)->getNode("FIELD");
 
@@ -289,7 +298,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_correct) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GRUPTREE");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr schedule(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr schedule(new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK( schedule->hasGroup( "FIELD" ));
     BOOST_CHECK( schedule->hasGroup( "PROD" ));
@@ -307,7 +317,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_iter_function) 
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr schedule(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr schedule(new Schedule(grid , deck, ioConfig));
 
     // Time 0, only from WELSPECS
     GroupTreeNodeConstPtr root = schedule->getGroupTree(0)->getNode("FIELD");
@@ -333,7 +344,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr schedule(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr schedule(new Schedule(grid , deck, ioConfig));
 
     // Time 0, only from WELSPECS
     GroupTreeNodePtr root0 = schedule->getGroupTree(0)->getNode("FIELD");
@@ -377,7 +389,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GROUPS_REPARENT");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr schedule(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr schedule(new Schedule(grid , deck, ioConfig));
 
 
     // Time , from  first GRUPTREE
@@ -409,7 +422,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_PrintGrouptree) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELSPECS_GROUPS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     GroupTreePtr rootNode = sched->getGroupTree(0);
     rootNode->printTree(std::cout);
@@ -422,7 +436,8 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_GROUPS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr sched( new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched( new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL( 3U , sched->numGroups() );
     BOOST_CHECK( sched->hasGroup( "INJ" ));
@@ -463,7 +478,8 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS_AND_GROUPS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    ScheduleConstPtr sched( new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched( new Schedule(grid , deck, ioConfig));
 
     GroupPtr group1 = sched->getGroup("GROUP1");
     GroupPtr group2 = sched->getGroup("GROUP2");
@@ -491,7 +507,8 @@ BOOST_AUTO_TEST_CASE(WellTestWELSPECSDataLoaded) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELLS2");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(40,60,30);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL(4U, sched->numWells());
     BOOST_CHECK(sched->hasWell("W_1"));
@@ -523,7 +540,8 @@ BOOST_AUTO_TEST_CASE(WellTestWELSPECS_InvalidConfig_Throws) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WELL_INVALID_WELSPECS");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    BOOST_CHECK_THROW(new Schedule(grid , deck), std::invalid_argument);
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_THROW(new Schedule(grid , deck, ioConfig), std::invalid_argument);
 
 }
 
@@ -561,7 +579,8 @@ BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_WGRUPCON");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10,10,10 );
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
     WellConstPtr well1 = sched->getWell("W_1");
     BOOST_CHECK(well1->isAvailableForGroupControl(0));
@@ -599,7 +618,8 @@ COMPDAT \n\
 /\n";
     DeckPtr deck =  parser->parseString(deckString);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 30,30,10 );
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
     WellConstPtr well = sched->getWell("W1");
     CompletionSetConstPtr completions = well->getCompletions(0);
     BOOST_CHECK_EQUAL( 10 , completions->get(0)->getI() );
@@ -616,7 +636,8 @@ BOOST_AUTO_TEST_CASE(OpmCode) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/wells_group.data");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
-    BOOST_CHECK_NO_THROW( new Schedule(grid , deck) );
+    IOConfigPtr ioConfig;
+    BOOST_CHECK_NO_THROW( new Schedule(grid , deck, ioConfig) );
 }
 
 
@@ -626,7 +647,8 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_SHUT_WELL");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 20,40,1 );
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
 
     WellConstPtr well1 = sched->getWell("W1");
@@ -649,7 +671,8 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_POLYMER");
     DeckPtr deck =  parser->parseFile(scheduleFile.string());
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 30,30,30);
-    ScheduleConstPtr sched(new Schedule(grid , deck));
+    IOConfigPtr ioConfig;
+    ScheduleConstPtr sched(new Schedule(grid , deck, ioConfig));
 
 
     BOOST_CHECK_EQUAL(4U, sched->numWells());

--- a/opm/parser/share/keywords/000_Eclipse100/N/NOGGF
+++ b/opm/parser/share/keywords/000_Eclipse100/N/NOGGF
@@ -1,0 +1,1 @@
+{"name" : "NOGGF", "sections" : ["GRID"]}


### PR DESCRIPTION
Added IOConfig class. The class holds data about input and output configuration; currently the following is supported:
- If UNIFIN/UNIFOUT/FMTIN/FMTOUT is set
- Should restart file be written at a given timestep (RPTRST keyword is supported)
- Should EGRID file be written (GRIDFILE / NOGGF keyword)
- Should INIT file be written (INIT keyword)
A const pointer to the IOConfig object can be fetched from EclipseState
