### PR TITLE
Added method globalReset() to DynamicState<T>

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -33,12 +33,16 @@ namespace Opm {
     class DynamicState {
     public:
 
+
         DynamicState(const TimeMapConstPtr timeMap, T initialValue) {
             m_timeMap = timeMap;
-            m_currentValue = initialValue;
-            m_initialValue = initialValue;
-            m_initialRange = 0;
+            init( initialValue );
         }
+
+        void globalReset( T newValue ) {
+            init( newValue );
+        }
+
 
 
         const T& at(size_t index) const {
@@ -108,7 +112,17 @@ namespace Opm {
         }
 
 
+
     private:
+
+        void init(T initialValue) {
+            m_data.clear();
+            m_currentValue = initialValue;
+            m_initialValue = initialValue;
+            m_initialRange = 0;
+        }
+
+
         std::vector<T> m_data;
         TimeMapConstPtr m_timeMap;
         T m_currentValue;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/DynamicStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/DynamicStateTests.cpp
@@ -197,3 +197,28 @@ BOOST_AUTO_TEST_CASE(DynamicStateInitial) {
     BOOST_CHECK_EQUAL( state2[10] , 200 );
 }
 
+BOOST_AUTO_TEST_CASE( ResetGlobal ) {
+    boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
+    Opm::TimeMapPtr timeMap(new Opm::TimeMap(boost::posix_time::ptime(startDate)));
+    Opm::DynamicState<int> state(timeMap , 137);
+    for (size_t i = 0; i < 10; i++)
+        timeMap->addTStep( boost::posix_time::hours( (i+1) * 24 ));
+
+    state.add(5 , 100);
+    BOOST_CHECK_EQUAL( state[0] , 137 );
+    BOOST_CHECK_EQUAL( state[4] , 137 );
+    BOOST_CHECK_EQUAL( state[5] , 100 );
+    BOOST_CHECK_EQUAL( state[9] , 100 );
+
+    state.updateInitial( 22 );
+    BOOST_CHECK_EQUAL( state[0] , 22 );
+    BOOST_CHECK_EQUAL( state[4] , 22 );
+    BOOST_CHECK_EQUAL( state[5] , 100 );
+    BOOST_CHECK_EQUAL( state[9] , 100 );
+
+    state.globalReset( 88 );
+    BOOST_CHECK_EQUAL( state[0] , 88 );
+    BOOST_CHECK_EQUAL( state[4] , 88 );
+    BOOST_CHECK_EQUAL( state[5] , 88 );
+    BOOST_CHECK_EQUAL( state[9] , 88 );
+}


### PR DESCRIPTION
This small PR adds the ability to reset the content of DynamicState<T> property - this is support full global override of properties which can be specified both in the deck and on the commandline.