### PR TITLE
Opm 211

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -13,6 +13,7 @@ add_subdirectory(EclipseState/Tables/tests)
 add_subdirectory(EclipseState/Grid/tests)
 add_subdirectory(EclipseState/Util/tests)
 add_subdirectory(EclipseState/IOConfig/tests)
+add_subdirectory(EclipseState/InitConfig/tests)
 
 add_subdirectory( Applications )
 
@@ -110,6 +111,7 @@ EclipseState/Grid/Fault.cpp
 EclipseState/Grid/FaultCollection.cpp
 EclipseState/Grid/NNC.cpp
 #
+EclipseState/InitConfig/InitConfig.cpp
 EclipseState/SimulationConfig/SimulationConfig.cpp
 EclipseState/SimulationConfig/ThresholdPressure.cpp
 #
@@ -198,6 +200,7 @@ EclipseState/Grid/Fault.hpp
 EclipseState/Grid/FaultCollection.hpp
 EclipseState/Grid/NNC.hpp
 #
+EclipseState/InitConfig/InitConfig.hpp
 EclipseState/SimulationConfig/SimulationConfig.hpp
 EclipseState/SimulationConfig/ThresholdPressure.hpp
 #

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -137,6 +137,7 @@ namespace Opm {
         initIOConfigPostSchedule(deck);
         initTitle(deck);
         initProperties(deck);
+        initInitConfig(deck);
         initSimulationConfig(deck);
         initTransMult();
         initFaults(deck);
@@ -265,6 +266,10 @@ namespace Opm {
         return m_ioConfig;
     }
 
+    InitConfigConstPtr EclipseState::getInitConfig() const {
+        return m_initConfig;
+    }
+
     SimulationConfigConstPtr EclipseState::getSimulationConfig() const {
         return m_simulationConfig;
     }
@@ -374,7 +379,6 @@ namespace Opm {
         }
     }
 
-
     void EclipseState::initIOConfigPostSchedule(DeckConstPtr deck) {
         if (Section::hasSOLUTION(deck)) {
             std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>(deck);
@@ -382,6 +386,9 @@ namespace Opm {
         }
     }
 
+    void EclipseState::initInitConfig(DeckConstPtr deck){
+        m_initConfig = std::make_shared<const InitConfig>(deck);
+    }
 
     void EclipseState::initSimulationConfig(DeckConstPtr deck) {
         m_simulationConfig = std::make_shared<const SimulationConfig>(deck , m_intGridProperties);
@@ -468,6 +475,7 @@ namespace Opm {
         for (size_t index=0; index < section->count("MULTFLT"); index++) {
             DeckKeywordConstPtr faultsKeyword = section->getKeyword("MULTFLT" , index);
             for (auto iter = faultsKeyword->begin(); iter != faultsKeyword->end(); ++iter) {
+
                 DeckRecordConstPtr faultRecord = *iter;
                 const std::string& faultName = faultRecord->getItem(0)->getString(0);
                 double multFlt = faultRecord->getItem(1)->getRawDouble(0);

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -58,7 +58,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
-
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 
@@ -80,6 +80,7 @@ namespace Opm {
 
         ScheduleConstPtr getSchedule() const;
         IOConfigConstPtr getIOConfig() const;
+        InitConfigConstPtr getInitConfig() const;
         SimulationConfigConstPtr getSimulationConfig() const;
         EclipseGridConstPtr getEclipseGrid() const;
         EclipseGridPtr getEclipseGridCopy() const;
@@ -144,6 +145,7 @@ namespace Opm {
         void initIOConfig(DeckConstPtr deck);
         void initSchedule(DeckConstPtr deck);
         void initIOConfigPostSchedule(DeckConstPtr deck);
+        void initInitConfig(DeckConstPtr deck);
         void initSimulationConfig(DeckConstPtr deck);
         void initEclipseGrid(DeckConstPtr deck);
         void initGridopts(DeckConstPtr deck);
@@ -245,6 +247,7 @@ namespace Opm {
 
         EclipseGridConstPtr      m_eclipseGrid;
         IOConfigPtr              m_ioConfig;
+        InitConfigConstPtr       m_initConfig;
         ScheduleConstPtr         schedule;
         SimulationConfigConstPtr m_simulationConfig;
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -1,0 +1,69 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <iostream>
+
+namespace Opm {
+
+    InitConfig::InitConfig(DeckConstPtr deck) {
+        m_restartInitiated = false;
+        m_restartStep = 0;
+        m_restartRootName = "";
+
+        initRestartKW(deck);
+    }
+
+    void InitConfig::initRestartKW(DeckConstPtr deck) {
+        if (deck->hasKeyword("RESTART") && deck->hasKeyword("SKIPREST")) {
+            DeckKeywordConstPtr restart_kw = deck->getKeyword("RESTART");
+            DeckRecordConstPtr restart_dataRecord = restart_kw->getRecord(0);
+            DeckItemPtr restart_rootname_item = restart_dataRecord->getItem(0);
+            const std::string restart_rootname_string = restart_rootname_item->getString(0);
+
+            DeckItemPtr restart_report_step_item = restart_dataRecord->getItem(1);
+            int restart_report_step_int = restart_report_step_item->getInt(0);
+
+            DeckItemPtr save_item = restart_dataRecord->getItem(2);
+            if (save_item->hasValue(0)) {
+                throw std::runtime_error("OPM does not support RESTART from a SAVE file, only from RESTART files");
+            }
+
+            m_restartInitiated = true;
+            m_restartStep = restart_report_step_int;
+            m_restartRootName = restart_rootname_string;
+        } else if (deck->hasKeyword("RESTART") || deck->hasKeyword("SKIPREST")){
+            throw std::runtime_error("Error in deck: Only one of the kewywords RESTART and SKIPREST are supplied. None or both of them should be supplied.");
+        }
+    }
+
+    bool InitConfig::getRestartInitiated() const {
+        return m_restartInitiated;
+    }
+
+    int InitConfig::getRestartStep() const {
+        return m_restartStep;
+    }
+
+    const std::string& InitConfig::getRestartRootName() const {
+        return m_restartRootName;
+    }
+} //namespace Opm

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -1,0 +1,49 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_INIT_CONFIG_HPP
+#define OPM_INIT_CONFIG_HPP
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+namespace Opm {
+
+    class InitConfig {
+
+    public:
+        InitConfig(DeckConstPtr deck);
+
+        bool getRestartInitiated() const;
+        int getRestartStep() const;
+        const std::string& getRestartRootName() const;
+
+    private:
+        void initRestartKW(DeckConstPtr deck);
+
+        bool m_restartInitiated;
+        int m_restartStep;
+        std::string m_restartRootName;
+    };
+
+    typedef std::shared_ptr<InitConfig> InitConfigPtr;
+    typedef std::shared_ptr<const InitConfig> InitConfigConstPtr;
+
+} //namespace Opm
+
+#endif

--- a/opm/parser/eclipse/EclipseState/InitConfig/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/InitConfig/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+opm_add_test(runInitConfigTests SOURCES InitConfigTest.cpp
+                              LIBRARIES opmparser ${Boost_LIBRARIES})

--- a/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
@@ -1,0 +1,115 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+
+#define BOOST_TEST_MODULE InitConfigTests
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+
+
+using namespace Opm;
+
+const std::string& deckStr =
+                            "RUNSPEC\n"
+                            "DIMENS\n"
+                            " 10 10 10 /\n"
+                            "SOLUTION\n"
+                            "RESTART\n"
+                            "BASE 5\n"
+                            "/\n"
+                            "GRID\n"
+                            "START             -- 0 \n"
+                            "19 JUN 2007 / \n"
+                            "SCHEDULE\n"
+                            "SKIPREST \n"
+                            "/\n";
+
+const std::string& deckStr2 =
+                            "RUNSPEC\n"
+                            "DIMENS\n"
+                            " 10 10 10 /\n"
+                            "SOLUTION\n"
+                            "/\n"
+                            "GRID\n"
+                            "START             -- 0 \n"
+                            "19 JUN 2007 / \n"
+                            "SCHEDULE\n"
+                            "/\n";
+
+const std::string& deckStr3 =
+                            "RUNSPEC\n"
+                            "DIMENS\n"
+                            " 10 10 10 /\n"
+                            "SOLUTION\n"
+                            "RESTART\n"
+                            "BASE 5 SAVE UNFORMATTED\n"
+                            "/\n"
+                            "GRID\n"
+                            "START             -- 0 \n"
+                            "19 JUN 2007 / \n"
+                            "SCHEDULE\n"
+                            "SKIPREST \n"
+                            "/\n";
+
+const std::string& deckStr4 =
+                            "RUNSPEC\n"
+                            "DIMENS\n"
+                            " 10 10 10 /\n"
+                            "SOLUTION\n"
+                            "RESTART\n"
+                            "BASE 5\n"
+                            "/\n"
+                            "GRID\n"
+                            "START             -- 0 \n"
+                            "19 JUN 2007 / \n"
+                            "SCHEDULE\n"
+                            "/\n";
+
+static DeckPtr createDeck(const std::string& input) {
+    Opm::Parser parser;
+    return parser.parseString(input);
+}
+
+BOOST_AUTO_TEST_CASE(InitConfigTest) {
+
+    DeckPtr deck = createDeck(deckStr);
+    InitConfigPtr initConfigPtr;
+    BOOST_CHECK_NO_THROW(initConfigPtr = std::make_shared<InitConfig>(deck));
+    BOOST_CHECK_EQUAL(initConfigPtr->getRestartInitiated(), true);
+    BOOST_CHECK_EQUAL(initConfigPtr->getRestartStep(), 5);
+    BOOST_CHECK_EQUAL(initConfigPtr->getRestartRootName(), "BASE");
+
+    DeckPtr deck2 = createDeck(deckStr2);
+    InitConfigPtr initConfigPtr2;
+    BOOST_CHECK_NO_THROW(initConfigPtr2 = std::make_shared<InitConfig>(deck2));
+    BOOST_CHECK_EQUAL(initConfigPtr2->getRestartInitiated(), false);
+    BOOST_CHECK_EQUAL(initConfigPtr2->getRestartStep(), 0);
+    BOOST_CHECK_EQUAL(initConfigPtr2->getRestartRootName(), "");
+
+    DeckPtr deck3 = createDeck(deckStr3);
+    BOOST_CHECK_THROW(std::make_shared<InitConfig>(deck3), std::runtime_error);
+
+    DeckPtr deck4 = createDeck(deckStr4);
+    BOOST_CHECK_THROW(std::make_shared<InitConfig>(deck4), std::runtime_error);
+}

--- a/opm/parser/share/keywords/000_Eclipse100/R/RESTART
+++ b/opm/parser/share/keywords/000_Eclipse100/R/RESTART
@@ -1,0 +1,6 @@
+{"name" : "RESTART", "sections" : ["SOLUTION"], "size"  : 1 , "items" : [
+    {"name" : "ROOTNAME"         , "value_type" : "STRING" , "default" : "BASE"       },
+    {"name" : "REPORTNUMBER"     , "value_type" : "INT"                               },
+    {"name" : "SAVEFILE"         , "value_type" : "STRING"                            },
+    {"name" : "SAVEFILE_FORMAT"  , "value_type" : "STRING" , "default" : "UNFORMATTED"}
+]}


### PR DESCRIPTION
Added new class InitConfig to handle RESTART and SKIPREST keywords from the deck. 
EclipseState holds an instance of the InitConfig class. 

This PR is supporting the task of implementing initialzation from a RESTART file in Flow