### PR TITLE
Add phase info to tests

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -258,6 +258,9 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
     const char *deckString =
         "RUNSPEC\n"
         "\n"
+        "OIL\n"
+        "GAS\n"
+        "WATER\n"
         "TABDIMS\n"
         "3 /\n"
         "\n"

--- a/opm/parser/eclipse/EclipseState/Grid/tests/SatfuncPropertyInitializersTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/SatfuncPropertyInitializersTests.cpp
@@ -42,6 +42,9 @@ void check_property(EclipseState eclState1, EclipseState eclState2,  const std::
 BOOST_AUTO_TEST_CASE(SaturationFunctionFamilyTests) {
     const char * deckdefault =
             "RUNSPEC\n"
+            "OIL\n"
+            "GAS\n"
+            "WATER\n"
             "DIMENS\n"
             " 1 1 1 /\n"
             "TABDIMS\n"


### PR DESCRIPTION
OIL, GAS and WATER is specified to avoid the 3-phase assert test in
SatfuncPropertyInitializers to fail. 

See #556 