### PR TITLE
Relaxed parse

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -60,16 +60,22 @@ namespace Opm {
 
 
     DeckKeywordConstPtr Deck::getKeyword(const std::string& keyword, size_t index) const {
-        const std::vector<DeckKeywordConstPtr>& keywordList = getKeywordList( keyword );
-        if (index < keywordList.size())
-            return keywordList[index];
-        else
-            throw std::out_of_range("Keyword index is out of range.");
+        if (hasKeyword(keyword)) {
+            const std::vector<DeckKeywordConstPtr>& keywordList = getKeywordList( keyword );
+            if (index < keywordList.size())
+                return keywordList[index];
+            else
+                throw std::out_of_range("Keyword index is out of range.");
+        } else
+            throw std::invalid_argument("Keyword not in deck.");
     }
 
     DeckKeywordConstPtr Deck::getKeyword(const std::string& keyword) const {
-        const std::vector<DeckKeywordConstPtr>& keywordList = getKeywordList( keyword );
-        return keywordList.back();
+        if (hasKeyword(keyword)) {
+            const std::vector<DeckKeywordConstPtr>& keywordList = getKeywordList( keyword );
+            return keywordList.back();
+        } else
+            throw std::invalid_argument("Keyword not in deck.");
     }
 
     DeckKeywordConstPtr Deck::getKeyword(size_t index) const {
@@ -92,7 +98,7 @@ namespace Opm {
             const std::vector<DeckKeywordConstPtr>& keywordList = m_keywordMap.find(keyword)->second;
             return keywordList;
         } else
-            throw std::invalid_argument("Keyword: " + keyword + " is not found in the container");
+            return m_emptyList;
     }
 
     std::vector<DeckKeywordConstPtr>::const_iterator Deck::begin() const {

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -66,6 +66,11 @@ namespace Opm {
             return getKeyword( Keyword::keywordName );
         }
 
+        template <class Keyword>
+        const std::vector<DeckKeywordConstPtr>& getKeywordList() const {
+            return getKeywordList( Keyword::keywordName );
+        }
+
 
     private:
         std::shared_ptr<UnitSystem> m_defaultUnits;

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -76,6 +76,7 @@ namespace Opm {
         std::shared_ptr<UnitSystem> m_defaultUnits;
         std::shared_ptr<UnitSystem> m_activeUnits;
 
+        std::vector<DeckKeywordConstPtr> m_emptyList;
         std::vector<DeckKeywordConstPtr> m_keywordList;
         std::map<std::string, std::vector<DeckKeywordConstPtr> > m_keywordMap;
         std::map<const DeckKeyword *, size_t> m_keywordIndex;

--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -39,6 +39,7 @@ BOOST_AUTO_TEST_CASE(Initialize) {
 BOOST_AUTO_TEST_CASE(hasKeyword_empty_returnFalse) {
     Deck deck;
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("Bjarne"));
+    BOOST_CHECK_THROW( deck.getKeyword("Bjarne") , std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(addKeyword_singlekeyword_keywordAdded) {
@@ -47,14 +48,11 @@ BOOST_AUTO_TEST_CASE(addKeyword_singlekeyword_keywordAdded) {
     BOOST_CHECK_NO_THROW(deck.addKeyword(keyword));
 }
 
-BOOST_AUTO_TEST_CASE(getKeyword_nosuchkeyword_throws) {
-    Deck deck;
-    BOOST_CHECK_THROW(deck.getKeyword("TRULS" , 0), std::invalid_argument);
-}
 
-BOOST_AUTO_TEST_CASE(getKeywordList_nosuchkeyword_throws) {
+BOOST_AUTO_TEST_CASE(getKeywordList_empty_list) {
     Deck deck;
-    BOOST_CHECK_THROW(deck.getKeywordList("TRULS"), std::invalid_argument);
+    auto kw_list = deck.getKeywordList("TRULS");
+    BOOST_CHECK_EQUAL( kw_list.size() , 0 );
 }
 
 BOOST_AUTO_TEST_CASE(getKeyword_singlekeyword_keywordreturned) {
@@ -146,12 +144,6 @@ BOOST_AUTO_TEST_CASE(getKeyword_outOfRange_throws) {
 }
 
 
-BOOST_AUTO_TEST_CASE(getKeywordList_notFound_throws) {
-    Deck deck;
-    DeckKeywordPtr keyword = DeckKeywordPtr(new DeckKeyword("TRULS"));
-    deck.addKeyword(keyword);
-    BOOST_CHECK_THROW( deck.getKeywordList("TRULSX") , std::invalid_argument)
-}
 
 BOOST_AUTO_TEST_CASE(getKeywordList_OK) {
     Deck deck;

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -431,42 +431,13 @@ namespace Opm {
 
     void EclipseState::initFaults(DeckConstPtr deck) {
         EclipseGridConstPtr grid = getEclipseGrid();
-        m_faults = std::make_shared<FaultCollection>();
-        std::shared_ptr<Opm::GRIDSection> gridSection(new Opm::GRIDSection(deck) );
+        std::shared_ptr<GRIDSection> gridSection = std::make_shared<GRIDSection>( deck );
 
-        for (size_t index=0; index < gridSection->count("FAULTS"); index++) {
-            DeckKeywordConstPtr faultsKeyword = gridSection->getKeyword("FAULTS" , index);
-            for (auto iter = faultsKeyword->begin(); iter != faultsKeyword->end(); ++iter) {
-                DeckRecordConstPtr faultRecord = *iter;
-                const std::string& faultName = faultRecord->getItem(0)->getString(0);
-                int I1 = faultRecord->getItem(1)->getInt(0) - 1;
-                int I2 = faultRecord->getItem(2)->getInt(0) - 1;
-                int J1 = faultRecord->getItem(3)->getInt(0) - 1;
-                int J2 = faultRecord->getItem(4)->getInt(0) - 1;
-                int K1 = faultRecord->getItem(5)->getInt(0) - 1;
-                int K2 = faultRecord->getItem(6)->getInt(0) - 1;
-                FaceDir::DirEnum faceDir = FaceDir::FromString( faultRecord->getItem(7)->getString(0) );
-                std::shared_ptr<const FaultFace> face = std::make_shared<const FaultFace>(grid->getNX() , grid->getNY() , grid->getNZ(),
-                                                                                          static_cast<size_t>(I1) , static_cast<size_t>(I2) ,
-                                                                                          static_cast<size_t>(J1) , static_cast<size_t>(J2) ,
-                                                                                          static_cast<size_t>(K1) , static_cast<size_t>(K2) ,
-                                                                                          faceDir);
-                if (!m_faults->hasFault(faultName)) {
-                    std::shared_ptr<Fault> fault = std::make_shared<Fault>( faultName );
-                    m_faults->addFault( fault );
-                }
-
-                {
-                    std::shared_ptr<Fault> fault = m_faults->getFault( faultName );
-                    fault->addFace( face );
-                }
-            }
-        }
-
+        m_faults = std::make_shared<FaultCollection>(gridSection , grid);
         setMULTFLT(gridSection);
 
         if (Section::hasEDIT(deck)) {
-            std::shared_ptr<Opm::EDITSection> editSection(new Opm::EDITSection(deck) );
+            std::shared_ptr<EDITSection> editSection = std::make_shared<EDITSection>( deck );
             setMULTFLT(editSection);
         }
 

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -27,6 +27,9 @@
 
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
@@ -37,6 +40,8 @@ namespace Opm {
 class FaultCollection {
 public:
     FaultCollection();
+    FaultCollection( std::shared_ptr<const Deck> deck, std::shared_ptr<const EclipseGrid> grid);
+
     size_t size() const;
     bool hasFault(const std::string& faultName) const;
     std::shared_ptr<Fault>  getFault(const std::string& faultName) const;

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
@@ -16,35 +16,36 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include "NNC.hpp"
 #include <array>
+
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+
 
 namespace Opm
 {
     NNC::NNC(Opm::DeckConstPtr deck, EclipseGridConstPtr eclipseGrid)
     {
-        if (deck->hasKeyword("NNC")) {
-            const std::vector<DeckKeywordConstPtr>& nncs = deck->getKeywordList("NNC");
-            for (size_t idx_nnc = 0; idx_nnc<nncs.size(); ++idx_nnc) {
-                Opm::DeckKeywordConstPtr nnc = nncs[idx_nnc];
-                size_t numNNC = nnc->size();
-                for (size_t i = 0; i<numNNC; ++i) {
-                    std::array<size_t, 3> ijk1;
-                    ijk1[0] = static_cast<size_t>(nnc->getRecord(i)->getItem(0)->getInt(0)-1);
-                    ijk1[1] = static_cast<size_t>(nnc->getRecord(i)->getItem(1)->getInt(0)-1);
-                    ijk1[2] = static_cast<size_t>(nnc->getRecord(i)->getItem(2)->getInt(0)-1);
-                    size_t global_index1 = eclipseGrid->getGlobalIndex(ijk1[0],ijk1[1],ijk1[2]);
-
-                    std::array<size_t, 3> ijk2;
-                    ijk2[0] = static_cast<size_t>(nnc->getRecord(i)->getItem(3)->getInt(0)-1);
-                    ijk2[1] = static_cast<size_t>(nnc->getRecord(i)->getItem(4)->getInt(0)-1);
-                    ijk2[2] = static_cast<size_t>(nnc->getRecord(i)->getItem(5)->getInt(0)-1);
-                    size_t global_index2 = eclipseGrid->getGlobalIndex(ijk2[0],ijk2[1],ijk2[2]);
-
-                    const double trans = nnc->getRecord(i)->getItem(6)->getSIDouble(0);
-
-                    addNNC(global_index1,global_index2,trans);
-                }
+        const std::vector<DeckKeywordConstPtr>& nncs = deck->getKeywordList<ParserKeywords::NNC>();
+        for (size_t idx_nnc = 0; idx_nnc<nncs.size(); ++idx_nnc) {
+            Opm::DeckKeywordConstPtr nnc = nncs[idx_nnc];
+            size_t numNNC = nnc->size();
+            for (size_t i = 0; i<numNNC; ++i) {
+                std::array<size_t, 3> ijk1;
+                ijk1[0] = static_cast<size_t>(nnc->getRecord(i)->getItem(0)->getInt(0)-1);
+                ijk1[1] = static_cast<size_t>(nnc->getRecord(i)->getItem(1)->getInt(0)-1);
+                ijk1[2] = static_cast<size_t>(nnc->getRecord(i)->getItem(2)->getInt(0)-1);
+                size_t global_index1 = eclipseGrid->getGlobalIndex(ijk1[0],ijk1[1],ijk1[2]);
+                
+                std::array<size_t, 3> ijk2;
+                ijk2[0] = static_cast<size_t>(nnc->getRecord(i)->getItem(3)->getInt(0)-1);
+                ijk2[1] = static_cast<size_t>(nnc->getRecord(i)->getItem(4)->getInt(0)-1);
+                ijk2[2] = static_cast<size_t>(nnc->getRecord(i)->getItem(5)->getInt(0)-1);
+                size_t global_index2 = eclipseGrid->getGlobalIndex(ijk2[0],ijk2[1],ijk2[2]);
+                
+                const double trans = nnc->getRecord(i)->getItem(6)->getSIDouble(0);
+                
+                addNNC(global_index1,global_index2,trans);
             }
         }
     }

--- a/opm/parser/eclipse/IntegrationTests/CMakeLists.txt
+++ b/opm/parser/eclipse/IntegrationTests/CMakeLists.txt
@@ -6,7 +6,8 @@ foreach(tapp CheckDeckValidity IntegrationTests ParseWellProbe
              ParseTVDP ParseDENSITY ParseVFPPROD ScheduleCreateFromDeck
              CompletionsFromDeck ParseEND IncludeTest ParseEQUIL
              ParseRSVD ParsePVTG ParsePVTO ParseSWOF BoxTest
-             ParseMULTREGT ParseSGOF EclipseGridCreateFromDeck NNCTests)
+             ParseMULTREGT ParseSGOF EclipseGridCreateFromDeck NNCTests
+             ResinsightTest )
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})
 endforeach()

--- a/opm/parser/eclipse/IntegrationTests/ResinsightTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ResinsightTest.cpp
@@ -1,0 +1,52 @@
+/*
+  Copyright 2013 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE BoxTest
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+
+
+using namespace Opm;
+
+BOOST_AUTO_TEST_CASE( test_parse ) {
+    Parser parser(false);
+
+    parser.addKeyword<ParserKeywords::SPECGRID>();
+    parser.addKeyword<ParserKeywords::FAULTS>();
+    auto deck = parser.parseFile("testdata/integration_tests/Resinsight/DECK1.DATA" , false);
+
+    BOOST_CHECK( deck->hasKeyword<ParserKeywords::SPECGRID>() );
+    BOOST_CHECK( deck->hasKeyword<ParserKeywords::FAULTS>() );
+}
+
+
+BOOST_AUTO_TEST_CASE( test_state ) {
+    Parser parser(false);
+
+    parser.addKeyword<ParserKeywords::SPECGRID>();
+    parser.addKeyword<ParserKeywords::FAULTS>();
+    auto deck = parser.parseFile("testdata/integration_tests/Resinsight/DECK1.DATA" , false);
+    auto grid = std::make_shared<EclipseGrid>( deck );
+    auto faults = std::make_shared<FaultCollection>( deck , grid );
+}

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -46,9 +46,9 @@ namespace Opm {
         Parser(bool addDefault = true);
 
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
-        DeckPtr parseFile(const std::string &dataFile) const;
-        DeckPtr parseString(const std::string &data) const;
-        DeckPtr parseStream(std::shared_ptr<std::istream> inputStream) const;
+        DeckPtr parseFile(const std::string &dataFile, bool strict = true) const;
+        DeckPtr parseString(const std::string &data, bool strict = true) const;
+        DeckPtr parseStream(std::shared_ptr<std::istream> inputStream , bool strict = true) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(ParserKeywordConstPtr parserKeyword);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -108,7 +108,6 @@ namespace Opm {
         void addDefaultKeywords();
 
         boost::filesystem::path getIncludeFilePath(std::shared_ptr<ParserState> parserState, std::string path) const;
-        boost::filesystem::path getRootPathFromFile(const boost::filesystem::path &inputDataFile) const;
         std::string doSpecialHandlingForTitleKeyword(std::string line, std::shared_ptr<ParserState> parserState) const;
     };
 

--- a/testdata/integration_tests/Resinsight/DECK1.DATA
+++ b/testdata/integration_tests/Resinsight/DECK1.DATA
@@ -1,0 +1,22 @@
+SPECGRID
+ 20  20 10 /
+
+IGNORED
+Have no clue /
+how to /
+parse This keyword/
+/
+ 
+
+FAULTS 
+  'F1'  1  1  1  4   1  4  'X' / 
+  'F2'  5  5  1  4   1  4  'X-' /
+/
+
+And then comes more crap??!
+
+-- And a valid keyword:
+TABDIMS
+ 1 2 3 /
+
+And it ends with crap?!


### PR DESCRIPTION
Have introduced a flag bool flag for relaxed parsing. The main purpose of this is that one can create a custom parser with only some keywords, this parser will then ignore the unknown keywords gracefully.

The flag is defaulted to `false` - i.e. no change in behavior, see: bceb824 for more details and an example.