### PR TITLE
Handle quotes when stripping off comments.

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -46,12 +46,14 @@ namespace Opm {
     public:
         Parser(bool addDefault = true);
 
+        static std::string stripComments(const std::string& inputString);
+
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
         DeckPtr parseFile(const std::string &dataFile, const ParseMode& parseMode) const;
         DeckPtr parseString(const std::string &data, const ParseMode& parseMode) const;
         DeckPtr parseStream(std::shared_ptr<std::istream> inputStream , const ParseMode& parseMode) const;
 
-        
+
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(ParserKeywordConstPtr parserKeyword);
         bool dropParserKeyword(const std::string& parserKeywordName);

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -312,7 +312,18 @@ static ParserKeywordPtr __attribute__((unused)) setupParserKeywordInt(std::strin
 }
 
 
-
+BOOST_AUTO_TEST_CASE( quoted_comments ) {
+    BOOST_CHECK_EQUAL( Parser::stripComments( "ABC" ) , "ABC");
+    BOOST_CHECK_EQUAL( Parser::stripComments( "--ABC") , "");
+    BOOST_CHECK_EQUAL( Parser::stripComments( "ABC--DEF") , "ABC");
+    BOOST_CHECK_EQUAL( Parser::stripComments( "'ABC'--DEF") , "'ABC'");
+    BOOST_CHECK_EQUAL( Parser::stripComments( "\"ABC\"--DEF") , "\"ABC\"");
+    BOOST_CHECK_EQUAL( Parser::stripComments( "ABC--'DEF'") , "ABC");
+    BOOST_CHECK_EQUAL( Parser::stripComments("ABC'--'DEF") , "ABC'--'DEF");
+    BOOST_CHECK_EQUAL( Parser::stripComments("ABC'--'DEF\"--\"GHI") , "ABC'--'DEF\"--\"GHI");
+    BOOST_CHECK_EQUAL( Parser::stripComments("ABC'--'DEF'GHI") , "ABC'--'DEF'GHI");
+    BOOST_CHECK_EQUAL( Parser::stripComments("ABC'--'DEF'--GHI") , "ABC'--'DEF'--GHI");
+}
 
 
 


### PR DESCRIPTION
With this we should handle case like this: https://github.com/OPM/opm-parser/issues/561