### PR TITLE
SatfuncPropertyInitializer: determine the critical saturations correctly

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -145,10 +145,10 @@ protected:
             // find the critical oil saturation of the oil-gas system
             numRows = sgofTables[tableIdx].numRows();
             const auto &kroOGCol = sgofTables[tableIdx].getKrogColumn();
-            for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-                if (kroOGCol[rowIdx] == 0.0) {
-                    double Sg = sgofTables[tableIdx].getSgColumn()[rowIdx];
-                    m_criticalOilOGSat[tableIdx] = 1 - Sg - m_minWaterSat[tableIdx];
+            for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
+                if (kroOGCol[rowIdx] > 0.0) {
+                    double Sg = sgofTables[tableIdx].getSgColumn()[rowIdx + 1];
+                    m_criticalOilOGSat[tableIdx] = 1 - Sg;
                     break;
                 }
             }
@@ -156,10 +156,10 @@ protected:
             // find the critical oil saturation of the water-oil system
             numRows = swofTables[tableIdx].numRows();
             const auto &kroOWCol = swofTables[tableIdx].getKrowColumn();
-            for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-                if (kroOWCol[rowIdx] == 0.0) {
-                    double Sw = swofTables[tableIdx].getSwColumn()[rowIdx];
-                    m_criticalOilOWSat[tableIdx] = 1 - Sw - m_minGasSat[tableIdx];
+            for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
+                if (kroOWCol[rowIdx] > 0.0) {
+                    double Sw = swofTables[tableIdx].getSwColumn()[rowIdx + 1];
+                    m_criticalOilOWSat[tableIdx] = 1 - Sw;
                     break;
                 }
             }
@@ -195,7 +195,7 @@ protected:
             const auto &krwCol = swofTables[tableIdx].getKrwColumn();
             const auto &krowCol = swofTables[tableIdx].getKrowColumn();
             for (size_t rowIdx = 0; rowIdx < krwCol.size(); ++rowIdx) {
-                if (krwCol[rowIdx] == 0.0) {
+                if (krwCol[rowIdx] > 0.0) {
                     m_krorw[tableIdx] = krowCol[rowIdx - 1];
                     break;
                 }
@@ -205,7 +205,7 @@ protected:
             const auto &krgCol = sgofTables[tableIdx].getKrgColumn();
             const auto &krogCol = sgofTables[tableIdx].getKrogColumn();
             for (size_t rowIdx = 0; rowIdx < krgCol.size(); ++rowIdx) {
-                if (krgCol[rowIdx] == 0.0) {
+                if (krgCol[rowIdx] > 0.0) {
                     m_krorg[tableIdx] = krogCol[rowIdx - 1];
                     break;
                 }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -288,6 +288,7 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
         "/\n"
         // table 2
         // S_w    k_r,w    k_r,o    p_c,ow
+        "  0.00   0        1.0      2.0\n"
         "  0.05   0.01     1.0      2.0\n"
         "  0.10   0.02     0.9      1.0\n"
         "  0.15   0.03     0.5      0.5\n"
@@ -295,7 +296,7 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
         "/\n"
         // table 3
         // S_w    k_r,w    k_r,o    p_c,ow
-        "  0.00   0.01     0.9      2.0\n"
+        "  0.00   0.00     0.9      2.0\n"
         "  0.05   0.02     0.8      1.0\n"
         "  0.10   0.03     0.5      0.5\n"
         "  0.801  1.00     0.0      0.0\n"
@@ -304,14 +305,14 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
         "SGOF\n"
         // table 1
         // S_g    k_r,g    k_r,o    p_c,og
-        "  0.00   0.01     0.9      2.0\n"
+        "  0.00   0.00     0.9      2.0\n"
         "  0.05   0.02     0.8      1.0\n"
         "  0.10   0.03     0.5      0.5\n"
         "  0.80   1.00     0.0      0.0\n"
         "/\n"
         // table 2
         // S_g    k_r,g    k_r,o    p_c,og
-        "  0.05   0.01     1.0      2\n"
+        "  0.05   0.00     1.0      2\n"
         "  0.10   0.02     0.9      1\n"
         "  0.15   0.03     0.5      0.5\n"
         "  0.85   1.00     0.0      0\n"


### PR DESCRIPTION
At least I hope it's correct: the condition for breaking the loops
where inverted in some places.

thanks to [at]bska for discovering this.

this PR should fix #520, but it would be good if @bska could confirm this