### PR TITLE
Install VFP Table Headers

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -241,6 +241,8 @@ EclipseState/Tables/OilvisctTable.hpp
 EclipseState/Tables/GasvisctTable.hpp
 EclipseState/Tables/WatvisctTable.hpp
 EclipseState/Tables/PvtgOuterTable.hpp
+EclipseState/Tables/VFPProdTable.hpp
+EclipseState/Tables/VFPInjTable.hpp
 #
 Utility/WconinjeWrapper.hpp
 Utility/CompdatWrapper.hpp


### PR DESCRIPTION
This change-set marks the `VFP*Table.hpp` header files as installable.  That, in turn, is needed for consumers of an installed opm-parser module.