### PR TITLE
Improve updateFile and suppress warnings.

### DIFF
--- a/opm/parser/eclipse/Generator/KeywordGenerator.cpp
+++ b/opm/parser/eclipse/Generator/KeywordGenerator.cpp
@@ -89,22 +89,24 @@ namespace Opm {
             boost::filesystem::create_directories( file.parent_path());
     }
 
-    bool KeywordGenerator::updateFile(std::stringstream& newContent , const std::string& filename) {
-        std::ifstream stream(filename.c_str());
+    bool KeywordGenerator::updateFile(const std::stringstream& newContent , const std::string& filename) {
         bool update = true;
-
-        ensurePath( filename );
-        if (stream.is_open()) {
-            std::stringstream oldContent;
-            oldContent << stream.rdbuf( );
-            if (oldContent.str() == newContent.str())
-                update = false;
+        {
+            // Check if file already contains the newContent.
+            std::ifstream inputStream(filename);
+            if (inputStream) {
+                std::stringstream oldContent;
+                oldContent << inputStream.rdbuf();
+                if (oldContent.str() == newContent.str()) {
+                    update = false;
+                }
+            }
         }
 
         if (update) {
-            std::fstream stream(filename.c_str() , std::fstream::out);
-            stream << newContent.str();
-            stream.close();
+            ensurePath(filename);
+            std::ofstream outputStream(filename);
+            outputStream << newContent.str();
         }
 
         return update;

--- a/opm/parser/eclipse/Generator/KeywordGenerator.hpp
+++ b/opm/parser/eclipse/Generator/KeywordGenerator.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         static std::string startTest(const std::string& test_name);
         static std::string sourceHeader();
         static std::string headerHeader();
-        static bool updateFile(std::stringstream& newContent , const std::string& filename);
+        static bool updateFile(const std::stringstream& newContent, const std::string& filename);
 
         bool updateSource(const KeywordLoader& loader, const std::string& sourceFile) const;
         bool updateHeader(const KeywordLoader& loader, const std::string& headerFile) const;


### PR DESCRIPTION
This fixes one of the problems described in #501.

A few notes:
 - Now that we can assume quite new compiler versions we can finally use the std::string constructor of the file stream classes!
 - I used scoping to ensure the input stream is closed before the output stream opens. For all I know it was perfectly legal the way it was used, but it certainly opens the door to extremely thorny issues of how they would interact so it is better to keep them apart.
 - I could not see any tests for this, if there are any, where should I check?