### PR TITLE
Add missing method implementation for hasNNC().

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -303,6 +303,10 @@ namespace Opm {
         return m_nnc;
     }
 
+    bool EclipseState::hasNNC() const {
+        return m_nnc->hasNNC();
+    }
+
     std::string EclipseState::getTitle() const {
         return m_title;
     }


### PR DESCRIPTION
This method was not used anywhere yet, so the error was not discovered.