### PR TITLE
fix linking of applications after targets was renamed

### DIFF
--- a/opm/parser/eclipse/Applications/CMakeLists.txt
+++ b/opm/parser/eclipse/Applications/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(opm-eclkwtest opm-eclkwtest.cpp)
-target_link_libraries(opm-eclkwtest Parser)
+target_link_libraries(opm-eclkwtest opmparser)
 install(TARGETS opm-eclkwtest DESTINATION "bin")
 
 add_executable(opm-eclkw opm-eclkw.cpp)
-target_link_libraries(opm-eclkw Parser)
+target_link_libraries(opm-eclkw opmparser)
 install(TARGETS opm-eclkw DESTINATION "bin")
 
 add_executable(schedule Schedule.cpp)
-target_link_libraries(schedule Parser)
+target_link_libraries(schedule opmparser)
 


### PR DESCRIPTION
Sorry, forgot to test the all target, was only focused on tests.