### PR TITLE
Fixed IOConfig compiler warning;  wrong return type for method overrideRestartWriteInterval

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -255,7 +255,7 @@ namespace Opm {
     }
 
 
-    bool IOConfig::overrideRestartWriteInterval(size_t interval) {
+    void IOConfig::overrideRestartWriteInterval(size_t interval) {
         if (interval > 0) {
             size_t basic = 3;
             size_t timestep = 0;

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -43,7 +43,7 @@ namespace Opm {
         bool getFMTOUT() const;
         const std::string& getEclipseInputPath() const;
 
-        bool overrideRestartWriteInterval(size_t interval);
+        void overrideRestartWriteInterval(size_t interval);
 
         void handleRPTRSTBasic(TimeMapConstPtr timemap,
                                size_t timestep,


### PR DESCRIPTION
Fixed IOConfig compiler warning;  wrong return type for method overrideRestartWriteInterval. Should be void, not bool. 
