### PR TITLE
Support slgof

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -240,6 +240,7 @@ EclipseState/Tables/PlyshlogTable.hpp
 EclipseState/Tables/EnkrvdTable.hpp
 EclipseState/Tables/ImkrvdTable.hpp
 EclipseState/Tables/SgofTable.hpp
+EclipseState/Tables/SlgofTable.hpp
 EclipseState/Tables/PvtoTable.hpp
 EclipseState/Tables/ImptvdTable.hpp
 EclipseState/Tables/RsvdTable.hpp

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -263,6 +263,10 @@ namespace Opm {
         return m_sgofTables;
     }
 
+    const std::vector<SlgofTable>& EclipseState::getSlgofTables() const {
+        return m_slgofTables;
+    }
+
     const std::vector<Sof2Table>& EclipseState::getSof2Tables() const {
         return m_sof2Tables;
     }
@@ -374,6 +378,7 @@ namespace Opm {
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
         initSimpleTables(deck, "SGOF", m_sgofTables);
+        initSimpleTables(deck, "SLGOF", m_slgofTables);
         initSimpleTables(deck, "SOF2", m_sof2Tables);
         initSimpleTables(deck, "SOF3", m_sof3Tables);
         initSimpleTables(deck, "SWOF", m_swofTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -57,6 +57,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
@@ -142,6 +143,7 @@ namespace Opm {
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
         const std::vector<SgofTable>& getSgofTables() const;
+        const std::vector<SlgofTable>& getSlgofTables() const;
         const std::vector<Sof2Table>& getSof2Tables() const;
         const std::vector<Sof3Table>& getSof3Tables() const;
         const std::vector<SwofTable>& getSwofTables() const;
@@ -299,6 +301,7 @@ namespace Opm {
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
         std::vector<SgofTable> m_sgofTables;
+        std::vector<SlgofTable> m_slgofTables;
         std::vector<Sof2Table> m_sof2Tables;
         std::vector<Sof3Table> m_sof3Tables;
         std::vector<SwofTable> m_swofTables;

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -420,22 +420,23 @@ protected:
 
         const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
         const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
+        const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
         const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
         const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
         const std::vector<Sof3Table>& sof3Tables = m_eclipseState.getSof3Tables();
 
-        bool family1 = !sgofTables.empty() && !swofTables.empty();
+        bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
 
         if (family1 && family2) {
             throw std::invalid_argument("Saturation families should not be mixed \n"
-                                        "Use either SGOF and SWOF or SGFN, SWFN and SOF3");
+                                        "Use either SGOF (or SLGOF) and SWOF or SGFN, SWFN and SOF3");
         }
 
         if (!family1 && !family2) {
             throw std::invalid_argument("Saturations function must be specified using either "
                                         "family 1 or family 2 keywords \n"
-                                        "Use either SGOF and SWOF or SGFN, SWFN and SOF3" );
+                                        "Use either SGOF (or SLGOF) and SWOF or SGFN, SWFN and SOF3" );
         }
 
         if (family1 && !family2)

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -72,7 +72,7 @@ protected:
     /*
       The method here goes through the saturation function tables
       Either family I (SWOF,SGOF) or family II (SWFN, SGFN and SOF3)
-      must be specified. Other keyword alternatives like SLGOF, SOF2
+      must be specified. Other keyword alternatives like SOF2
       and SGWFN and the two dimensional saturation tables
       are currently not supported.
 
@@ -93,18 +93,32 @@ protected:
         case SaturationFunctionFamily::FamilyI:
         {
             const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
-            const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
-            assert(swofTables.size() == numSatTables);
             assert(swofTables.size() == numSatTables);
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 m_minWaterSat[tableIdx] = swofTables[tableIdx].getSwColumn().front();
                 m_maxWaterSat[tableIdx] = swofTables[tableIdx].getSwColumn().back();
-
-                m_minGasSat[tableIdx] = sgofTables[tableIdx].getSgColumn().front();
-                m_maxGasSat[tableIdx] = sgofTables[tableIdx].getSgColumn().back();
             }
-            break;
 
+            if (!m_eclipseState.getSgofTables().empty()) {
+                const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
+                assert(sgofTables.size() == numSatTables);
+                for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                    m_minGasSat[tableIdx] = sgofTables[tableIdx].getSgColumn().front();
+                    m_maxGasSat[tableIdx] = sgofTables[tableIdx].getSgColumn().back();
+                }
+            }
+            else {
+                assert(!m_eclipseState.getSlgofTables().empty());
+
+                const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
+                assert(slgofTables.size() == numSatTables);
+                for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                    m_minGasSat[tableIdx] = 1.0 - slgofTables[tableIdx].getSlColumn().back();
+                    m_maxGasSat[tableIdx] = 1.0 - slgofTables[tableIdx].getSlColumn().front();
+                }
+            }
+
+            break;
         }
         case SaturationFunctionFamily::FamilyII:
         {
@@ -141,7 +155,6 @@ protected:
         case SaturationFunctionFamily::FamilyI:
         {
             const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
-            const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
 
             for (int tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 // find the critical water saturation
@@ -157,32 +170,7 @@ protected:
                     }
                 }
 
-                // find the critical gas saturation
-                numRows = sgofTables[tableIdx].numRows();
-                const auto &krgCol = sgofTables[tableIdx].getKrgColumn();
-                for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-                    if (krgCol[rowIdx] > 0.0) {
-                        double Sg = 0.0;
-                        if (rowIdx > 0)
-                            Sg = sgofTables[tableIdx].getSgColumn()[rowIdx - 1];
-                        m_criticalGasSat[tableIdx] = Sg;
-                        break;
-                    }
-                }
-
-                // find the critical oil saturation of the oil-gas system
-                numRows = sgofTables[tableIdx].numRows();
-                const auto &kroOGCol = sgofTables[tableIdx].getKrogColumn();
-                for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
-                    if (kroOGCol[rowIdx] > 0.0) {
-                        double Sg = sgofTables[tableIdx].getSgColumn()[rowIdx + 1];
-                        m_criticalOilOGSat[tableIdx] = 1 - Sg;
-                        break;
-                    }
-                }
-
                 // find the critical oil saturation of the water-oil system
-                numRows = swofTables[tableIdx].numRows();
                 const auto &kroOWCol = swofTables[tableIdx].getKrowColumn();
                 for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
                     if (kroOWCol[rowIdx] > 0.0) {
@@ -192,6 +180,66 @@ protected:
                     }
                 }
             }
+
+            if (!m_eclipseState.getSgofTables().empty()) {
+                const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
+
+                for (int tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                    // find the critical gas saturation
+                    int numRows = sgofTables[tableIdx].numRows();
+                    const auto &krgCol = sgofTables[tableIdx].getKrgColumn();
+                    for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+                        if (krgCol[rowIdx] > 0.0) {
+                            double Sg = 0.0;
+                            if (rowIdx > 0)
+                                Sg = sgofTables[tableIdx].getSgColumn()[rowIdx - 1];
+                            m_criticalGasSat[tableIdx] = Sg;
+                            break;
+                        }
+                    }
+
+                    // find the critical oil saturation of the oil-gas system
+                    const auto &kroOGCol = sgofTables[tableIdx].getKrogColumn();
+                    for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
+                        if (kroOGCol[rowIdx] > 0.0) {
+                            double Sg = sgofTables[tableIdx].getSgColumn()[rowIdx + 1];
+                            m_criticalOilOGSat[tableIdx] = 1 - Sg;
+                            break;
+                        }
+                    }
+                }
+            }
+            else {
+                assert(!m_eclipseState.getSlgofTables().empty());
+
+                const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
+                assert(slgofTables.size() == numSatTables);
+                for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                    // find the critical gas saturation
+                    int numRows = slgofTables[tableIdx].numRows();
+                    const auto &krgCol = slgofTables[tableIdx].getKrgColumn();
+                    for (int rowIdx = numRows - 1; rowIdx >= 0; -- rowIdx) {
+                        if (krgCol[rowIdx] > 0.0) {
+                            assert(rowIdx < numRows - 1);
+
+                            m_criticalGasSat[tableIdx] =
+                                1.0 - slgofTables[tableIdx].getSlColumn()[rowIdx + 1];
+                            break;
+                        }
+                    }
+
+                    // find the critical oil saturation of the oil-gas system
+                    const auto &kroOGCol = slgofTables[tableIdx].getKrogColumn();
+                    for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+                        if (kroOGCol[rowIdx] > 0.0) {
+                            m_criticalOilOGSat[tableIdx] =
+                                slgofTables[tableIdx].getSlColumn()[rowIdx + 1];
+                            break;
+                        }
+                    }
+                }
+            }
+
             break;
 
         }

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -1,0 +1,78 @@
+/*
+  Copyright (C) 2015 by Andreas Lauser
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_SLGOF_TABLE_HPP
+#define	OPM_PARSER_SLGOF_TABLE_HPP
+
+#include "SingleRecordTable.hpp"
+
+namespace Opm {
+    // forward declaration
+    class EclipseState;
+
+    class SlgofTable : protected SingleRecordTable {
+        typedef SingleRecordTable ParentType;
+
+        friend class EclipseState;
+
+        /*!
+         * \brief Read the SGOF keyword and provide some convenience
+         *        methods for it.
+         */
+        void init(Opm::DeckKeywordConstPtr keyword,
+                  int recordIdx)
+        {
+            ParentType::init(keyword,
+                             std::vector<std::string>{"SL", "KRG", "KROG", "PCOG"},
+                             recordIdx,
+                             /*firstEntityOffset=*/0);
+
+            ParentType::checkNonDefaultable("SL");
+            ParentType::checkMonotonic("SL", /*isAscending=*/true);
+            ParentType::applyDefaultsLinear("KRG");
+            ParentType::applyDefaultsLinear("KROG");
+            ParentType::applyDefaultsLinear("PCOG");
+        }
+
+    public:
+        SlgofTable() = default;
+
+        using ParentType::numTables;
+        using ParentType::numRows;
+        using ParentType::numColumns;
+        using ParentType::evaluate;
+
+        const std::vector<double> &getSlColumn() const
+        { return ParentType::getColumn(0); }
+
+        const std::vector<double> &getKrgColumn() const
+        { return ParentType::getColumn(1); }
+
+        const std::vector<double> &getKrogColumn() const
+        { return ParentType::getColumn(2); }
+
+        // this column is p_g - p_o (non-wetting phase pressure minus
+        // wetting phase pressure for a given gas saturation. the name
+        // is inconsistent, but it is the one used in the Eclipse
+        // manual...)
+        const std::vector<double> &getPcogColumn() const
+        { return ParentType::getColumn(3); }
+    };
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -44,9 +44,16 @@ namespace Opm {
 
             ParentType::checkNonDefaultable("SL");
             ParentType::checkMonotonic("SL", /*isAscending=*/true);
+            ParentType::checkMonotonic("KRG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            ParentType::checkMonotonic("KROG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            ParentType::checkMonotonic("PCOG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
             ParentType::applyDefaultsLinear("KRG");
             ParentType::applyDefaultsLinear("KROG");
             ParentType::applyDefaultsLinear("PCOG");
+
+            if (getSlColumn().back() != 1.0) {
+                throw std::invalid_argument("The last saturation of the SLGOF keyword must be 1!");
+            }
         }
 
     public:

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -59,6 +59,12 @@ namespace Opm {
     public:
         SlgofTable() = default;
 
+#ifdef BOOST_TEST_MODULE
+        // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
+        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
+        { init(keyword, tableIdx); }
+#endif
+
         using ParentType::numTables;
         using ParentType::numRows;
         using ParentType::numColumns;

--- a/opm/parser/eclipse/IntegrationTests/CMakeLists.txt
+++ b/opm/parser/eclipse/IntegrationTests/CMakeLists.txt
@@ -6,7 +6,7 @@ foreach(tapp CheckDeckValidity IntegrationTests ParseWellProbe
              ParseTVDP ParseDENSITY ParseVFPPROD ScheduleCreateFromDeck
              CompletionsFromDeck ParseEND IncludeTest ParseEQUIL
              ParseRSVD ParsePVTG ParsePVTO ParseSWOF BoxTest
-             ParseMULTREGT ParseSGOF EclipseGridCreateFromDeck NNCTests
+             ParseMULTREGT ParseSGOF ParseSLGOF EclipseGridCreateFromDeck NNCTests
              ResinsightTest IOConfigIntegrationTest )
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})

--- a/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
@@ -1,0 +1,68 @@
+#define BOOST_TEST_MODULE ParserIntegrationTests
+#include <math.h>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/test/test_tools.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckDoubleItem.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseMode.hpp>
+#include <opm/parser/eclipse/Parser/ParserIntItem.hpp>
+#include <opm/parser/eclipse/Parser/ParserDoubleItem.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
+
+using namespace Opm;
+
+// the data which ought to be parsed
+const char *parserData =
+    "TABDIMS\n"
+    "-- NTSFUN NTPVT NSSFUN NPPVT NTFIP NRPVT\n"
+    "        1     1     30     1     1     1 /\n"
+    "\n"
+    "--  S_l k_rg k_rog p_cog\n"
+    "SLGOF\n"
+    "    0.1 1.0 0.0 9.0\n"
+    "    0.2 0.9 0.2 8.0\n"
+    "    0.3 0.8 0.3 7.0\n"
+    "    0.4 0.7 0.3 6.0\n"
+    "    0.5 0.6 0.4 5.0\n"
+    "    0.6 0.5 0.5 4.0\n"
+    "    0.7 0.3 0.8 3.0\n"
+    "    0.8 0.2 0.9 2.0\n"
+    "    0.9 0.1 1.0 1.0\n"
+    "    1.0 0.0 1.0 0.0 /\n";
+
+static void check_parser(ParserPtr parser) {
+    DeckPtr deck =  parser->parseString(parserData, ParseMode());
+    DeckKeywordConstPtr kw1 = deck->getKeyword("SLGOF");
+    BOOST_CHECK_EQUAL(1U , kw1->size());
+
+    DeckRecordConstPtr record0 = kw1->getRecord(0);
+    BOOST_CHECK_EQUAL(1U , record0->size());
+
+    DeckItemConstPtr item0 = record0->getItem(0);
+    BOOST_CHECK_EQUAL(10U * 4, item0->size());
+}
+
+static void check_SlgofTable(ParserPtr parser) {
+    DeckPtr deck =  parser->parseString(parserData, ParseMode());
+    Opm::SlgofTable slgofTable;
+    slgofTable.initFORUNITTESTONLY(deck->getKeyword("SLGOF"), /*recordIdx=*/0);
+
+    BOOST_CHECK_EQUAL(10U, slgofTable.getSlColumn().size());
+    BOOST_CHECK_EQUAL(0.1, slgofTable.getSlColumn()[0]);
+    BOOST_CHECK_EQUAL(1.0, slgofTable.getSlColumn()[9]);
+    BOOST_CHECK_EQUAL(0.0, slgofTable.getKrgColumn()[9]);
+    BOOST_CHECK_EQUAL(1.0, slgofTable.getKrogColumn()[9]);
+    BOOST_CHECK_EQUAL(0.0, slgofTable.getPcogColumn()[9]);
+}
+
+BOOST_AUTO_TEST_CASE( parse_SLGOF_OK ) {
+    ParserPtr parser(new Parser(/*addDefault=*/true));
+
+    check_parser( parser );
+    check_SlgofTable(parser);
+}


### PR DESCRIPTION
as far as I can see, SLGOF is the same as SGOF but with the saturation column defined as So + Swco (instead of Sg), so everything is reversed. (wow! what a wonderful concept!) Also this is probably the last table (except for, maybe, for SOF2 and friends) which is required to support the family 1 saturation functions fully.
