### PR TITLE
Fix warnings

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -171,7 +171,7 @@ protected:
         const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
         const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
         auto tabdims = m_eclipseState.getTabdims();
-        int numSatTables = tabdims->getNumSatTables();
+        size_t numSatTables = tabdims->getNumSatTables();
 
         m_maxPcog.resize( numSatTables , 0 );
         m_maxPcow.resize( numSatTables , 0 );
@@ -183,7 +183,7 @@ protected:
         m_maxKrw.resize( numSatTables , 0 );
         m_krwr.resize( numSatTables , 0 );
 
-        for (int tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+        for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
             // find the maximum output values of the oil-gas system
             m_maxPcog[tableIdx] = sgofTables[tableIdx].getPcogColumn().front();
             m_maxKrg[tableIdx] = sgofTables[tableIdx].getKrgColumn().back();
@@ -194,7 +194,7 @@ protected:
             // find the oil relperm which corresponds to the critical water saturation
             const auto &krwCol = swofTables[tableIdx].getKrwColumn();
             const auto &krowCol = swofTables[tableIdx].getKrowColumn();
-            for (int rowIdx = 0; rowIdx < krwCol.size(); ++rowIdx) {
+            for (size_t rowIdx = 0; rowIdx < krwCol.size(); ++rowIdx) {
                 if (krwCol[rowIdx] == 0.0) {
                     m_krorw[tableIdx] = krowCol[rowIdx - 1];
                     break;
@@ -204,7 +204,7 @@ protected:
             // find the oil relperm which corresponds to the critical gas saturation
             const auto &krgCol = sgofTables[tableIdx].getKrgColumn();
             const auto &krogCol = sgofTables[tableIdx].getKrogColumn();
-            for (int rowIdx = 0; rowIdx < krgCol.size(); ++rowIdx) {
+            for (size_t rowIdx = 0; rowIdx < krgCol.size(); ++rowIdx) {
                 if (krgCol[rowIdx] == 0.0) {
                     m_krorg[tableIdx] = krogCol[rowIdx - 1];
                     break;

--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
@@ -31,10 +31,10 @@ namespace Opm {
         : m_i(i), m_j(j), m_k(k),
           m_diameter(diameter),
           m_connectionTransmissibilityFactor(connectionTransmissibilityFactor),
+          m_wellPi(1.0),
           m_skinFactor(skinFactor),
           m_state(state),
-          m_direction(direction),
-          m_wellPi(1.0)
+          m_direction(direction)
     {}
 
     Completion::Completion(std::shared_ptr<const Completion> oldCompletion, WellCompletion::StateEnum newStatus)
@@ -44,10 +44,10 @@ namespace Opm {
         m_k(oldCompletion->getK()),
         m_diameter(oldCompletion->getDiameterAsValueObject()),
         m_connectionTransmissibilityFactor(oldCompletion->getConnectionTransmissibilityFactorAsValueObject()),
+        m_wellPi(oldCompletion->getWellPi()),
         m_skinFactor(oldCompletion->getSkinFactorAsValueObject()),
         m_state(newStatus),
-        m_direction(oldCompletion->getDirection()),
-        m_wellPi(oldCompletion->getWellPi())
+        m_direction(oldCompletion->getDirection())
     {}
 
     Completion::Completion(std::shared_ptr<const Completion> oldCompletion, double wellPi)
@@ -57,10 +57,10 @@ namespace Opm {
             m_k(oldCompletion->getK()),
             m_diameter(oldCompletion->getDiameterAsValueObject()),
             m_connectionTransmissibilityFactor(oldCompletion->getConnectionTransmissibilityFactorAsValueObject()),
+            m_wellPi(oldCompletion->getWellPi()),
             m_skinFactor(oldCompletion->getSkinFactorAsValueObject()),
             m_state(oldCompletion->getState()),
-            m_direction(oldCompletion->getDirection()),
-            m_wellPi(oldCompletion->getWellPi())
+            m_direction(oldCompletion->getDirection())
     {
         if(m_wellPi!=0){
             m_wellPi*=wellPi;

--- a/opm/parser/eclipse/EclipseState/Tables/VFPInjTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPInjTable.cpp
@@ -164,7 +164,7 @@ void VFPInjTable::init(DeckKeywordConstPtr table, std::shared_ptr<Opm::UnitSyste
     }
 
     const double table_scaling_factor = deck_unit_system->parse("Pressure")->getSIScaling();
-    for (int i=3; i<table->size(); ++i) {
+    for (size_t i=3; i<table->size(); ++i) {
         const auto& record = table->getRecord(i);
         //Get indices (subtract 1 to get 0-based index)
         int t = getNonEmptyItem<VFPINJ::THP_INDEX>(record)->getInt(0) - 1;


### PR DESCRIPTION
This silences a few warnings: signed/unsigned comparisons and member initialisation order (should be same as declaration order).