### PR TITLE
Remove unused deck argument from IOConfig constructor.

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -357,7 +357,7 @@ namespace Opm {
    }
 
     void EclipseState::initIOConfig(DeckConstPtr deck) {
-        m_ioConfig = std::make_shared<IOConfig>(deck);
+        m_ioConfig = std::make_shared<IOConfig>();
         if (Section::hasGRID(deck)) {
             std::shared_ptr<const GRIDSection> gridSection = std::make_shared<const GRIDSection>(deck);
             m_ioConfig->handleGridSection(gridSection);

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -20,14 +20,12 @@
 #include <iterator>
 
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Deck/DeckIntItem.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 
 
 namespace Opm {
 
-    IOConfig::IOConfig(DeckConstPtr deck, const std::string& input_path):
+    IOConfig::IOConfig(const std::string& input_path):
         m_write_INIT_file(false),
         m_write_EGRID_file(true),
         m_UNIFIN(false),

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -20,7 +20,6 @@
 #ifndef OPM_IO_CONFIG_HPP
 #define OPM_IO_CONFIG_HPP
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
@@ -32,7 +31,7 @@ namespace Opm {
 
     public:
 
-        IOConfig(DeckConstPtr deck, const std::string& input_path = "");
+        explicit IOConfig(const std::string& input_path = "");
 
 
         bool getWriteRestartFile(size_t timestep) const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -101,7 +101,7 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     DeckPtr deck = createDeck(deckStr);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     IOConfigPtr ioConfigPtr;
-    BOOST_CHECK_NO_THROW(ioConfigPtr = std::make_shared<IOConfig>(deck));
+    BOOST_CHECK_NO_THROW(ioConfigPtr = std::make_shared<IOConfig>());
 
     std::shared_ptr<const GRIDSection> gridSection = std::make_shared<const GRIDSection>(deck);
     std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(deck);
@@ -273,14 +273,14 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     /*Throw exception if write GRID file is specified*/
     DeckPtr deck2 = createDeck(deckStr2);
     IOConfigPtr ioConfigPtr2;
-    BOOST_CHECK_NO_THROW(ioConfigPtr2 = std::make_shared<IOConfig>(deck2));
+    BOOST_CHECK_NO_THROW(ioConfigPtr2 = std::make_shared<IOConfig>());
     std::shared_ptr<const GRIDSection> gridSection2 = std::make_shared<const GRIDSection>(deck2);
     BOOST_CHECK_THROW(ioConfigPtr2->handleGridSection(gridSection2), std::runtime_error);
 
     /*If NOGGF keyword is present, no EGRID file is written*/
     DeckPtr deck3 = createDeck(deckStr3);
     IOConfigPtr ioConfigPtr3;
-    BOOST_CHECK_NO_THROW(ioConfigPtr3 = std::make_shared<IOConfig>(deck3));
+    BOOST_CHECK_NO_THROW(ioConfigPtr3 = std::make_shared<IOConfig>());
 
     std::shared_ptr<const GRIDSection> gridSection3 = std::make_shared<const GRIDSection>(deck3);
     std::shared_ptr<const RUNSPECSection> runspecSection3 = std::make_shared<const RUNSPECSection>(deck3);
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     /*If GRIDFILE 0 0 is specified, no EGRID file is written */
     DeckPtr deck4 = createDeck(deckStr4);
     IOConfigPtr ioConfigPtr4;
-    BOOST_CHECK_NO_THROW(ioConfigPtr4 = std::make_shared<IOConfig>(deck4));
+    BOOST_CHECK_NO_THROW(ioConfigPtr4 = std::make_shared<IOConfig>());
 
     std::shared_ptr<const GRIDSection> gridSection4 = std::make_shared<const GRIDSection>(deck4);
     std::shared_ptr<const RUNSPECSection> runspecSection4 = std::make_shared<const RUNSPECSection>(deck4);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -852,7 +852,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTRST) {
     Opm::Parser parser;
 
     DeckPtr deck = parser.parseString(deckData);
-    IOConfigPtr ioConfig = std::make_shared<IOConfig>(deck);
+    IOConfigPtr ioConfig = std::make_shared<IOConfig>();
     Schedule schedule(grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
@@ -861,7 +861,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTRST) {
 
 
     DeckPtr deck2 = parser.parseString(deckData2) ;
-    IOConfigPtr ioConfig2 = std::make_shared<IOConfig>(deck2);
+    IOConfigPtr ioConfig2 = std::make_shared<IOConfig>();
     Schedule schedule2(grid , deck2, ioConfig2);
 
     BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(0));


### PR DESCRIPTION
Also made constructor explicit since it now only takes a single argument, to avoid unintended implicit conversion.

All tests still succeed, and I do not thing there are downstream consequences (at least there were none in opm-core).