### PR TITLE
Opm 218 fix for write of restart files

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -87,6 +87,8 @@ namespace Opm {
             size_t timestep;
             size_t basic;
             size_t frequency;
+            bool   rptsched_restart_set;
+            size_t rptsched_restart;
 
             bool operator!=(const restartConfig& rhs) {
                 bool ret = true;

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -172,10 +172,10 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     frequency     = 0;
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic, frequency);
 
-    /*Expected results: Write timestep for timestep 20, 22, 23, 26*/
+    /*Expected results: Write timestep for timestep 17, 20, 22, 23, 26*/
 
     for (size_t ts = 17; ts <= 26; ++ts) {
-        if ((20 == ts) || (22 == ts) || (23 == ts) || (26 == ts)) {
+        if ((17 == ts) || (20 == ts) || (22 == ts) || (23 == ts) || (26 == ts)) {
             BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
         } else {
             BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
@@ -202,10 +202,10 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     frequency     = 2;
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(), timestep, basic, frequency);
 
-    //Expected results: Write timestep for 30 and 33 (30, 32, 33, 36 with frequency 2)
+    //Expected results: Write timestep for 27, 32 and 36 (27, 30, 32, 33, 36 with frequency 2)
 
     for (size_t ts = 27; ts <= 36; ++ts) {
-        if ((30 == ts) || (33 == ts)) {
+        if ((27 == ts) || (32 == ts) || (36 == ts)) {
             BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
         } else {
             BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -226,12 +226,13 @@ namespace Opm {
     }
 
 
-     void TimeMap::initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t start_timestep) const {
+     void TimeMap::initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t from_timestep) const {
         timesteps.clear();
-        const boost::posix_time::ptime& ptime_start = getStartTime(start_timestep);
-        boost::gregorian::date prev_date = ptime_start.date();
 
-        for (size_t timestepIndex = start_timestep; timestepIndex < m_timeList.size(); ++timestepIndex) {
+        const boost::posix_time::ptime& ptime_prev = getStartTime(from_timestep-1);
+        boost::gregorian::date prev_date = ptime_prev.date();
+
+        for (size_t timestepIndex = from_timestep; timestepIndex < m_timeList.size(); ++timestepIndex) {
             const boost::posix_time::ptime& ptime_cur = getStartTime(timestepIndex);
             boost::gregorian::date cur_date = ptime_cur.date();
 
@@ -244,12 +245,13 @@ namespace Opm {
 
 
 
-    void TimeMap::initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t start_timestep) const {
+    void TimeMap::initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t from_timestep) const {
         timesteps.clear();
-        const boost::posix_time::ptime& ptime_start = getStartTime(start_timestep);
-        boost::gregorian::date prev_date = ptime_start.date();
 
-        for (size_t timestepIndex = start_timestep; timestepIndex < m_timeList.size(); ++timestepIndex) {
+        const boost::posix_time::ptime& ptime_prev = getStartTime(from_timestep-1);
+        boost::gregorian::date prev_date = ptime_prev.date();
+
+        for (size_t timestepIndex = from_timestep; timestepIndex < m_timeList.size(); ++timestepIndex) {
             const boost::posix_time::ptime& ptime_cur = getStartTime(timestepIndex);
             boost::gregorian::date cur_date = ptime_cur.date();
 

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -49,9 +49,9 @@ namespace Opm {
         /// Return the length of a given time step in seconds.
         double getTimeStepLength(size_t tStepIdx) const;
         /// Return a list of the first timesteps of each month
-        void initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t timestep=0) const;
+        void initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t from_timestep=1) const;
         /// Return a list of the first timesteps of each year
-        void initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t start_timestep=0) const;
+        void initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t from_timestep=1) const;
         static boost::posix_time::ptime timeFromEclipse(DeckRecordConstPtr dateRecord);
         static boost::posix_time::ptime timeFromEclipse(int day , const std::string& month, int year, const std::string& eclipseTimeString = "00:00:00.000");
         static boost::posix_time::time_duration dayTimeFromEclipse(const std::string& eclipseTimeString);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -846,7 +846,30 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTRST) {
                           "DATES             -- 3\n"
                           " 20  JAN 2011 / \n"
                           "/\n"
-                          "/\n";;
+                          "/\n";
+
+    const char *deckData3 =
+                          "RUNSPEC\n"
+                          "DIMENS\n"
+                          " 10 10 10 /\n"
+                          "GRID\n"
+                          "START             -- 0 \n"
+                          "19 JUN 2007 / \n"
+                          "SCHEDULE\n"
+                          "DATES             -- 1\n"
+                          " 10  OKT 2008 / \n"
+                          "/\n"
+                          "RPTRST\n"
+                          "3 0 0 0 0 2\n"
+                          "/\n"
+                          "DATES             -- 2\n"
+                          " 20  JAN 2010 / \n"
+                          "/\n"
+                          "DATES             -- 3\n"
+                          " 20  JAN 2011 / \n"
+                          "/\n"
+                          "/\n";
+
 
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     Opm::Parser parser;
@@ -856,7 +879,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTRST) {
     Schedule schedule(grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
 
 
@@ -865,10 +888,21 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTRST) {
     Schedule schedule2(grid , deck2, ioConfig2);
 
     BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig2->getWriteRestartFile(1));
-    BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(true, ioConfig2->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(true, ioConfig2->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(false, ioConfig2->getWriteRestartFile(3));
+
+
+    DeckPtr deck3 = parser.parseString(deckData3) ;
+    IOConfigPtr ioConfig3 = std::make_shared<IOConfig>();
+    Schedule schedule3(grid , deck3, ioConfig3);
+
+    BOOST_CHECK_EQUAL(false, ioConfig3->getWriteRestartFile(0));
+    BOOST_CHECK_EQUAL(false, ioConfig3->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(true, ioConfig3->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(false, ioConfig3->getWriteRestartFile(3));
 }
+
 
 BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHED) {
 
@@ -956,9 +990,9 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHED) {
     Schedule schedule(grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
 
 
     DeckPtr deck1 = parser.parseString(deckData1);
@@ -966,22 +1000,23 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHED) {
     Schedule schedule1(grid , deck1, ioConfig1);
 
     BOOST_CHECK_EQUAL(false, ioConfig1->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig1->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig1->getWriteRestartFile(1));
     BOOST_CHECK_EQUAL(true, ioConfig1->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(false, ioConfig1->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(true, ioConfig1->getWriteRestartFile(3));
 
 
-    /*Older ECLIPSE 100 data set may use integer controls instead of mnemonics*/
+    //Older ECLIPSE 100 data set may use integer controls instead of mnemonics
 
     DeckPtr deck2 = parser.parseString(deckData2) ;
     IOConfigPtr ioConfig2 = std::make_shared<IOConfig>();
     Schedule schedule2(grid , deck2, ioConfig2);
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
 }
+
 
 BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHEDandRPTRST) {
   const char *deckData =
@@ -1018,8 +1053,8 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHEDandRPTRST) {
     Schedule schedule(grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
@@ -329,9 +329,9 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
 
     first_timestep_of_each_month.clear();
     tmap.initFirstTimestepsMonths(first_timestep_of_each_month, 6);
-    BOOST_CHECK_EQUAL(6, first_timestep_of_each_month.size());
-    int expected_results3[6] = {8,9,10,11,12,13};
-    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results3, expected_results3+6, first_timestep_of_each_month.begin(), first_timestep_of_each_month.end());
+    BOOST_CHECK_EQUAL(7, first_timestep_of_each_month.size());
+    int expected_results3[7] = {6,8,9,10,11,12,13};
+    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results3, expected_results3+7, first_timestep_of_each_month.begin(), first_timestep_of_each_month.end());
 
     std::vector<size_t> first_timestep_of_each_year;
     tmap.initFirstTimestepsYears(first_timestep_of_each_year);
@@ -341,6 +341,6 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
 
     first_timestep_of_each_year.clear();
     tmap.initFirstTimestepsYears(first_timestep_of_each_year, 13);
-    BOOST_CHECK_EQUAL(0, first_timestep_of_each_year.size());
+    BOOST_CHECK_EQUAL(1, first_timestep_of_each_year.size());
 }
 

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -446,9 +446,9 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
     IOConfigConstPtr ioConfig = state.getIOConfigConst();
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
 }
 
 
@@ -493,9 +493,9 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
     IOConfigConstPtr ioConfig = state.getIOConfigConst();
 
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(0));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(1));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
 }
 
 


### PR DESCRIPTION
- Added proper handling for rptsched restart; not just in terms of rptrst basic for equal logic
- Added handling of rptrst basic as integer mnemonic (old eclipse files), and test
- Fixed timemap initTimestepMonths and initTimestepYears methods (to get equal startdate as eclipse) - and corresponding tests


To get correct writing of restart files, pull requests for OPM-218 for opm-core and opm-autodiff must also be merged. 