### PR TITLE
Reimplmented ParseMode based on string keys.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -179,15 +179,8 @@ namespace Opm {
 
 
             if (unsupportedModifiers.find( keyword->name() ) != unsupportedModifiers.end()) {
-                auto action = parseMode.unsupportedScheduleGeoModifiers;
-
-                if (action != InputError::IGNORE) {
-                    std::string msg = "OPM does not support grid property modifier " + keyword->name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
-                    if (action == InputError::THROW_EXCEPTION)
-                        throw std::invalid_argument( msg );
-                    else if (action == InputError::WARN)
-                        OpmLog::addMessage(Log::MessageType::Warning , msg );
-                }
+                std::string msg = "OPM does not support grid property modifier " + keyword->name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
+                parseMode.handleError( ParseMode::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , msg );
             }
         }
 
@@ -243,16 +236,8 @@ namespace Opm {
         for (const auto record : (*compordKeyword)) {
             auto methodItem = record->getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if (methodItem->getString(0) != "TRACK") {
-                auto action = parseMode.unsupportedCOMPORDType;
-                if (action != InputError::IGNORE) {
-                    std::string msg = "The COMPORD keyword only handles 'TRACK' order. [ParseMode::unsupportedCOMPORDType]";
-
-                    if (action == InputError::THROW_EXCEPTION)
-                        throw std::invalid_argument(msg);
-                    else
-                        OpmLog::addMessage(Log::MessageType::Warning , msg );
-
-                }
+                std::string msg = "The COMPORD keyword only handles 'TRACK' order.";
+                parseMode.handleError( ParseMode::UNSUPPORTED_COMPORD_TYPE , msg );
             }
         }
     }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -104,14 +104,8 @@ namespace Opm {
                         m_thresholdPressureTable[r1 + maxEqlnum*r2] = p;
                         m_thresholdPressureTable[r2 + maxEqlnum*r1] = p;
                     } else {
-                        auto action = parseMode.unsupportedInitialTHPRES;
-                        if (action != InputError::IGNORE) {
-                            std::string msg = "Inferring threshold pressure from the initial state is not supported. [ParseMode::unsupportedInitialTHPRES]";
-                            if (action == InputError::THROW_EXCEPTION)
-                                throw std::invalid_argument( msg );
-                            else
-                                OpmLog::addMessage(Log::MessageType::Warning , msg );
-                        }
+                        std::string msg = "Inferring threshold pressure from the initial state is not supported.";
+                        parseMode.handleError( ParseMode::UNSUPPORTED_INITIAL_THPRES , msg );
                     }
                 } else
                     throw std::runtime_error("Missing region data for use of the THPRES keyword");

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -222,7 +222,7 @@ BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
         BOOST_CHECK_THROW(std::make_shared<ThresholdPressure>(parseMode , deck, gridPropertiesEQLNUMall0), std::runtime_error);
     }
 
-    parseMode.unsupportedInitialTHPRES = InputError::IGNORE;
+    parseMode.update( ParseMode::UNSUPPORTED_INITIAL_THPRES , InputError::IGNORE );
     BOOST_CHECK_NO_THROW(ThresholdPressure(parseMode,deck_missingPressure, gridProperties));
 }
 

--- a/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
@@ -39,7 +39,7 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_EQUIL_MISSING_DIMS ) {
     Parser parser;
     ParseMode parseMode;
-    parseMode.missingDIMSKeyword = InputError::IGNORE;
+    parseMode.update(ParseMode::PARSE_MISSING_DIMS_KEYWORD, InputError::IGNORE);
     const std::string equil = "EQUIL\n"
         "2469   382.4   1705.0  0.0    500    0.0     1     1      20 /";
     std::shared_ptr<const Deck> deck = parser.parseString(equil, parseMode);

--- a/opm/parser/eclipse/IntegrationTests/ResinsightTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ResinsightTest.cpp
@@ -33,9 +33,10 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( test_parse ) {
     Parser parser(false);
     ParseMode parseMode;
-    parseMode.unknownKeyword = InputError::IGNORE;
-    parseMode.randomText = InputError::IGNORE;
-    parseMode.randomSlash = InputError::IGNORE;
+
+    parseMode.update( ParseMode::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
+    parseMode.update( ParseMode::PARSE_RANDOM_TEXT , InputError::IGNORE );
+    parseMode.update( ParseMode::PARSE_RANDOM_SLASH , InputError::IGNORE );
 
     parser.addKeyword<ParserKeywords::SPECGRID>();
     parser.addKeyword<ParserKeywords::FAULTS>();
@@ -50,9 +51,10 @@ BOOST_AUTO_TEST_CASE( test_parse ) {
 BOOST_AUTO_TEST_CASE( test_state ) {
     Parser parser(false);
     ParseMode parseMode;
-    parseMode.unknownKeyword = InputError::IGNORE;
-    parseMode.randomText = InputError::IGNORE;
-    parseMode.randomSlash = InputError::IGNORE;
+
+    parseMode.update( ParseMode::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
+    parseMode.update( ParseMode::PARSE_RANDOM_TEXT , InputError::IGNORE );
+    parseMode.update( ParseMode::PARSE_RANDOM_SLASH , InputError::IGNORE );
 
     parser.addKeyword<ParserKeywords::SPECGRID>();
     parser.addKeyword<ParserKeywords::FAULTS>();

--- a/opm/parser/eclipse/Parser/ParseMode.cpp
+++ b/opm/parser/eclipse/Parser/ParseMode.cpp
@@ -17,22 +17,198 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <ert/util/util.h>
+#include <cstdlib>
 
+#include <iostream>
+#include <boost/algorithm/string.hpp>
+
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 #include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
 
 namespace Opm {
 
-    ParseMode::ParseMode() {
-        unknownKeyword = InputError::THROW_EXCEPTION;
-        randomText = InputError::THROW_EXCEPTION;
-        randomSlash = InputError::THROW_EXCEPTION;
-        missingDIMSKeyword = InputError::THROW_EXCEPTION;
 
-        unsupportedScheduleGeoModifiers = InputError::THROW_EXCEPTION;
-        unsupportedCOMPORDType = InputError::THROW_EXCEPTION;
-        unsupportedInitialTHPRES = InputError::THROW_EXCEPTION;
+    /*
+      A set of predefined error modes are added, with the default
+      setting 'InputError::IGNORE, then afterwards the environment
+      variables 'OPM_ERRORS_EXCEPTION', 'OPM_ERRORS_WARN' and
+      'OPM_ERRORS_IGNORE' are consulted
+    */
+
+    ParseMode::ParseMode() {
+        initDefault();
+        initEnv();
     }
+
+    /*
+      If you intend to hardwire settings you should use this
+      constructor, as that way the environment variables are applied
+      after the hawrdwired settings.
+    */
+
+    ParseMode::ParseMode(const std::vector<std::pair<std::string , InputError::Action>> initial) {
+        initDefault();
+
+        for (const auto& pair : initial)
+            update( pair.first , pair.second );
+
+        initEnv();
+    }
+
+
+    void ParseMode::initDefault() {
+        addKey(PARSE_UNKNOWN_KEYWORD);
+        addKey(PARSE_RANDOM_TEXT);
+        addKey(PARSE_RANDOM_SLASH);
+        addKey(PARSE_MISSING_DIMS_KEYWORD);
+        addKey(UNSUPPORTED_SCHEDULE_GEO_MODIFIER);
+        addKey(UNSUPPORTED_COMPORD_TYPE);
+        addKey(UNSUPPORTED_INITIAL_THPRES);
+    }
+
+    void ParseMode::initEnv() {
+        envUpdate( "OPM_ERRORS_EXCEPTION" , InputError::THROW_EXCEPTION );
+        envUpdate( "OPM_ERRORS_WARN" , InputError::WARN );
+        envUpdate( "OPM_ERRORS_IGNORE" , InputError::IGNORE );
+    }
+
+
+    void ParseMode::handleError( const std::string& errorKey , const std::string& msg) const {
+        InputError::Action action = get( errorKey );
+
+        if (action == InputError::WARN)
+            OpmLog::addMessage(Log::MessageType::Warning , msg);
+        else if (action == InputError::THROW_EXCEPTION)
+            throw std::invalid_argument(errorKey + ": " + msg);
+
+    }
+
+    std::map<std::string,InputError::Action>::const_iterator ParseMode::begin() const {
+        return m_errorModes.begin();
+    }
+
+
+    std::map<std::string,InputError::Action>::const_iterator ParseMode::end() const {
+        return m_errorModes.end();
+    }
+
+
+    bool ParseMode::hasKey(const std::string& key) const {
+        if (m_errorModes.find( key ) == m_errorModes.end())
+            return false;
+        else
+            return true;
+    }
+
+
+    void ParseMode::addKey(const std::string& key) {
+        if (key.find_first_of("|:*") != std::string::npos)
+            throw std::invalid_argument("The ParseMode keys can not contain '|', '*' or ':'");
+
+        if (!hasKey(key))
+            m_errorModes.insert( std::pair<std::string , InputError::Action>( key , InputError::THROW_EXCEPTION ));
+    }
+
+
+    InputError::Action ParseMode::get(const std::string& key) const {
+        if (hasKey( key ))
+            return m_errorModes.find( key )->second;
+        else
+            throw std::invalid_argument("The errormode key: " + key + " has not been registered");
+    }
+
+    /*****************************************************************/
+
+    /*
+      This is the 'strict' update function, it will throw an exception
+      if the input string is not a defined error mode. This should
+      typically be used in a downstream module where the policy
+      regarding an error mode is hardcoded. When using this method the
+      static string constanst for the different error modes should be
+      used as arguments:
+
+        parseMode.updateKey( ParseMode::PARSE_RANDOM_SLASH , InputError::IGNORE )
+
+    */
+
+    void ParseMode::updateKey(const std::string& key , InputError::Action action) {
+        if (hasKey(key))
+            m_errorModes[key] = action;
+        else
+            throw std::invalid_argument("The errormode key: " + key + " has not been registered");
+    }
+
+
+    void ParseMode::envUpdate( const std::string& envVariable , InputError::Action action ) {
+        const char * userSetting = getenv(envVariable.c_str());
+        if (userSetting )
+            update( userSetting , action);
+    }
+
+
+    void ParseMode::update(InputError::Action action) {
+        for (const auto& pair : m_errorModes) {
+            const std::string& key = pair.first;
+            updateKey( key , action );
+         }
+    }
+
+
+    void ParseMode::patternUpdate( const std::string& pattern , InputError::Action action) {
+        const char * c_pattern = pattern.c_str();
+        for (const auto& pair : m_errorModes) {
+            const std::string& key = pair.first;
+            if (util_fnmatch( c_pattern , key.c_str()) == 0)
+                updateKey( key , action );
+         }
+    }
+
+
+    /*
+      This is the most general update function. The input keyString is
+      "selector string", and all matching error modes will be set to
+      @action. The algorithm for decoding the @keyString is:
+
+        1. The input string is split into several tokens on occurences
+           of ':' or ':' - and then each element is treated
+           seperately.
+
+        2. For each element in the list from 1):
+
+           a) If it contains at least one '*' - update all error modes
+              matching the input string.
+
+           b) If it is exactly equal to recognized error mode - update
+              that.
+
+           c) Otherwise - silently ignore.
+    */
+
+    void ParseMode::update(const std::string& keyString , InputError::Action action) {
+        std::vector<std::string> keys;
+        boost::split( keys , keyString , boost::is_any_of(":|"));
+        for (const auto& input_key : keys) {
+            std::vector<std::string> matching_keys;
+            size_t wildcard_pos = input_key.find("*");
+
+            if (wildcard_pos == std::string::npos) {
+                if (hasKey( input_key ))
+                    updateKey( input_key , action );
+            } else
+                patternUpdate( input_key , action );
+
+        }
+    }
+
+    const std::string ParseMode::PARSE_UNKNOWN_KEYWORD = "PARSE_UNKNOWN_KEYWORD";
+    const std::string ParseMode::PARSE_RANDOM_TEXT = "PARSE_RANDOM_TEXT";
+    const std::string ParseMode::PARSE_RANDOM_SLASH = "PARSE_RANDOM_SLASH";
+    const std::string ParseMode::PARSE_MISSING_DIMS_KEYWORD = "PARSE_MISSING_DIMS_KEYWORD";
+    const std::string ParseMode::UNSUPPORTED_SCHEDULE_GEO_MODIFIER = "UNSUPPORTED_SCHEDULE_GEO_MODIFIER";
+    const std::string ParseMode::UNSUPPORTED_COMPORD_TYPE = "UNSUPPORTED_COMPORD_TYPE";
+    const std::string ParseMode::UNSUPPORTED_INITIAL_THPRES = "UNSUPPORTED_INITIAL_THPRES";
 }
 
 


### PR DESCRIPTION
With this PR the implementation of the ParseMode class has changed completely. Instead of hardwiring  the error scenarios the implementation is based on a map strings and expected action. The main advantage of this is that it becomes easier and more flexible to add update the policy.

When updating a policy you send a string which can contain '?' and '*' and several settings split by '|'. So to ignore all errors arising from unsupported features and random '/' found in the input:

````
parserMode.update("UNSUPPORTED_*|PARSER_RANDOM_SLASH" , InputError::IGNORE)
```

By default the ParseMode object will be instantiated with all settings set to `InputError::THROW_EXCEPTION` - but before returning the constructor will consult the environment variables `OPM_ERRORS_IGNORE, OPM_ERRORS_WARN` and `OPM_ERRORS_EXCEPTION` - if these variables have been set the value will be sent to the `update( )`function.

Followup PR's to the other modules will come; I suspect and hope only opm-autodiff will actually need an update.