### PR TITLE
Add warning-suppression utility headers.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ set(EXECUTABLE_OUTPUT_PATH ${CMAKE_CURRENT_BINARY_DIR}/bin)
 
 add_subdirectory(opm/json)
 add_subdirectory(opm/parser)
+add_subdirectory(opm/core)
 
 add_custom_target(check ${CMAKE_CTEST_COMMAND} WORKING_DIRECTORY ${PROJECT_BINARY_DIR})
 add_dependencies(check test-suite)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,7 @@ set(Boost_USE_STATIC_RUNTIME    OFF)
 
 include(UseMultiArch)
 include(OpmSatellites)
+include(UseWarnings)
 
 # Requires BOOST filesystem version 3, thus 1.44 is necessary.
 add_definitions(-DBOOST_FILESYSTEM_VERSION=3)

--- a/opm/core/CMakeLists.txt
+++ b/opm/core/CMakeLists.txt
@@ -1,0 +1,8 @@
+set( HEADER_FILES
+utility/platform_dependent/disable_warnings.h
+utility/platform_dependent/reenable_warnings.h
+)
+
+install_headers( "${HEADER_FILES}" "${CMAKE_INSTALL_PREFIX}" )
+
+

--- a/opm/core/utility/platform_dependent/disable_warnings.h
+++ b/opm/core/utility/platform_dependent/disable_warnings.h
@@ -1,0 +1,75 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Note: this file shall not have include guards or #pragma once.
+
+#ifdef SILENCE_EXTERNAL_WARNINGS
+
+// To use this feature, we must have sufficiently new compiler.
+
+// Using gcc is ok if version 4.6 or newer.
+#if defined(__GNUC__)
+#  define __GNUC_VERSION__ (__GNUC__ * 100 \
+                            + __GNUC_MINOR__ * 1)
+#  if (__GNUC_VERSION__ >= 406)
+#    define GNU_COMPILER_OK 1
+#  else
+#    define GNU_COMPILER_OK 0
+#  endif
+#else
+#  define GNU_COMPILER_OK 0
+#endif
+
+// Uncertain what version of clang to require,
+// assume all versions are fine.
+#if defined(__clang__)
+#  define CLANG_COMPILER_OK 1
+#else
+#  define CLANG_COMPILER_OK 0
+#endif
+
+// More compilers can be added here if necessary.
+#define COMPATIBLE_COMPILER (GNU_COMPILER_OK || CLANG_COMPILER_OK)
+
+// If compiler is compatible, push current warning level
+// and ignore warnings that are usually generated from
+// third-party libraries that are not warning-clean.
+// Note that both clang and (newer) gcc accept the
+// "#pragma GCC diagnostic" syntax.
+#if COMPATIBLE_COMPILER
+#pragma GCC diagnostic push
+// Suppress warnings: "unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]".
+// This is necessary because not all the compilers have the same warning options.
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#pragma GCC diagnostic ignored "-Wdeprecated-register"
+#pragma GCC diagnostic ignored "-Wignored-qualifiers"
+#pragma GCC diagnostic ignored "-Wmismatched-tags"
+#pragma GCC diagnostic ignored "-Wshadow"
+#pragma GCC diagnostic ignored "-Wsign-compare"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wtautological-compare"
+#pragma GCC diagnostic ignored "-Wtype-limits"
+#pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunneeded-internal-declaration"
+#pragma GCC diagnostic ignored "-Wunused-private-field"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#endif // COMPATIBLE_COMPILER
+
+#endif // SILENCE_EXTERNAL_WARNINGS

--- a/opm/core/utility/platform_dependent/reenable_warnings.h
+++ b/opm/core/utility/platform_dependent/reenable_warnings.h
@@ -1,0 +1,57 @@
+/*
+  Copyright 2014 SINTEF ICT, Applied Mathematics.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Note: this file shall not have include guards or #pragma once.
+
+#ifdef SILENCE_EXTERNAL_WARNINGS
+
+// To use this feature, we must have sufficiently new compiler.
+
+// Using gcc is ok if version 4.6 or newer.
+#if defined(__GNUC__)
+#  define __GNUC_VERSION__ (__GNUC__ * 100 \
+                            + __GNUC_MINOR__ * 1)
+#  if (__GNUC_VERSION__ >= 406)
+#    define GNU_COMPILER_OK 1
+#  else
+#    define GNU_COMPILER_OK 0
+#  endif
+#else
+#  define GNU_COMPILER_OK 0
+#endif
+
+// Uncertain what version of clang to require,
+// assume all versions are fine.
+#if defined(__clang__)
+#  define CLANG_COMPILER_OK 1
+#else
+#  define CLANG_COMPILER_OK 0
+#endif
+
+// More compilers can be added here if necessary.
+#define COMPATIBLE_COMPILER (GNU_COMPILER_OK || CLANG_COMPILER_OK)
+
+// If compiler is compatible, pop current warning level.
+// Note that both clang and (newer) gcc accept the
+// "#pragma GCC diagnostic" syntax.
+#if COMPATIBLE_COMPILER
+#pragma GCC diagnostic pop
+#endif // COMPATIBLE_COMPILER
+
+#endif // SILENCE_EXTERNAL_WARNINGS


### PR DESCRIPTION
This should be merged simultaneously with the corresponding PR in opm-core that removes the header from there. Please review the (small) CMake changes, as I am not intimately familiar with how things should be done in opm-parser (since it does not use the exact same approach to adding files as the other modules do). The actual headers are the same as before.

This is a pragmatic move to make it possible to use this functionality in opm-parser. In the longer term the headers should end up in the topmost core module of opm (which no longer opm-core can be said to be). Keeping the paths identical means that no client code needs to change.