### PR TITLE
Opm 212: Extend IOConfig to support override of RESTART config 

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -262,7 +262,11 @@ namespace Opm {
         return schedule;
     }
 
-    IOConfigConstPtr EclipseState::getIOConfig() const {
+    IOConfigConstPtr EclipseState::getIOConfigConst() const {
+        return m_ioConfig;
+    }
+
+    IOConfigPtr EclipseState::getIOConfig() const {
         return m_ioConfig;
     }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -79,7 +79,8 @@ namespace Opm {
         EclipseState(DeckConstPtr deck);
 
         ScheduleConstPtr getSchedule() const;
-        IOConfigConstPtr getIOConfig() const;
+        IOConfigConstPtr getIOConfigConst() const;
+        IOConfigPtr getIOConfig() const;
         InitConfigConstPtr getInitConfig() const;
         SimulationConfigConstPtr getSimulationConfig() const;
         EclipseGridConstPtr getEclipseGrid() const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -113,7 +113,7 @@ namespace Opm {
     }
 
 
-    void IOConfig::handleRPTRSTBasic(TimeMapConstPtr timemap, size_t timestep, size_t basic, size_t frequency, bool update_default) {
+    void IOConfig::handleRPTRSTBasic(TimeMapConstPtr timemap, size_t timestep, size_t basic, size_t frequency, bool update_default, bool reset_global) {
 
         if (6 == basic )
         {
@@ -136,10 +136,14 @@ namespace Opm {
         rs.basic     = basic;
         rs.frequency = frequency;
 
-        if (!update_default) {
-            m_restart_output_config->add(timestep, rs);
-        } else {
+        if (update_default) {
             m_restart_output_config->updateInitial(rs);
+        }
+        else if (reset_global) {
+            m_restart_output_config->globalReset(rs);
+        }
+        else {
+            m_restart_output_config->add(timestep, rs);
         }
     }
 
@@ -251,6 +255,18 @@ namespace Opm {
     }
 
 
+    bool IOConfig::overrideRestartWriteInterval(size_t interval) {
+        if (interval > 0) {
+            size_t basic = 3;
+            size_t timestep = 0;
+            handleRPTRSTBasic(m_timemap, timestep, basic, interval, false, true);
+        } else {
+            size_t basic = 0;
+            size_t timestep = 0;
+            handleRPTRSTBasic(m_timemap, timestep, basic, interval, false, true);
+        }
+    }
+
     bool IOConfig::getUNIFIN() const {
         return m_UNIFIN;
     }
@@ -267,13 +283,11 @@ namespace Opm {
         return m_FMTOUT;
     }
 
-    void IOConfig::setEclipseInputPath(const std::string& path) {
-        m_eclipse_input_path = path;
-    }
-
     const std::string& IOConfig::getEclipseInputPath() const {
         return m_eclipse_input_path;
     }
+
+
 
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -43,14 +43,24 @@ namespace Opm {
         bool getFMTOUT() const;
         const std::string& getEclipseInputPath() const;
 
-        void setEclipseInputPath(const std::string& path);
-        void handleRPTRSTBasic(TimeMapConstPtr timemap, size_t timestep, size_t basic, size_t frequency=1, bool update_default=false);
+        bool overrideRestartWriteInterval(size_t interval);
+
+        void handleRPTRSTBasic(TimeMapConstPtr timemap,
+                               size_t timestep,
+                               size_t basic,
+                               size_t frequency = 1,
+                               bool update_default = false,
+                               bool reset_global = false);
         void handleRPTSCHEDRestart(TimeMapConstPtr timemap, size_t timestep, size_t restart);
         void handleSolutionSection(TimeMapConstPtr timemap, std::shared_ptr<const SOLUTIONSection> solutionSection);
         void handleGridSection(std::shared_ptr<const GRIDSection> gridSection);
         void handleRunspecSection(std::shared_ptr<const RUNSPECSection> runspecSection);
 
+
     private:
+
+
+
 
 
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -332,8 +332,21 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     ioConfigPtr->handleRPTSCHEDRestart(schedule.getTimeMap(), timestep, restart);
     BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(timestep));
 
+    /*Override, interval = 2*/
+    ioConfigPtr->overrideRestartWriteInterval(2);
+    for (size_t timestep = 0; timestep <= 61; ++timestep) {
+        if ((timestep % 2) == 0) {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(timestep));
+        } else {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(timestep));
+        }
+    }
 
-
+    /*Override, turn off RESTART write*/
+    ioConfigPtr->overrideRestartWriteInterval(0);
+    for (size_t timestep = 0; timestep <= 61; ++timestep) {
+        BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(timestep));
+    }
 
     /*If no GRIDFILE nor NOGGF keywords are specified, default output an EGRID file*/
     BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteEGRIDFile());

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -443,7 +443,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
     DeckPtr deck = parser->parseString(deckData) ;
     EclipseState state(deck);
 
-    IOConfigConstPtr ioConfig = state.getIOConfig();
+    IOConfigConstPtr ioConfig = state.getIOConfigConst();
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
@@ -490,7 +490,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
     DeckPtr deck = parser->parseString(deckData) ;
     EclipseState state(deck);
 
-    IOConfigConstPtr ioConfig = state.getIOConfig();
+    IOConfigConstPtr ioConfig = state.getIOConfigConst();
 
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));


### PR DESCRIPTION
Opm 212: Extend IOConfig to support override of RESTART config from deck with config from param