### PR TITLE
Silence unused argument warning.

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -59,7 +59,7 @@ namespace Opm {
     }
 
 
-    void ThresholdPressure::initThresholdPressure(const ParseMode& parseMode,
+    void ThresholdPressure::initThresholdPressure(const ParseMode& /* parseMode */,
                                                   std::shared_ptr<const RUNSPECSection> runspecSection,
                                                   std::shared_ptr<const SOLUTIONSection> solutionSection,
                                                   std::shared_ptr<GridProperties<int>> gridProperties) {


### PR DESCRIPTION
I just suppressed the warning, did not check if the argument actually *should* be used.