### PR TITLE
Created Tables class to hold all the tables

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -102,6 +102,7 @@ EclipseState/Tables/SingleRecordTable.cpp
 EclipseState/Tables/MultiRecordTable.cpp
 EclipseState/Tables/VFPProdTable.cpp
 EclipseState/Tables/VFPInjTable.cpp
+EclipseState/Tables/TableManager.cpp
 #
 EclipseState/Grid/GridProperty.cpp
 EclipseState/Grid/Box.cpp
@@ -253,6 +254,7 @@ EclipseState/Tables/WatvisctTable.hpp
 EclipseState/Tables/PvtgOuterTable.hpp
 EclipseState/Tables/VFPProdTable.hpp
 EclipseState/Tables/VFPInjTable.hpp
+EclipseState/Tables/TableManager.hpp
 #
 Utility/WconinjeWrapper.hpp
 Utility/CompdatWrapper.hpp

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -184,10 +184,6 @@ namespace Opm {
         return m_imptvdTables;
     }
 
-    const std::vector<OilvisctTable>& EclipseState::getOilvisctTables() const {
-        return m_oilvisctTables;
-    }
-
     const std::vector<PlyadsTable>& EclipseState::getPlyadsTables() const {
         return m_plyadsTables;
     }
@@ -235,10 +231,6 @@ namespace Opm {
 
     const std::vector<RtempvdTable>& EclipseState::getRtempvdTables() const {
         return m_rtempvdTables;
-    }
-
-    const std::vector<WatvisctTable>& EclipseState::getWatvisctTables() const {
-        return m_watvisctTables;
     }
 
     const std::map<int, VFPProdTable>& EclipseState::getVFPProdTables() const {
@@ -299,7 +291,6 @@ namespace Opm {
         initSimpleTables(deck, "ENPTVD", m_enptvdTables);
         initSimpleTables(deck, "IMKRVD", m_imkrvdTables);
         initSimpleTables(deck, "IMPTVD", m_imptvdTables);
-        initSimpleTables(deck, "OILVISCT", m_oilvisctTables);
         initSimpleTables(deck, "PLYADS", m_plyadsTables);
         initSimpleTables(deck, "PLYMAX", m_plymaxTables);
         initSimpleTables(deck, "PLYROCK", m_plyrockTables);
@@ -307,7 +298,6 @@ namespace Opm {
         initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-        initSimpleTables(deck, "WATVISCT", m_watvisctTables);
 
         // the number of columns of the GASVSISCT tables depends on the value of the
         // COMPS keyword...

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -260,10 +260,6 @@ namespace Opm {
         return m_vfpinjTables;
     }
 
-    const std::vector<SgofTable>& EclipseState::getSgofTables() const {
-        return m_sgofTables;
-    }
-
     const std::vector<SlgofTable>& EclipseState::getSlgofTables() const {
         return m_slgofTables;
     }
@@ -346,7 +342,6 @@ namespace Opm {
         initSimpleTables(deck, "PVDO", m_pvdoTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-        initSimpleTables(deck, "SGOF", m_sgofTables);
         initSimpleTables(deck, "SLGOF", m_slgofTables);
         initSimpleTables(deck, "SOF2", m_sof2Tables);
         initSimpleTables(deck, "SOF3", m_sof3Tables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -175,16 +175,6 @@ namespace Opm {
     }
 
 
-    const std::map<int, VFPProdTable>& EclipseState::getVFPProdTables() const {
-        return m_vfpprodTables;
-    }
-
-    const std::map<int, VFPInjTable>& EclipseState::getVFPInjTables() const {
-        return m_vfpinjTables;
-    }
-
-
-
     ScheduleConstPtr EclipseState::getSchedule() const {
         return schedule;
     }
@@ -229,10 +219,6 @@ namespace Opm {
 
     void EclipseState::initTables(DeckConstPtr deck) {
         m_tables = std::make_shared<const Tables>( *deck );
-        initVFPProdTables(deck, m_vfpprodTables);
-        initVFPInjTables(deck,  m_vfpinjTables);
-
-
         initFullTables(deck, "PVTG", m_pvtgTables);
         initFullTables(deck, "PVTO", m_pvtoTables);
    }
@@ -428,57 +414,6 @@ namespace Opm {
 
 
 
-    void EclipseState::initVFPProdTables(DeckConstPtr deck,
-                                          std::map<int, VFPProdTable>& tableMap) {
-        if (!deck->hasKeyword(ParserKeywords::VFPPROD::keywordName)) {
-            return;
-        }
-
-        int num_tables = deck->numKeywords(ParserKeywords::VFPPROD::keywordName);
-        const auto& keywords = deck->getKeywordList<ParserKeywords::VFPPROD>();
-        const auto unit_system = deck->getActiveUnitSystem();
-        for (int i=0; i<num_tables; ++i) {
-            const auto& keyword = keywords[i];
-
-            VFPProdTable table;
-            table.init(keyword, unit_system);
-
-            //Check that the table in question has a unique ID
-            int table_id = table.getTableNum();
-            if (tableMap.find(table_id) == tableMap.end()) {
-                tableMap.insert(std::make_pair(table_id, std::move(table)));
-            }
-            else {
-                throw std::invalid_argument("Duplicate table numbers for VFPPROD found");
-            }
-        }
-    }
-
-    void EclipseState::initVFPInjTables(DeckConstPtr deck,
-                                        std::map<int, VFPInjTable>& tableMap) {
-        if (!deck->hasKeyword(ParserKeywords::VFPINJ::keywordName)) {
-            return;
-        }
-
-        int num_tables = deck->numKeywords(ParserKeywords::VFPINJ::keywordName);
-        const auto& keywords = deck->getKeywordList<ParserKeywords::VFPINJ>();
-        const auto unit_system = deck->getActiveUnitSystem();
-        for (int i=0; i<num_tables; ++i) {
-            const auto& keyword = keywords[i];
-
-            VFPInjTable table;
-            table.init(keyword, unit_system);
-
-            //Check that the table in question has a unique ID
-            int table_id = table.getTableNum();
-            if (tableMap.find(table_id) == tableMap.end()) {
-                tableMap.insert(std::make_pair(table_id, std::move(table)));
-            }
-            else {
-                throw std::invalid_argument("Duplicate table numbers for VFPINJ found");
-            }
-        }
-    }
 
     bool EclipseState::supportsGridProperty(const std::string& keyword, int enabledTypes) const {
         bool result = false;

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -165,15 +165,6 @@ namespace Opm {
     }
 
 
-    const std::vector<PvtgTable>& EclipseState::getPvtgTables() const {
-        return m_pvtgTables;
-    }
-
-
-    const std::vector<PvtoTable>& EclipseState::getPvtoTables() const {
-        return m_pvtoTables;
-    }
-
 
     ScheduleConstPtr EclipseState::getSchedule() const {
         return schedule;
@@ -219,8 +210,6 @@ namespace Opm {
 
     void EclipseState::initTables(DeckConstPtr deck) {
         m_tables = std::make_shared<const Tables>( *deck );
-        initFullTables(deck, "PVTG", m_pvtgTables);
-        initFullTables(deck, "PVTO", m_pvtoTables);
    }
 
     void EclipseState::initIOConfig(DeckConstPtr deck) {

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -182,10 +182,6 @@ namespace Opm {
     }
 
 
-    const std::vector<PlyshlogTable>& EclipseState::getPlyshlogTables() const {
-        return m_plyshlogTables;
-    }
-
 
     const std::vector<PvtgTable>& EclipseState::getPvtgTables() const {
         return m_pvtgTables;
@@ -265,8 +261,6 @@ namespace Opm {
         initSimpleTables(deck, "IMPTVD", m_imptvdTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-
-        initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
 
         initVFPProdTables(deck, m_vfpprodTables);
         initVFPInjTables(deck,  m_vfpinjTables);
@@ -466,26 +460,6 @@ namespace Opm {
 
 
 
-    void EclipseState::initPlyshlogTables(DeckConstPtr deck,
-                                          const std::string& keywordName,
-                                          std::vector<PlyshlogTable>& tableVector){
-
-        if (!deck->hasKeyword(keywordName)) {
-            return;
-        }
-
-        if (!deck->numKeywords(keywordName)) {
-            complainAboutAmbiguousKeyword(deck, keywordName);
-            return;
-        }
-
-        const auto& keyword = deck->getKeyword(keywordName);
-
-        tableVector.push_back(PlyshlogTable());
-
-        tableVector[0].init(keyword);
-
-    }
 
     void EclipseState::initVFPProdTables(DeckConstPtr deck,
                                           std::map<int, VFPProdTable>& tableMap) {

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -172,9 +172,6 @@ namespace Opm {
         return m_enptvdTables;
     }
 
-    const std::vector<GasvisctTable>& EclipseState::getGasvisctTables() const {
-        return m_gasvisctTables;
-    }
 
     const std::vector<ImkrvdTable>& EclipseState::getImkrvdTables() const {
         return m_imkrvdTables;
@@ -271,11 +268,6 @@ namespace Opm {
         initSimpleTables(deck, "IMPTVD", m_imptvdTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-
-        // the number of columns of the GASVSISCT tables depends on the value of the
-        // COMPS keyword...
-
-        initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
 
         initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
 
@@ -486,35 +478,6 @@ namespace Opm {
     }
 
 
-    void EclipseState::initGasvisctTables(DeckConstPtr deck,
-                                          const std::string& keywordName,
-                                          std::vector<GasvisctTable>& tableVector) {
-        if (!deck->hasKeyword(keywordName))
-            return; // the table is not featured by the deck...
-
-        if (deck->numKeywords(keywordName) > 1) {
-            complainAboutAmbiguousKeyword(deck, keywordName);
-            return;
-        }
-
-        const auto& tableKeyword = deck->getKeyword(keywordName);
-        for (size_t tableIdx = 0; tableIdx < tableKeyword->size(); ++tableIdx) {
-            if (tableKeyword->getRecord(tableIdx)->getItem(0)->size() == 0) {
-                // for simple tables, an empty record indicates that the previous table
-                // should be copied...
-                if (tableIdx == 0) {
-                    std::string msg = "The first table for keyword " + keywordName + " must be explicitly defined! Ignoring keyword";
-                    OpmLog::addMessage(Log::MessageType::Error , Log::fileMessage(tableKeyword->getFileName(),tableKeyword->getLineNumber(),msg));
-                    return;
-                }
-                tableVector.push_back(tableVector.back());
-                continue;
-            }
-
-            tableVector.push_back(GasvisctTable());
-            tableVector[tableIdx].init(deck, tableKeyword, tableIdx);
-        }
-    }
 
     void EclipseState::initPlyshlogTables(DeckConstPtr deck,
                                           const std::string& keywordName,

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -204,9 +204,6 @@ namespace Opm {
         return m_rvvdTables;
     }
 
-    const std::vector<RtempvdTable>& EclipseState::getRtempvdTables() const {
-        return m_rtempvdTables;
-    }
 
     const std::map<int, VFPProdTable>& EclipseState::getVFPProdTables() const {
         return m_vfpprodTables;
@@ -274,16 +271,6 @@ namespace Opm {
         initVFPProdTables(deck, m_vfpprodTables);
         initVFPInjTables(deck,  m_vfpinjTables);
 
-        // the temperature vs depth table. the problem here is that
-        // the TEMPVD (E300) and RTEMPVD (E300 + E100) keywords are
-        // synonymous, but we want to provide only a single cannonical
-        // API here, so we jump through some small hoops...
-        if (deck->hasKeyword("TEMPVD") && deck->hasKeyword("RTEMPVD"))
-            throw std::invalid_argument("The TEMPVD and RTEMPVD tables are mutually exclusive!");
-        else if (deck->hasKeyword("TEMPVD"))
-            initSimpleTables(deck, "TEMPVD", m_rtempvdTables);
-        else if (deck->hasKeyword("RTEMPVD"))
-            initSimpleTables(deck, "RTEMPVD", m_rtempvdTables);
 
         initFullTables(deck, "PVTG", m_pvtgTables);
         initFullTables(deck, "PVTO", m_pvtoTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -260,10 +260,6 @@ namespace Opm {
         return m_vfpinjTables;
     }
 
-    const std::vector<SlgofTable>& EclipseState::getSlgofTables() const {
-        return m_slgofTables;
-    }
-
     const std::vector<Sof2Table>& EclipseState::getSof2Tables() const {
         return m_sof2Tables;
     }
@@ -342,7 +338,6 @@ namespace Opm {
         initSimpleTables(deck, "PVDO", m_pvdoTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-        initSimpleTables(deck, "SLGOF", m_slgofTables);
         initSimpleTables(deck, "SOF2", m_sof2Tables);
         initSimpleTables(deck, "SOF3", m_sof3Tables);
         initSimpleTables(deck, "SWFN", m_swfnTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -184,29 +184,11 @@ namespace Opm {
         return m_imptvdTables;
     }
 
-    const std::vector<PlyadsTable>& EclipseState::getPlyadsTables() const {
-        return m_plyadsTables;
-    }
-
-    const std::vector<PlymaxTable>& EclipseState::getPlymaxTables() const {
-        return m_plymaxTables;
-    }
-
-    const std::vector<PlyrockTable>& EclipseState::getPlyrockTables() const {
-        return m_plyrockTables;
-    }
-
-    const std::vector<PlyviscTable>& EclipseState::getPlyviscTables() const {
-        return m_plyviscTables;
-    }
 
     const std::vector<PlyshlogTable>& EclipseState::getPlyshlogTables() const {
         return m_plyshlogTables;
     }
 
-    const std::vector<PlydhflfTable>& EclipseState::getPlydhflfTables() const {
-        return m_plydhflfTables;
-    }
 
     const std::vector<PvtgTable>& EclipseState::getPvtgTables() const {
         return m_pvtgTables;
@@ -291,11 +273,6 @@ namespace Opm {
         initSimpleTables(deck, "ENPTVD", m_enptvdTables);
         initSimpleTables(deck, "IMKRVD", m_imkrvdTables);
         initSimpleTables(deck, "IMPTVD", m_imptvdTables);
-        initSimpleTables(deck, "PLYADS", m_plyadsTables);
-        initSimpleTables(deck, "PLYMAX", m_plymaxTables);
-        initSimpleTables(deck, "PLYROCK", m_plyrockTables);
-        initSimpleTables(deck, "PLYVISC", m_plyviscTables);
-        initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -164,24 +164,6 @@ namespace Opm {
         return m_tables;
     }
 
-    const std::vector<EnkrvdTable>& EclipseState::getEnkrvdTables() const {
-        return m_enkrvdTables;
-    }
-
-    const std::vector<EnptvdTable>& EclipseState::getEnptvdTables() const {
-        return m_enptvdTables;
-    }
-
-
-    const std::vector<ImkrvdTable>& EclipseState::getImkrvdTables() const {
-        return m_imkrvdTables;
-    }
-
-    const std::vector<ImptvdTable>& EclipseState::getImptvdTables() const {
-        return m_imptvdTables;
-    }
-
-
 
     const std::vector<PvtgTable>& EclipseState::getPvtgTables() const {
         return m_pvtgTables;
@@ -190,14 +172,6 @@ namespace Opm {
 
     const std::vector<PvtoTable>& EclipseState::getPvtoTables() const {
         return m_pvtoTables;
-    }
-
-    const std::vector<RsvdTable>& EclipseState::getRsvdTables() const {
-        return m_rsvdTables;
-    }
-
-    const std::vector<RvvdTable>& EclipseState::getRvvdTables() const {
-        return m_rvvdTables;
     }
 
 
@@ -255,13 +229,6 @@ namespace Opm {
 
     void EclipseState::initTables(DeckConstPtr deck) {
         m_tables = std::make_shared<const Tables>( *deck );
-        initSimpleTables(deck, "ENKRVD", m_enkrvdTables);
-        initSimpleTables(deck, "ENPTVD", m_enptvdTables);
-        initSimpleTables(deck, "IMKRVD", m_imkrvdTables);
-        initSimpleTables(deck, "IMPTVD", m_imptvdTables);
-        initSimpleTables(deck, "RSVD", m_rsvdTables);
-        initSimpleTables(deck, "RVVD", m_rvvdTables);
-
         initVFPProdTables(deck, m_vfpprodTables);
         initVFPInjTables(deck,  m_vfpinjTables);
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -159,8 +159,9 @@ namespace Opm {
         return std::make_shared<EclipseGrid>( m_eclipseGrid->c_ptr() );
     }
 
-    std::shared_ptr<const Tabdims> EclipseState::getTabdims() const {
-        return m_tabdims;
+
+    std::shared_ptr<const Tables> EclipseState::getTables() const {
+        return m_tables;
     }
 
     const std::vector<EnkrvdTable>& EclipseState::getEnkrvdTables() const {
@@ -331,38 +332,10 @@ namespace Opm {
         return m_title;
     }
 
-    void EclipseState::initTabdims(DeckConstPtr deck) {
-        /*
-          The default values for the various number of tables is
-          embedded in the ParserKeyword("TABDIMS") instance; however
-          the EclipseState object does not have a dependency on the
-          Parser classes, have therefor decided not to add an explicit
-          dependency here, and instead duplicated all the default
-          values.
-        */
-        size_t ntsfun = 1;
-        size_t ntpvt = 1;
-        size_t nssfun = 1;
-        size_t nppvt = 1;
-        size_t ntfip = 1;
-        size_t nrpvt = 1;
-
-        if (deck->hasKeyword("TABDIMS")) {
-            auto keyword = deck->getKeyword("TABDIMS");
-            auto record = keyword->getRecord(0);
-            ntsfun = record->getItem("NTSFUN")->getInt(0);
-            ntpvt  = record->getItem("NTPVT")->getInt(0);
-            nssfun = record->getItem("NSSFUN")->getInt(0);
-            nppvt  = record->getItem("NPPVT")->getInt(0);
-            ntfip  = record->getItem("NTFIP")->getInt(0);
-            nrpvt  = record->getItem("NRPVT")->getInt(0);
-        }
-        m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
-    }
 
 
     void EclipseState::initTables(DeckConstPtr deck) {
-        initTabdims( deck );
+        m_tables = std::make_shared<const Tables>( *deck );
         initSimpleTables(deck, "ENKRVD", m_enkrvdTables);
         initSimpleTables(deck, "ENPTVD", m_enptvdTables);
         initSimpleTables(deck, "IMKRVD", m_imkrvdTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -212,14 +212,6 @@ namespace Opm {
         return m_plydhflfTables;
     }
 
-    const std::vector<PvdgTable>& EclipseState::getPvdgTables() const {
-        return m_pvdgTables;
-    }
-
-    const std::vector<PvdoTable>& EclipseState::getPvdoTables() const {
-        return m_pvdoTables;
-    }
-
     const std::vector<PvtgTable>& EclipseState::getPvtgTables() const {
         return m_pvtgTables;
     }
@@ -327,8 +319,6 @@ namespace Opm {
         initSimpleTables(deck, "PLYROCK", m_plyrockTables);
         initSimpleTables(deck, "PLYVISC", m_plyviscTables);
         initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
-        initSimpleTables(deck, "PVDG", m_pvdgTables);
-        initSimpleTables(deck, "PVDO", m_pvdoTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
         initSimpleTables(deck, "SWFN", m_swfnTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -216,9 +216,6 @@ namespace Opm {
         return m_pvtgTables;
     }
 
-    const std::vector<PvdsTable>& EclipseState::getPvdsTables() const {
-        return m_pvdsTables;
-    }
 
     const std::vector<PvtoTable>& EclipseState::getPvtoTables() const {
         return m_pvtoTables;
@@ -311,7 +308,6 @@ namespace Opm {
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
         initSimpleTables(deck, "WATVISCT", m_watvisctTables);
-        initSimpleTables(deck, "PVDS", m_pvdsTables);
 
         // the number of columns of the GASVSISCT tables depends on the value of the
         // COMPS keyword...

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -276,10 +276,6 @@ namespace Opm {
         return m_sof3Tables;
     }
 
-    const std::vector<SwofTable>& EclipseState::getSwofTables() const {
-        return m_swofTables;
-    }
-
     const std::vector<SwfnTable>& EclipseState::getSwfnTables() const {
         return m_swfnTables;
     }
@@ -354,7 +350,6 @@ namespace Opm {
         initSimpleTables(deck, "SLGOF", m_slgofTables);
         initSimpleTables(deck, "SOF2", m_sof2Tables);
         initSimpleTables(deck, "SOF3", m_sof3Tables);
-        initSimpleTables(deck, "SWOF", m_swofTables);
         initSimpleTables(deck, "SWFN", m_swfnTables);
         initSimpleTables(deck, "SGFN", m_sgfnTables);
         initSimpleTables(deck, "SSFN", m_ssfnTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -253,17 +253,6 @@ namespace Opm {
     }
 
 
-    const std::vector<SwfnTable>& EclipseState::getSwfnTables() const {
-        return m_swfnTables;
-    }
-
-    const std::vector<SgfnTable>& EclipseState::getSgfnTables() const {
-        return m_sgfnTables;
-    }
-
-    const std::vector<SsfnTable>& EclipseState::getSsfnTables() const {
-        return m_ssfnTables;
-    }
 
     ScheduleConstPtr EclipseState::getSchedule() const {
         return schedule;
@@ -321,9 +310,6 @@ namespace Opm {
         initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-        initSimpleTables(deck, "SWFN", m_swfnTables);
-        initSimpleTables(deck, "SGFN", m_sgfnTables);
-        initSimpleTables(deck, "SSFN", m_ssfnTables);
         initSimpleTables(deck, "WATVISCT", m_watvisctTables);
         initSimpleTables(deck, "PVDS", m_pvdsTables);
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -260,13 +260,6 @@ namespace Opm {
         return m_vfpinjTables;
     }
 
-    const std::vector<Sof2Table>& EclipseState::getSof2Tables() const {
-        return m_sof2Tables;
-    }
-
-    const std::vector<Sof3Table>& EclipseState::getSof3Tables() const {
-        return m_sof3Tables;
-    }
 
     const std::vector<SwfnTable>& EclipseState::getSwfnTables() const {
         return m_swfnTables;
@@ -338,8 +331,6 @@ namespace Opm {
         initSimpleTables(deck, "PVDO", m_pvdoTables);
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
-        initSimpleTables(deck, "SOF2", m_sof2Tables);
-        initSimpleTables(deck, "SOF3", m_sof3Tables);
         initSimpleTables(deck, "SWFN", m_swfnTables);
         initSimpleTables(deck, "SGFN", m_sgfnTables);
         initSimpleTables(deck, "SSFN", m_ssfnTables);

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -34,14 +34,8 @@
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
@@ -99,14 +93,8 @@ namespace Opm {
         // the tables used by the deck. If the tables had some defaulted data in the
         // deck, the objects returned here exhibit the correct values. If the table is
         // not present in the deck, the corresponding vector is of size zero.
-        const std::vector<EnkrvdTable>& getEnkrvdTables() const;
-        const std::vector<EnptvdTable>& getEnptvdTables() const;
-        const std::vector<ImkrvdTable>& getImkrvdTables() const;
-        const std::vector<ImptvdTable>& getImptvdTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
-        const std::vector<RsvdTable>& getRsvdTables() const;
-        const std::vector<RvvdTable>& getRvvdTables() const;
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
         size_t getNumPhases() const;
@@ -225,14 +213,8 @@ namespace Opm {
         SimulationConfigConstPtr m_simulationConfig;
 
         std::shared_ptr<const Tables> m_tables;
-        std::vector<EnkrvdTable> m_enkrvdTables;
-        std::vector<EnptvdTable> m_enptvdTables;
-        std::vector<ImkrvdTable> m_imkrvdTables;
-        std::vector<ImptvdTable> m_imptvdTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::vector<RsvdTable> m_rsvdTables;
-        std::vector<RvvdTable> m_rvvdTables;
         std::map<int, VFPProdTable> m_vfpprodTables;
         std::map<int, VFPInjTable> m_vfpinjTables;
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -36,8 +36,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
@@ -95,8 +93,6 @@ namespace Opm {
         // not present in the deck, the corresponding vector is of size zero.
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
-        const std::map<int, VFPProdTable>& getVFPProdTables() const;
-        const std::map<int, VFPInjTable>& getVFPInjTables() const;
         size_t getNumPhases() const;
 
         // the unit system used by the deck. note that it is rarely needed to convert
@@ -174,11 +170,6 @@ namespace Opm {
             }
         }
 
-        void initVFPProdTables(DeckConstPtr deck,
-                               std::map<int, VFPProdTable>& tableMap);
-
-        void initVFPInjTables(DeckConstPtr deck,
-                              std::map<int, VFPInjTable>& tableMap);
 
         void setMULTFLT(std::shared_ptr<const Section> section) const;
         void initMULTREGT(DeckConstPtr deck);
@@ -215,8 +206,6 @@ namespace Opm {
         std::shared_ptr<const Tables> m_tables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::map<int, VFPProdTable> m_vfpprodTables;
-        std::map<int, VFPInjTable> m_vfpinjTables;
 
         std::set<enum Phase::PhaseEnum> phases;
         std::string m_title;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -47,7 +47,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
@@ -124,7 +123,6 @@ namespace Opm {
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;
-        const std::vector<PvdsTable>& getPvdsTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
         const std::vector<RocktabTable>& getRocktabTables() const;
         const std::vector<RsvdTable>& getRsvdTables() const;
@@ -271,7 +269,6 @@ namespace Opm {
         std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<PvtgTable> m_pvtgTables;
-        std::vector<PvdsTable> m_pvdsTables;
         std::vector<PvtoTable> m_pvtoTables;
         std::vector<RocktabTable> m_rocktabTables;
         std::vector<RsvdTable> m_rsvdTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -34,8 +34,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
@@ -88,11 +86,6 @@ namespace Opm {
         bool hasNNC() const;
 
         std::shared_ptr<const Tables> getTables() const;
-        // the tables used by the deck. If the tables had some defaulted data in the
-        // deck, the objects returned here exhibit the correct values. If the table is
-        // not present in the deck, the corresponding vector is of size zero.
-        const std::vector<PvtgTable>& getPvtgTables() const;
-        const std::vector<PvtoTable>& getPvtoTables() const;
         size_t getNumPhases() const;
 
         // the unit system used by the deck. note that it is rarely needed to convert
@@ -149,27 +142,6 @@ namespace Opm {
             }
         }
 
-        template <class TableType>
-        void initFullTables(DeckConstPtr deck,
-                            const std::string& keywordName,
-                            std::vector<TableType>& tableVector) {
-            if (!deck->hasKeyword(keywordName))
-                return; // the table is not featured by the deck...
-
-            if (deck->numKeywords(keywordName) > 1) {
-                complainAboutAmbiguousKeyword(deck, keywordName);
-                return;
-            }
-
-            const auto& tableKeyword = deck->getKeyword(keywordName);
-
-            int numTables = TableType::numTables(tableKeyword);
-            for (int tableIdx = 0; tableIdx < numTables; ++tableIdx) {
-                tableVector.push_back(TableType());
-                tableVector[tableIdx].init(tableKeyword, tableIdx);
-            }
-        }
-
 
         void setMULTFLT(std::shared_ptr<const Section> section) const;
         void initMULTREGT(DeckConstPtr deck);
@@ -204,8 +176,6 @@ namespace Opm {
         SimulationConfigConstPtr m_simulationConfig;
 
         std::shared_ptr<const Tables> m_tables;
-        std::vector<PvtgTable> m_pvtgTables;
-        std::vector<PvtoTable> m_pvtoTables;
 
         std::set<enum Phase::PhaseEnum> phases;
         std::string m_title;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -33,7 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
@@ -117,10 +117,10 @@ namespace Opm {
         std::shared_ptr<const NNC> getNNC() const;
         bool hasNNC() const;
 
+        std::shared_ptr<const Tables> getTables() const;
         // the tables used by the deck. If the tables had some defaulted data in the
         // deck, the objects returned here exhibit the correct values. If the table is
         // not present in the deck, the corresponding vector is of size zero.
-        std::shared_ptr<const Tabdims> getTabdims() const;
         const std::vector<EnkrvdTable>& getEnkrvdTables() const;
         const std::vector<EnptvdTable>& getEnptvdTables() const;
         const std::vector<GasvisctTable>& getGasvisctTables() const;
@@ -277,8 +277,7 @@ namespace Opm {
         ScheduleConstPtr         schedule;
         SimulationConfigConstPtr m_simulationConfig;
 
-
-        std::shared_ptr<const Tabdims> m_tabdims;
+        std::shared_ptr<const Tables> m_tables;
         std::vector<EnkrvdTable> m_enkrvdTables;
         std::vector<EnptvdTable> m_enptvdTables;
         std::vector<GasvisctTable> m_gasvisctTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -54,9 +54,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
@@ -133,9 +130,6 @@ namespace Opm {
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<SwfnTable>& getSwfnTables() const;
-        const std::vector<SgfnTable>& getSgfnTables() const;
-        const std::vector<SsfnTable>& getSsfnTables() const;
         const std::vector<WatvisctTable>& getWatvisctTables() const;
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
@@ -283,9 +277,6 @@ namespace Opm {
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<SwfnTable> m_swfnTables;
-        std::vector<SgfnTable> m_sgfnTables;
-        std::vector<SsfnTable> m_ssfnTables;
         std::vector<WatvisctTable> m_watvisctTables;
         std::map<int, VFPProdTable> m_vfpprodTables;
         std::map<int, VFPInjTable> m_vfpinjTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -39,7 +39,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
@@ -52,7 +51,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
@@ -115,7 +113,6 @@ namespace Opm {
         const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<ImkrvdTable>& getImkrvdTables() const;
         const std::vector<ImptvdTable>& getImptvdTables() const;
-        const std::vector<OilvisctTable>& getOilvisctTables() const;
         const std::vector<PlyadsTable>& getPlyadsTables() const;
         const std::vector<PlymaxTable>& getPlymaxTables() const;
         const std::vector<PlyrockTable>& getPlyrockTables() const;
@@ -128,7 +125,6 @@ namespace Opm {
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<WatvisctTable>& getWatvisctTables() const;
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
         size_t getNumPhases() const;
@@ -261,7 +257,6 @@ namespace Opm {
         std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<ImkrvdTable> m_imkrvdTables;
         std::vector<ImptvdTable> m_imptvdTables;
-        std::vector<OilvisctTable> m_oilvisctTables;
         std::vector<PlyadsTable> m_plyadsTables;
         std::vector<PlymaxTable> m_plymaxTables;
         std::vector<PlyrockTable> m_plyrockTables;
@@ -274,7 +269,6 @@ namespace Opm {
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<WatvisctTable> m_watvisctTables;
         std::map<int, VFPProdTable> m_vfpprodTables;
         std::map<int, VFPInjTable> m_vfpinjTables;
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -56,8 +56,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
@@ -139,8 +137,6 @@ namespace Opm {
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<Sof2Table>& getSof2Tables() const;
-        const std::vector<Sof3Table>& getSof3Tables() const;
         const std::vector<SwfnTable>& getSwfnTables() const;
         const std::vector<SgfnTable>& getSgfnTables() const;
         const std::vector<SsfnTable>& getSsfnTables() const;
@@ -293,8 +289,6 @@ namespace Opm {
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<Sof2Table> m_sof2Tables;
-        std::vector<Sof3Table> m_sof3Tables;
         std::vector<SwfnTable> m_swfnTables;
         std::vector<SgfnTable> m_sgfnTables;
         std::vector<SsfnTable> m_ssfnTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -56,7 +56,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
@@ -141,7 +140,6 @@ namespace Opm {
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<SgofTable>& getSgofTables() const;
         const std::vector<SlgofTable>& getSlgofTables() const;
         const std::vector<Sof2Table>& getSof2Tables() const;
         const std::vector<Sof3Table>& getSof3Tables() const;
@@ -297,7 +295,6 @@ namespace Opm {
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<SgofTable> m_sgofTables;
         std::vector<SlgofTable> m_slgofTables;
         std::vector<Sof2Table> m_sof2Tables;
         std::vector<Sof3Table> m_sof3Tables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -46,8 +46,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
@@ -128,8 +126,6 @@ namespace Opm {
         const std::vector<PlyviscTable>& getPlyviscTables() const;
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
-        const std::vector<PvdgTable>& getPvdgTables() const;
-        const std::vector<PvdoTable>& getPvdoTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvdsTable>& getPvdsTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
@@ -280,8 +276,6 @@ namespace Opm {
         std::vector<PlyviscTable> m_plyviscTables;
         std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
-        std::vector<PvdgTable> m_pvdgTables;
-        std::vector<PvdoTable> m_pvdoTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvdsTable> m_pvdsTables;
         std::vector<PvtoTable> m_pvtoTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -42,7 +42,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
@@ -111,7 +110,6 @@ namespace Opm {
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
-        const std::vector<RocktabTable>& getRocktabTables() const;
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
@@ -194,7 +192,6 @@ namespace Opm {
             }
         }
 
-        void initRocktabTables(DeckConstPtr deck);
         void initGasvisctTables(DeckConstPtr deck,
                                 const std::string& keywordName,
                                 std::vector<GasvisctTable>& tableVector);
@@ -250,7 +247,6 @@ namespace Opm {
         std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::vector<RocktabTable> m_rocktabTables;
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -56,7 +56,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
@@ -140,7 +139,6 @@ namespace Opm {
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<SlgofTable>& getSlgofTables() const;
         const std::vector<Sof2Table>& getSof2Tables() const;
         const std::vector<Sof3Table>& getSof3Tables() const;
         const std::vector<SwfnTable>& getSwfnTables() const;
@@ -295,7 +293,6 @@ namespace Opm {
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<SlgofTable> m_slgofTables;
         std::vector<Sof2Table> m_sof2Tables;
         std::vector<Sof3Table> m_sof3Tables;
         std::vector<SwfnTable> m_swfnTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -36,15 +36,10 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
@@ -113,11 +108,6 @@ namespace Opm {
         const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<ImkrvdTable>& getImkrvdTables() const;
         const std::vector<ImptvdTable>& getImptvdTables() const;
-        const std::vector<PlyadsTable>& getPlyadsTables() const;
-        const std::vector<PlymaxTable>& getPlymaxTables() const;
-        const std::vector<PlyrockTable>& getPlyrockTables() const;
-        const std::vector<PlyviscTable>& getPlyviscTables() const;
-        const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
@@ -257,11 +247,6 @@ namespace Opm {
         std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<ImkrvdTable> m_imkrvdTables;
         std::vector<ImptvdTable> m_imptvdTables;
-        std::vector<PlyadsTable> m_plyadsTables;
-        std::vector<PlymaxTable> m_plymaxTables;
-        std::vector<PlyrockTable> m_plyrockTables;
-        std::vector<PlyviscTable> m_plyviscTables;
-        std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -60,7 +60,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
@@ -146,7 +145,6 @@ namespace Opm {
         const std::vector<SlgofTable>& getSlgofTables() const;
         const std::vector<Sof2Table>& getSof2Tables() const;
         const std::vector<Sof3Table>& getSof3Tables() const;
-        const std::vector<SwofTable>& getSwofTables() const;
         const std::vector<SwfnTable>& getSwfnTables() const;
         const std::vector<SgfnTable>& getSgfnTables() const;
         const std::vector<SsfnTable>& getSsfnTables() const;
@@ -303,7 +301,6 @@ namespace Opm {
         std::vector<SlgofTable> m_slgofTables;
         std::vector<Sof2Table> m_sof2Tables;
         std::vector<Sof3Table> m_sof3Tables;
-        std::vector<SwofTable> m_swofTables;
         std::vector<SwfnTable> m_swfnTables;
         std::vector<SgfnTable> m_sgfnTables;
         std::vector<SsfnTable> m_ssfnTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -43,7 +43,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
@@ -110,7 +109,6 @@ namespace Opm {
         const std::vector<PvtoTable>& getPvtoTables() const;
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
-        const std::vector<RtempvdTable>& getRtempvdTables() const;
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
         size_t getNumPhases() const;
@@ -242,7 +240,6 @@ namespace Opm {
         std::vector<PvtoTable> m_pvtoTables;
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
-        std::vector<RtempvdTable> m_rtempvdTables;
         std::map<int, VFPProdTable> m_vfpprodTables;
         std::map<int, VFPInjTable> m_vfpinjTables;
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -36,7 +36,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
@@ -104,7 +103,6 @@ namespace Opm {
         const std::vector<EnptvdTable>& getEnptvdTables() const;
         const std::vector<ImkrvdTable>& getImkrvdTables() const;
         const std::vector<ImptvdTable>& getImptvdTables() const;
-        const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
         const std::vector<RsvdTable>& getRsvdTables() const;
@@ -188,10 +186,6 @@ namespace Opm {
             }
         }
 
-        void initPlyshlogTables(DeckConstPtr deck,
-                                const std::string& keywordName,
-                                std::vector<PlyshlogTable>& tableVector);
-
         void initVFPProdTables(DeckConstPtr deck,
                                std::map<int, VFPProdTable>& tableMap);
 
@@ -235,7 +229,6 @@ namespace Opm {
         std::vector<EnptvdTable> m_enptvdTables;
         std::vector<ImkrvdTable> m_imkrvdTables;
         std::vector<ImptvdTable> m_imptvdTables;
-        std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
         std::vector<RsvdTable> m_rsvdTables;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -37,7 +37,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp>
@@ -104,7 +103,6 @@ namespace Opm {
         // not present in the deck, the corresponding vector is of size zero.
         const std::vector<EnkrvdTable>& getEnkrvdTables() const;
         const std::vector<EnptvdTable>& getEnptvdTables() const;
-        const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<ImkrvdTable>& getImkrvdTables() const;
         const std::vector<ImptvdTable>& getImptvdTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
@@ -192,10 +190,6 @@ namespace Opm {
             }
         }
 
-        void initGasvisctTables(DeckConstPtr deck,
-                                const std::string& keywordName,
-                                std::vector<GasvisctTable>& tableVector);
-
         void initPlyshlogTables(DeckConstPtr deck,
                                 const std::string& keywordName,
                                 std::vector<PlyshlogTable>& tableVector);
@@ -241,7 +235,6 @@ namespace Opm {
         std::shared_ptr<const Tables> m_tables;
         std::vector<EnkrvdTable> m_enkrvdTables;
         std::vector<EnptvdTable> m_enptvdTables;
-        std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<ImkrvdTable> m_imkrvdTables;
         std::vector<ImptvdTable> m_imptvdTables;
         std::vector<PlyshlogTable> m_plyshlogTables;

--- a/opm/parser/eclipse/EclipseState/Grid/GridPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridPropertyInitializers.hpp
@@ -102,8 +102,9 @@ public:
             return;
         }
 
+        auto tables = m_eclipseState.getTables();
         auto eclipseGrid = m_eclipseState.getEclipseGrid();
-        const std::vector<RtempvdTable>& rtempvdTables = m_eclipseState.getRtempvdTables();
+        const std::vector<RtempvdTable>& rtempvdTables = tables->getRtempvdTables();
         const std::vector<int>& eqlNum = m_eclipseState.getIntGridProperty("EQLNUM")->getData();
 
         for (size_t cellIdx = 0; cellIdx < eqlNum.size(); ++ cellIdx) {

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -92,7 +92,7 @@ protected:
         switch (getSaturationFunctionFamily()) {
         case SaturationFunctionFamily::FamilyI:
         {
-            const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
+            const std::vector<SwofTable>& swofTables = tables->getSwofTables();
             assert(swofTables.size() == numSatTables);
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 m_minWaterSat[tableIdx] = swofTables[tableIdx].getSwColumn().front();
@@ -154,7 +154,7 @@ protected:
         switch (getSaturationFunctionFamily()) {
         case SaturationFunctionFamily::FamilyI:
         {
-            const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
+            const std::vector<SwofTable>& swofTables = tables->getSwofTables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 // find the critical water saturation
@@ -325,7 +325,7 @@ protected:
         switch (getSaturationFunctionFamily()) {
         case SaturationFunctionFamily::FamilyI:
         {
-            const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
+            const std::vector<SwofTable>& swofTables = tables->getSwofTables();
             const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
@@ -417,8 +417,8 @@ protected:
     // If SWFN, SGFN and SOF3 are specified in the deck it return FamilyII
     // If keywords are missing or mixed, an error is given.
     const SaturationFunctionFamily getSaturationFunctionFamily() const{
-
-        const std::vector<SwofTable>& swofTables = m_eclipseState.getSwofTables();
+        auto tables = m_eclipseState.getTables( );
+        const std::vector<SwofTable>& swofTables = tables->getSwofTables();
         const std::vector<SgofTable>& sgofTables = m_eclipseState.getSgofTables();
         const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
         const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -544,7 +544,7 @@ public:
         // sampling points. Both of these are outside the scope of opm-parser, so we just
         // assign a NaN in this case...
         bool useEnptvd = this->m_deck.hasKeyword("ENPTVD");
-        const auto& enptvdTables = this->m_eclipseState.getEnptvdTables();
+        const auto& enptvdTables = tables->getEnptvdTables();
         for (size_t cellIdx = 0; cellIdx < eclipseGrid->getCartesianSize(); cellIdx++) {
             int satTableIdx = satnum->iget( cellIdx ) - 1;
             int endNum = endnum->iget( cellIdx ) - 1;
@@ -599,7 +599,7 @@ public:
         // sampling points. Both of these are outside the scope of opm-parser, so we just
         // assign a NaN in this case...
         bool useImptvd = this->m_deck.hasKeyword("IMPTVD");
-        const auto& imptvdTables = this->m_eclipseState.getImptvdTables();
+        const auto& imptvdTables = tables->getImptvdTables();
         for (size_t cellIdx = 0; cellIdx < eclipseGrid->getCartesianSize(); cellIdx++) {
             int imbTableIdx = imbnum->iget( cellIdx ) - 1;
             int endNum = endnum->iget( cellIdx ) - 1;

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -246,9 +246,10 @@ protected:
         }
 
         case SaturationFunctionFamily::FamilyII: {
+            auto tables = m_eclipseState.getTables();
             const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
             const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
-            const std::vector<Sof3Table>& sof3Tables = m_eclipseState.getSof3Tables();
+            const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 // find the critical water saturation
@@ -373,9 +374,10 @@ protected:
             break;
         }
         case SaturationFunctionFamily::FamilyII: {
+            auto tables = m_eclipseState.getTables();
             const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
             const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
-            const std::vector<Sof3Table>& sof3Tables = m_eclipseState.getSof3Tables();
+            const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 // find the maximum output values of the oil-gas system
@@ -425,7 +427,7 @@ protected:
         const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
         const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
         const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
-        const std::vector<Sof3Table>& sof3Tables = m_eclipseState.getSof3Tables();
+        const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
         bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -81,8 +81,8 @@ protected:
 
 
     void findSaturationEndpoints( ) const {
-
-        auto tabdims = m_eclipseState.getTabdims();
+        auto tables = m_eclipseState.getTables();
+        auto tabdims = tables->getTabdims();
         size_t numSatTables = tabdims->getNumSatTables();
         m_minWaterSat.resize( numSatTables , 0 );
         m_maxWaterSat.resize( numSatTables , 0 );
@@ -142,8 +142,8 @@ protected:
 
 
     void findCriticalPoints( ) const {
-
-        auto tabdims = m_eclipseState.getTabdims();
+        auto tables = m_eclipseState.getTables();
+        auto tabdims = tables->getTabdims();
         size_t numSatTables = tabdims->getNumSatTables();
 
         m_criticalWaterSat.resize( numSatTables , 0 );
@@ -308,8 +308,8 @@ protected:
     }
 
     void findVerticalPoints( ) const {
-
-        auto tabdims = m_eclipseState.getTabdims();
+        auto tables = m_eclipseState.getTables();
+        auto tabdims = tables->getTabdims();
         size_t numSatTables = tabdims->getNumSatTables();
 
         m_maxPcog.resize( numSatTables , 0 );
@@ -518,7 +518,8 @@ public:
                       bool useOneMinusTableValue) const
     {
         auto eclipseGrid = this->m_eclipseState.getEclipseGrid();
-        auto tabdims = this->m_eclipseState.getTabdims();
+        auto tables = this->m_eclipseState.getTables();
+        auto tabdims = tables->getTabdims();
         auto satnum = this->m_eclipseState.getIntGridProperty("SATNUM");
         auto endnum = this->m_eclipseState.getIntGridProperty("ENDNUM");
         int numSatTables = tabdims->getNumSatTables();
@@ -576,9 +577,11 @@ public:
                       bool useOneMinusTableValue) const
     {
         auto eclipseGrid = this->m_eclipseState.getEclipseGrid();
-        auto tabdims = this->m_eclipseState.getTabdims();
+        auto tables = this->m_eclipseState.getTables();
         auto imbnum = this->m_eclipseState.getIntGridProperty("IMBNUM");
         auto endnum = this->m_eclipseState.getIntGridProperty("ENDNUM");
+
+        auto tabdims = tables->getTabdims();
         int numSatTables = tabdims->getNumSatTables();
 
         imbnum->checkLimits(1 , numSatTables);

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -101,7 +101,7 @@ protected:
 
             {
                 const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-                const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
+                const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
 
                 if (!sgofTables.empty()) {
                     assert(sgofTables.size() == numSatTables);
@@ -185,7 +185,7 @@ protected:
 
             {
                 const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-                const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
+                const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
 
                 if (!sgofTables.empty()) {
                     for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
@@ -422,7 +422,7 @@ protected:
         auto tables = m_eclipseState.getTables( );
         const std::vector<SwofTable>& swofTables = tables->getSwofTables();
         const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-        const std::vector<SlgofTable>& slgofTables = m_eclipseState.getSlgofTables();
+        const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
         const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
         const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
         const std::vector<Sof3Table>& sof3Tables = m_eclipseState.getSof3Tables();

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -124,8 +124,8 @@ protected:
         }
         case SaturationFunctionFamily::FamilyII:
         {
-            const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
-            const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
+            const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
+            const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
             assert(swfnTables.size() == numSatTables);
             assert(sgfnTables.size() == numSatTables);
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
@@ -247,8 +247,8 @@ protected:
 
         case SaturationFunctionFamily::FamilyII: {
             auto tables = m_eclipseState.getTables();
-            const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
-            const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
+            const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
+            const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
             const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
@@ -375,8 +375,8 @@ protected:
         }
         case SaturationFunctionFamily::FamilyII: {
             auto tables = m_eclipseState.getTables();
-            const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
-            const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
+            const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
+            const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
             const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
@@ -425,8 +425,8 @@ protected:
         const std::vector<SwofTable>& swofTables = tables->getSwofTables();
         const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
         const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
-        const std::vector<SwfnTable>& swfnTables = m_eclipseState.getSwfnTables();
-        const std::vector<SgfnTable>& sgfnTables = m_eclipseState.getSgfnTables();
+        const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
+        const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
         const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
         bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();

--- a/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class EnkrvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         EnkrvdTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class EnptvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         EnptvdTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -23,24 +23,24 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class GasvisctTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         GasvisctTable() = default;
 
         /*!
          * \brief Read the GASVISCT keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckConstPtr deck, Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(const Deck& deck, Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            int numComponents = deck->getKeyword("COMPS")->getRecord(0)->getItem(0)->getInt(0);
+            int numComponents = deck.getKeyword("COMPS")->getRecord(0)->getItem(0)->getInt(0);
 
-            auto temperatureDimension = deck->getActiveUnitSystem()->getDimension("Temperature");
-            auto viscosityDimension = deck->getActiveUnitSystem()->getDimension("Viscosity");
+            auto temperatureDimension = deck.getActiveUnitSystem()->getDimension("Temperature");
+            auto viscosityDimension = deck.getActiveUnitSystem()->getDimension("Viscosity");
 
             // create the columns: temperature plus one viscosity column per component
             std::vector<std::string> columnNames;

--- a/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class ImkrvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         ImkrvdTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class ImptvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         ImptvdTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class OilvisctTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         OilvisctTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PlyadsTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the PLYADS keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PlydhflfTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         PlydhflfTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PlymaxTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         PlymaxTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PlyrockTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         PlyrockTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -23,11 +23,11 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PlyshlogTable {
 
-        friend class EclipseState;
+        friend class Tables;
         PlyshlogTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PlyviscTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         PlyviscTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PvdgTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         PvdgTable() = default;
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PvdoTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         PvdoTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
@@ -24,12 +24,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class PvdsTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         PvdsTable() = default;
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgTable.hpp
@@ -25,7 +25,7 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     /*!
      * \brief Read the table for the PVTG and provide convenient access to it.
@@ -34,7 +34,7 @@ namespace Opm {
     {
         typedef Opm::FullTable<Opm::PvtgOuterTable, Opm::PvtgInnerTable> ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         using ParentType::init;
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp
@@ -25,7 +25,7 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     /*!
      * \brief Read the table for the PVTO and provide convenient access to it.
@@ -33,7 +33,7 @@ namespace Opm {
     class PvtoTable : public Opm::FullTable<Opm::PvtoOuterTable, Opm::PvtoInnerTable>
     {
         typedef Opm::FullTable<Opm::PvtoOuterTable, Opm::PvtoInnerTable> ParentType;
-        friend class EclipseState;
+        friend class Tables;
         using ParentType::init;
 
     public:

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class RocktabTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         RocktabTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class RsvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         RsvdTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class RtempvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         RtempvdTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class RvvdTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         RvvdTable() = default;
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class SgfnTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SGFN keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class SgofTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SGOF keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class SlgofTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SGOF keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class Sof2Table : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SOF2 keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class Sof3Table : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SOF3 keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class SsfnTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         SsfnTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class SwfnTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SWFN keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class SwofTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
 
         /*!
          * \brief Read the SWOF keyword and provide some convenience

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -27,8 +27,8 @@ namespace Opm {
     Tables::Tables( const Deck& deck ) {
         initTabdims( deck );
         initSimpleTables(deck, "SWOF", m_swofTables);
+        initSimpleTables(deck, "SGOF", m_sgofTables);
     }
-
 
 
     void Tables::initTabdims(const Deck& deck) {
@@ -68,6 +68,11 @@ namespace Opm {
 
     const std::vector<SwofTable>& Tables::getSwofTables() const {
         return m_swofTables;
+    }
+
+
+    const std::vector<SgofTable>& Tables::getSgofTables() const {
+        return m_sgofTables;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -45,6 +45,7 @@ namespace Opm {
         initSimpleTables(deck, "OILVISCT", m_oilvisctTables);
         initSimpleTables(deck, "WATVISCT", m_watvisctTables);
 
+        initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
         initRocktabTables(deck);
         initRTempTables(deck);
         initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
@@ -125,6 +126,29 @@ namespace Opm {
             tableVector[tableIdx].init(deck, tableKeyword, tableIdx);
         }
     }
+
+    void Tables::initPlyshlogTables(const Deck& deck,
+                                    const std::string& keywordName,
+                                    std::vector<PlyshlogTable>& tableVector){
+
+        if (!deck.hasKeyword(keywordName)) {
+            return;
+        }
+
+        if (!deck.numKeywords(keywordName)) {
+            complainAboutAmbiguousKeyword(deck, keywordName);
+            return;
+        }
+
+        const auto& keyword = deck.getKeyword(keywordName);
+
+        tableVector.push_back(PlyshlogTable());
+
+        tableVector[0].init(keyword);
+
+    }
+
+
 
 
     void Tables::initRocktabTables(const Deck& deck) {
@@ -246,6 +270,10 @@ namespace Opm {
 
     const std::vector<PlydhflfTable>& Tables::getPlydhflfTables() const {
         return m_plydhflfTables;
+    }
+
+    const std::vector<PlyshlogTable>& Tables::getPlyshlogTables() const {
+        return m_plyshlogTables;
     }
 
     const std::vector<RocktabTable>& Tables::getRocktabTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -37,6 +37,11 @@ namespace Opm {
         initSimpleTables(deck, "SGFN", m_sgfnTables);
         initSimpleTables(deck, "SSFN", m_ssfnTables);
         initSimpleTables(deck, "PVDS", m_pvdsTables);
+        initSimpleTables(deck, "PLYADS", m_plyadsTables);
+        initSimpleTables(deck, "PLYMAX", m_plymaxTables);
+        initSimpleTables(deck, "PLYROCK", m_plyrockTables);
+        initSimpleTables(deck, "PLYVISC", m_plyviscTables);
+        initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
         initSimpleTables(deck, "OILVISCT", m_oilvisctTables);
         initSimpleTables(deck, "WATVISCT", m_watvisctTables);
     }
@@ -129,6 +134,26 @@ namespace Opm {
 
     const std::vector<WatvisctTable>& Tables::getWatvisctTables() const {
         return m_watvisctTables;
+    }
+
+    const std::vector<PlyadsTable>& Tables::getPlyadsTables() const {
+        return m_plyadsTables;
+    }
+
+    const std::vector<PlymaxTable>& Tables::getPlymaxTables() const {
+        return m_plymaxTables;
+    }
+
+    const std::vector<PlyrockTable>& Tables::getPlyrockTables() const {
+        return m_plyrockTables;
+    }
+
+    const std::vector<PlyviscTable>& Tables::getPlyviscTables() const {
+        return m_plyviscTables;
+    }
+
+    const std::vector<PlydhflfTable>& Tables::getPlydhflfTables() const {
+        return m_plydhflfTables;
     }
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -28,6 +28,7 @@ namespace Opm {
         initTabdims( deck );
         initSimpleTables(deck, "SWOF", m_swofTables);
         initSimpleTables(deck, "SGOF", m_sgofTables);
+        initSimpleTables(deck, "SLGOF", m_slgofTables);
     }
 
 
@@ -68,6 +69,11 @@ namespace Opm {
 
     const std::vector<SwofTable>& Tables::getSwofTables() const {
         return m_swofTables;
+    }
+
+
+    const std::vector<SlgofTable>& Tables::getSlgofTables() const {
+        return m_slgofTables;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -29,6 +29,8 @@ namespace Opm {
         initSimpleTables(deck, "SWOF", m_swofTables);
         initSimpleTables(deck, "SGOF", m_sgofTables);
         initSimpleTables(deck, "SLGOF", m_slgofTables);
+        initSimpleTables(deck, "SOF2", m_sof2Tables);
+        initSimpleTables(deck, "SOF3", m_sof3Tables);
     }
 
 
@@ -81,6 +83,13 @@ namespace Opm {
         return m_sgofTables;
     }
 
+    const std::vector<Sof2Table>& Tables::getSof2Tables() const {
+        return m_sof2Tables;
+    }
+
+    const std::vector<Sof3Table>& Tables::getSof3Tables() const {
+        return m_sof3Tables;
+    }
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {
         OpmLog::addMessage(Log::MessageType::Error, "The " + keywordName + " keyword must be unique in the deck. Ignoring all!");

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -25,6 +25,43 @@
 namespace Opm {
 
     Tables::Tables( const Deck& deck ) {
+        initTabdims( deck );
+    }
+
+
+
+    void Tables::initTabdims(const Deck& deck) {
+        /*
+          The default values for the various number of tables is
+          embedded in the ParserKeyword("TABDIMS") instance; however
+          the EclipseState object does not have a dependency on the
+          Parser classes, have therefor decided not to add an explicit
+          dependency here, and instead duplicated all the default
+          values.
+        */
+        size_t ntsfun = 1;
+        size_t ntpvt = 1;
+        size_t nssfun = 1;
+        size_t nppvt = 1;
+        size_t ntfip = 1;
+        size_t nrpvt = 1;
+
+        if (deck.hasKeyword("TABDIMS")) {
+            auto keyword = deck.getKeyword("TABDIMS");
+            auto record = keyword->getRecord(0);
+            ntsfun = record->getItem("NTSFUN")->getInt(0);
+            ntpvt  = record->getItem("NTPVT")->getInt(0);
+            nssfun = record->getItem("NSSFUN")->getInt(0);
+            nppvt  = record->getItem("NPPVT")->getInt(0);
+            ntfip  = record->getItem("NTFIP")->getInt(0);
+            nrpvt  = record->getItem("NRPVT")->getInt(0);
+        }
+        m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
+    }
+
+
+    std::shared_ptr<const Tabdims> Tables::getTabdims() const {
+        return m_tabdims;
     }
 
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -31,6 +31,8 @@ namespace Opm {
         initSimpleTables(deck, "SLGOF", m_slgofTables);
         initSimpleTables(deck, "SOF2", m_sof2Tables);
         initSimpleTables(deck, "SOF3", m_sof3Tables);
+        initSimpleTables(deck, "PVDG", m_pvdgTables);
+        initSimpleTables(deck, "PVDO", m_pvdoTables);
     }
 
 
@@ -89,6 +91,14 @@ namespace Opm {
 
     const std::vector<Sof3Table>& Tables::getSof3Tables() const {
         return m_sof3Tables;
+    }
+
+    const std::vector<PvdgTable>& Tables::getPvdgTables() const {
+        return m_pvdgTables;
+    }
+
+    const std::vector<PvdoTable>& Tables::getPvdoTables() const {
+        return m_pvdoTables;
     }
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -26,6 +26,7 @@ namespace Opm {
 
     Tables::Tables( const Deck& deck ) {
         initTabdims( deck );
+        initSimpleTables(deck, "SWOF", m_swofTables);
     }
 
 
@@ -64,6 +65,20 @@ namespace Opm {
         return m_tabdims;
     }
 
+
+    const std::vector<SwofTable>& Tables::getSwofTables() const {
+        return m_swofTables;
+    }
+
+
+    void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {
+        OpmLog::addMessage(Log::MessageType::Error, "The " + keywordName + " keyword must be unique in the deck. Ignoring all!");
+        auto keywords = deck.getKeywordList(keywordName);
+        for (size_t i = 0; i < keywords.size(); ++i) {
+            std::string msg = "Ambiguous keyword "+keywordName+" defined here";
+            OpmLog::addMessage(Log::MessageType::Error , Log::fileMessage( keywords[i]->getFileName(), keywords[i]->getLineNumber(),msg));
+        }
+    }
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -36,6 +36,7 @@ namespace Opm {
         initSimpleTables(deck, "SWFN", m_swfnTables);
         initSimpleTables(deck, "SGFN", m_sgfnTables);
         initSimpleTables(deck, "SSFN", m_ssfnTables);
+        initSimpleTables(deck, "PVDS", m_pvdsTables);
     }
 
 
@@ -115,6 +116,11 @@ namespace Opm {
     const std::vector<SsfnTable>& Tables::getSsfnTables() const {
         return m_ssfnTables;
     }
+
+    const std::vector<PvdsTable>& Tables::getPvdsTables() const {
+        return m_pvdsTables;
+    }
+
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {
         OpmLog::addMessage(Log::MessageType::Error, "The " + keywordName + " keyword must be unique in the deck. Ignoring all!");

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -37,6 +37,8 @@ namespace Opm {
         initSimpleTables(deck, "SGFN", m_sgfnTables);
         initSimpleTables(deck, "SSFN", m_ssfnTables);
         initSimpleTables(deck, "PVDS", m_pvdsTables);
+        initSimpleTables(deck, "OILVISCT", m_oilvisctTables);
+        initSimpleTables(deck, "WATVISCT", m_watvisctTables);
     }
 
 
@@ -121,6 +123,13 @@ namespace Opm {
         return m_pvdsTables;
     }
 
+    const std::vector<OilvisctTable>& Tables::getOilvisctTables() const {
+        return m_oilvisctTables;
+    }
+
+    const std::vector<WatvisctTable>& Tables::getWatvisctTables() const {
+        return m_watvisctTables;
+    }
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {
         OpmLog::addMessage(Log::MessageType::Error, "The " + keywordName + " keyword must be unique in the deck. Ignoring all!");

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -51,11 +51,13 @@ namespace Opm {
         initSimpleTables(deck, "RSVD", m_rsvdTables);
         initSimpleTables(deck, "RVVD", m_rvvdTables);
 
-
         initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
         initRocktabTables(deck);
         initRTempTables(deck);
         initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
+
+        initVFPProdTables(deck, m_vfpprodTables);
+        initVFPInjTables(deck,  m_vfpinjTables);
     }
 
 
@@ -195,6 +197,59 @@ namespace Opm {
         }
     }
 
+
+
+    void Tables::initVFPProdTables(const Deck& deck,
+                                          std::map<int, VFPProdTable>& tableMap) {
+        if (!deck.hasKeyword(ParserKeywords::VFPPROD::keywordName)) {
+            return;
+        }
+
+        int num_tables = deck.numKeywords(ParserKeywords::VFPPROD::keywordName);
+        const auto& keywords = deck.getKeywordList<ParserKeywords::VFPPROD>();
+        const auto unit_system = deck.getActiveUnitSystem();
+        for (int i=0; i<num_tables; ++i) {
+            const auto& keyword = keywords[i];
+
+            VFPProdTable table;
+            table.init(keyword, unit_system);
+
+            //Check that the table in question has a unique ID
+            int table_id = table.getTableNum();
+            if (tableMap.find(table_id) == tableMap.end()) {
+                tableMap.insert(std::make_pair(table_id, std::move(table)));
+            }
+            else {
+                throw std::invalid_argument("Duplicate table numbers for VFPPROD found");
+            }
+        }
+    }
+
+    void Tables::initVFPInjTables(const Deck& deck,
+                                        std::map<int, VFPInjTable>& tableMap) {
+        if (!deck.hasKeyword(ParserKeywords::VFPINJ::keywordName)) {
+            return;
+        }
+
+        int num_tables = deck.numKeywords(ParserKeywords::VFPINJ::keywordName);
+        const auto& keywords = deck.getKeywordList<ParserKeywords::VFPINJ>();
+        const auto unit_system = deck.getActiveUnitSystem();
+        for (int i=0; i<num_tables; ++i) {
+            const auto& keyword = keywords[i];
+
+            VFPInjTable table;
+            table.init(keyword, unit_system);
+
+            //Check that the table in question has a unique ID
+            int table_id = table.getTableNum();
+            if (tableMap.find(table_id) == tableMap.end()) {
+                tableMap.insert(std::make_pair(table_id, std::move(table)));
+            }
+            else {
+                throw std::invalid_argument("Duplicate table numbers for VFPINJ found");
+            }
+        }
+    }
 
     std::shared_ptr<const Tabdims> Tables::getTabdims() const {
         return m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -1,0 +1,32 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
+
+namespace Opm {
+
+    Tables::Tables( const Deck& deck ) {
+    }
+
+}
+
+

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -55,6 +55,8 @@ namespace Opm {
         initRocktabTables(deck);
         initRTempTables(deck);
         initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
+        initFullTables(deck, "PVTG", m_pvtgTables);
+        initFullTables(deck, "PVTO", m_pvtoTables);
 
         initVFPProdTables(deck, m_vfpprodTables);
         initVFPInjTables(deck,  m_vfpinjTables);
@@ -373,6 +375,14 @@ namespace Opm {
         return m_rvvdTables;
     }
 
+    const std::vector<PvtgTable>& Tables::getPvtgTables() const {
+        return m_pvtgTables;
+    }
+
+
+    const std::vector<PvtoTable>& Tables::getPvtoTables() const {
+        return m_pvtoTables;
+    }
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {
         OpmLog::addMessage(Log::MessageType::Error, "The " + keywordName + " keyword must be unique in the deck. Ignoring all!");

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -33,6 +33,9 @@ namespace Opm {
         initSimpleTables(deck, "SOF3", m_sof3Tables);
         initSimpleTables(deck, "PVDG", m_pvdgTables);
         initSimpleTables(deck, "PVDO", m_pvdoTables);
+        initSimpleTables(deck, "SWFN", m_swfnTables);
+        initSimpleTables(deck, "SGFN", m_sgfnTables);
+        initSimpleTables(deck, "SSFN", m_ssfnTables);
     }
 
 
@@ -99,6 +102,18 @@ namespace Opm {
 
     const std::vector<PvdoTable>& Tables::getPvdoTables() const {
         return m_pvdoTables;
+    }
+
+    const std::vector<SwfnTable>& Tables::getSwfnTables() const {
+        return m_swfnTables;
+    }
+
+    const std::vector<SgfnTable>& Tables::getSgfnTables() const {
+        return m_sgfnTables;
+    }
+
+    const std::vector<SsfnTable>& Tables::getSsfnTables() const {
+        return m_ssfnTables;
     }
 
     void Tables::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -44,6 +44,13 @@ namespace Opm {
         initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
         initSimpleTables(deck, "OILVISCT", m_oilvisctTables);
         initSimpleTables(deck, "WATVISCT", m_watvisctTables);
+        initSimpleTables(deck, "ENKRVD", m_enkrvdTables);
+        initSimpleTables(deck, "ENPTVD", m_enptvdTables);
+        initSimpleTables(deck, "IMKRVD", m_imkrvdTables);
+        initSimpleTables(deck, "IMPTVD", m_imptvdTables);
+        initSimpleTables(deck, "RSVD", m_rsvdTables);
+        initSimpleTables(deck, "RVVD", m_rvvdTables);
+
 
         initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
         initRocktabTables(deck);
@@ -282,6 +289,33 @@ namespace Opm {
 
     const std::vector<RtempvdTable>& Tables::getRtempvdTables() const {
         return m_rtempvdTables;
+    }
+
+
+    const std::vector<EnkrvdTable>& Tables::getEnkrvdTables() const {
+        return m_enkrvdTables;
+    }
+
+    const std::vector<EnptvdTable>& Tables::getEnptvdTables() const {
+        return m_enptvdTables;
+    }
+
+
+    const std::vector<ImkrvdTable>& Tables::getImkrvdTables() const {
+        return m_imkrvdTables;
+    }
+
+    const std::vector<ImptvdTable>& Tables::getImptvdTables() const {
+        return m_imptvdTables;
+    }
+
+
+    const std::vector<RsvdTable>& Tables::getRsvdTables() const {
+        return m_rsvdTables;
+    }
+
+    const std::vector<RvvdTable>& Tables::getRvvdTables() const {
+        return m_rvvdTables;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -46,6 +46,7 @@ namespace Opm {
         initSimpleTables(deck, "WATVISCT", m_watvisctTables);
 
         initRocktabTables(deck);
+        initRTempTables(deck);
         initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
     }
 
@@ -77,6 +78,21 @@ namespace Opm {
             nrpvt  = record->getItem("NRPVT")->getInt(0);
         }
         m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
+    }
+
+
+    void Tables::initRTempTables(const Deck& deck) {
+        // the temperature vs depth table. the problem here is that
+        // the TEMPVD (E300) and RTEMPVD (E300 + E100) keywords are
+        // synonymous, but we want to provide only a single cannonical
+        // API here, so we jump through some small hoops...
+        if (deck.hasKeyword("TEMPVD") && deck.hasKeyword("RTEMPVD"))
+            throw std::invalid_argument("The TEMPVD and RTEMPVD tables are mutually exclusive!");
+        else if (deck.hasKeyword("TEMPVD"))
+            initSimpleTables(deck, "TEMPVD", m_rtempvdTables);
+        else if (deck.hasKeyword("RTEMPVD"))
+            initSimpleTables(deck, "RTEMPVD", m_rtempvdTables);
+
     }
 
 
@@ -234,6 +250,10 @@ namespace Opm {
 
     const std::vector<RocktabTable>& Tables::getRocktabTables() const {
         return m_rocktabTables;
+    }
+
+    const std::vector<RtempvdTable>& Tables::getRtempvdTables() const {
+        return m_rtempvdTables;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -25,6 +25,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 
 
 namespace Opm {
@@ -37,6 +38,7 @@ namespace Opm {
         std::shared_ptr<const Tabdims> getTabdims() const;
         const std::vector<SwofTable>& getSwofTables() const;
         const std::vector<SgofTable>& getSgofTables() const;
+        const std::vector<SlgofTable>& getSlgofTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
@@ -76,6 +78,7 @@ namespace Opm {
 
         std::vector<SgofTable> m_sgofTables;
         std::vector<SwofTable> m_swofTables;
+        std::vector<SlgofTable> m_slgofTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -26,6 +26,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
 
 
 namespace Opm {
@@ -36,6 +38,8 @@ namespace Opm {
 
 
         std::shared_ptr<const Tabdims> getTabdims() const;
+        const std::vector<Sof2Table>& getSof2Tables() const;
+        const std::vector<Sof3Table>& getSof3Tables() const;
         const std::vector<SwofTable>& getSwofTables() const;
         const std::vector<SgofTable>& getSgofTables() const;
         const std::vector<SlgofTable>& getSlgofTables() const;
@@ -76,6 +80,8 @@ namespace Opm {
             }
         }
 
+        std::vector<Sof2Table> m_sof2Tables;
+        std::vector<Sof3Table> m_sof3Tables;
         std::vector<SgofTable> m_sgofTables;
         std::vector<SwofTable> m_swofTables;
         std::vector<SlgofTable> m_slgofTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -24,6 +24,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 
 
 namespace Opm {
@@ -35,6 +36,7 @@ namespace Opm {
 
         std::shared_ptr<const Tabdims> getTabdims() const;
         const std::vector<SwofTable>& getSwofTables() const;
+        const std::vector<SgofTable>& getSgofTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
@@ -72,7 +74,7 @@ namespace Opm {
             }
         }
 
-
+        std::vector<SgofTable> m_sgofTables;
         std::vector<SwofTable> m_swofTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -41,6 +41,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
 
 
@@ -71,12 +72,15 @@ namespace Opm {
         const std::vector<RocktabTable>& getRocktabTables() const;
         const std::vector<WatvisctTable>& getWatvisctTables() const;
         const std::vector<OilvisctTable>& getOilvisctTables() const;
-
+        const std::vector<GasvisctTable>& getGasvisctTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
         void initTabdims(const Deck& deck);
         void initRocktabTables(const Deck& deck);
+        void initGasvisctTables(const Deck& deck,
+                                const std::string& keywordName,
+                                std::vector<GasvisctTable>& tableVector);
 
 
         template <class TableType>
@@ -129,6 +133,7 @@ namespace Opm {
         std::vector<RocktabTable> m_rocktabTables;
         std::vector<WatvisctTable> m_watvisctTables;
         std::vector<OilvisctTable> m_oilvisctTables;
+        std::vector<GasvisctTable> m_gasvisctTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -39,6 +39,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
@@ -65,6 +66,7 @@ namespace Opm {
         const std::vector<SgfnTable>& getSgfnTables() const;
         const std::vector<SsfnTable>& getSsfnTables() const;
         const std::vector<PvdsTable>& getPvdsTables() const;
+        const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PlyadsTable>& getPlyadsTables() const;
         const std::vector<PlymaxTable>& getPlymaxTables() const;
         const std::vector<PlyrockTable>& getPlyrockTables() const;
@@ -84,6 +86,10 @@ namespace Opm {
         void initGasvisctTables(const Deck& deck,
                                 const std::string& keywordName,
                                 std::vector<GasvisctTable>& tableVector);
+
+        void initPlyshlogTables(const Deck& deck,
+                                const std::string& keywordName,
+                                std::vector<PlyshlogTable>& tableVector);
 
 
         template <class TableType>
@@ -133,6 +139,7 @@ namespace Opm {
         std::vector<PlyrockTable> m_plyrockTables;
         std::vector<PlyviscTable> m_plyviscTables;
         std::vector<PlydhflfTable> m_plydhflfTables;
+        std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<RocktabTable> m_rocktabTables;
         std::vector<WatvisctTable> m_watvisctTables;
         std::vector<OilvisctTable> m_oilvisctTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -41,6 +41,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
 
 
 namespace Opm {
@@ -67,6 +68,7 @@ namespace Opm {
         const std::vector<PlyrockTable>& getPlyrockTables() const;
         const std::vector<PlyviscTable>& getPlyviscTables() const;
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
+        const std::vector<RocktabTable>& getRocktabTables() const;
         const std::vector<WatvisctTable>& getWatvisctTables() const;
         const std::vector<OilvisctTable>& getOilvisctTables() const;
 
@@ -74,6 +76,7 @@ namespace Opm {
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
         void initTabdims(const Deck& deck);
+        void initRocktabTables(const Deck& deck);
 
 
         template <class TableType>
@@ -123,7 +126,7 @@ namespace Opm {
         std::vector<PlyrockTable> m_plyrockTables;
         std::vector<PlyviscTable> m_plyviscTables;
         std::vector<PlydhflfTable> m_plydhflfTables;
-
+        std::vector<RocktabTable> m_rocktabTables;
         std::vector<WatvisctTable> m_watvisctTables;
         std::vector<OilvisctTable> m_oilvisctTables;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -42,6 +42,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
 
 
@@ -73,9 +74,11 @@ namespace Opm {
         const std::vector<WatvisctTable>& getWatvisctTables() const;
         const std::vector<OilvisctTable>& getOilvisctTables() const;
         const std::vector<GasvisctTable>& getGasvisctTables() const;
+        const std::vector<RtempvdTable>& getRtempvdTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
+        void initRTempTables(const Deck& deck);
         void initTabdims(const Deck& deck);
         void initRocktabTables(const Deck& deck);
         void initGasvisctTables(const Deck& deck,
@@ -134,6 +137,7 @@ namespace Opm {
         std::vector<WatvisctTable> m_watvisctTables;
         std::vector<OilvisctTable> m_oilvisctTables;
         std::vector<GasvisctTable> m_gasvisctTables;
+        std::vector<RtempvdTable> m_rtempvdTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -34,6 +34,11 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 
@@ -57,6 +62,11 @@ namespace Opm {
         const std::vector<SgfnTable>& getSgfnTables() const;
         const std::vector<SsfnTable>& getSsfnTables() const;
         const std::vector<PvdsTable>& getPvdsTables() const;
+        const std::vector<PlyadsTable>& getPlyadsTables() const;
+        const std::vector<PlymaxTable>& getPlymaxTables() const;
+        const std::vector<PlyrockTable>& getPlyrockTables() const;
+        const std::vector<PlyviscTable>& getPlyviscTables() const;
+        const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<WatvisctTable>& getWatvisctTables() const;
         const std::vector<OilvisctTable>& getOilvisctTables() const;
 
@@ -108,6 +118,12 @@ namespace Opm {
         std::vector<SgofTable> m_sgofTables;
         std::vector<SwofTable> m_swofTables;
         std::vector<SlgofTable> m_slgofTables;
+        std::vector<PlyadsTable> m_plyadsTables;
+        std::vector<PlymaxTable> m_plymaxTables;
+        std::vector<PlyrockTable> m_plyrockTables;
+        std::vector<PlyviscTable> m_plyviscTables;
+        std::vector<PlydhflfTable> m_plydhflfTables;
+
         std::vector<WatvisctTable> m_watvisctTables;
         std::vector<OilvisctTable> m_oilvisctTables;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -34,6 +34,9 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
+
 
 namespace Opm {
 
@@ -54,6 +57,8 @@ namespace Opm {
         const std::vector<SgfnTable>& getSgfnTables() const;
         const std::vector<SsfnTable>& getSsfnTables() const;
         const std::vector<PvdsTable>& getPvdsTables() const;
+        const std::vector<WatvisctTable>& getWatvisctTables() const;
+        const std::vector<OilvisctTable>& getOilvisctTables() const;
 
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
@@ -103,6 +108,8 @@ namespace Opm {
         std::vector<SgofTable> m_sgofTables;
         std::vector<SwofTable> m_swofTables;
         std::vector<SlgofTable> m_slgofTables;
+        std::vector<WatvisctTable> m_watvisctTables;
+        std::vector<OilvisctTable> m_oilvisctTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -45,6 +45,12 @@
 #include <opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
 
 
 namespace Opm {
@@ -77,6 +83,12 @@ namespace Opm {
         const std::vector<OilvisctTable>& getOilvisctTables() const;
         const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
+        const std::vector<EnkrvdTable>& getEnkrvdTables() const;
+        const std::vector<EnptvdTable>& getEnptvdTables() const;
+        const std::vector<ImkrvdTable>& getImkrvdTables() const;
+        const std::vector<ImptvdTable>& getImptvdTables() const;
+        const std::vector<RsvdTable>& getRsvdTables() const;
+        const std::vector<RvvdTable>& getRvvdTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
@@ -145,6 +157,12 @@ namespace Opm {
         std::vector<OilvisctTable> m_oilvisctTables;
         std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<RtempvdTable> m_rtempvdTables;
+        std::vector<EnkrvdTable> m_enkrvdTables;
+        std::vector<EnptvdTable> m_enptvdTables;
+        std::vector<ImkrvdTable> m_imkrvdTables;
+        std::vector<ImptvdTable> m_imptvdTables;
+        std::vector<RsvdTable> m_rsvdTables;
+        std::vector<RvvdTable> m_rvvdTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -33,7 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
-
+#include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
 
 namespace Opm {
 
@@ -53,6 +53,7 @@ namespace Opm {
         const std::vector<SwfnTable>& getSwfnTables() const;
         const std::vector<SgfnTable>& getSgfnTables() const;
         const std::vector<SsfnTable>& getSsfnTables() const;
+        const std::vector<PvdsTable>& getPvdsTables() const;
 
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
@@ -91,6 +92,7 @@ namespace Opm {
             }
         }
 
+        std::vector<PvdsTable> m_pvdsTables;
         std::vector<SwfnTable> m_swfnTables;
         std::vector<SgfnTable> m_sgfnTables;
         std::vector<SsfnTable> m_ssfnTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -51,6 +51,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
 
 
 namespace Opm {
@@ -89,6 +91,8 @@ namespace Opm {
         const std::vector<ImptvdTable>& getImptvdTables() const;
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
+        const std::map<int, VFPProdTable>& getVFPProdTables() const;
+        const std::map<int, VFPInjTable>& getVFPInjTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
@@ -102,6 +106,13 @@ namespace Opm {
         void initPlyshlogTables(const Deck& deck,
                                 const std::string& keywordName,
                                 std::vector<PlyshlogTable>& tableVector);
+
+
+        void initVFPProdTables(const Deck& deck,
+                               std::map<int, VFPProdTable>& tableMap);
+
+        void initVFPInjTables(const Deck& deck,
+                              std::map<int, VFPInjTable>& tableMap);
 
 
         template <class TableType>
@@ -135,6 +146,8 @@ namespace Opm {
             }
         }
 
+        std::map<int, VFPProdTable> m_vfpprodTables;
+        std::map<int, VFPInjTable> m_vfpinjTables;
         std::vector<PvdsTable> m_pvdsTables;
         std::vector<SwfnTable> m_swfnTables;
         std::vector<SgfnTable> m_sgfnTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_TABLES_HPP
 #define OPM_TABLES_HPP
 
+#include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
 
 namespace Opm {
 
@@ -27,8 +28,13 @@ namespace Opm {
     public:
         Tables( const Deck& deck );
 
+
+        std::shared_ptr<const Tabdims> getTabdims() const;
     private:
-        
+        void initTabdims(const Deck& deck);
+
+
+        std::shared_ptr<Tabdims> m_tabdims;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -20,7 +20,11 @@
 #ifndef OPM_TABLES_HPP
 #define OPM_TABLES_HPP
 
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
+
 
 namespace Opm {
 
@@ -30,10 +34,46 @@ namespace Opm {
 
 
         std::shared_ptr<const Tabdims> getTabdims() const;
+        const std::vector<SwofTable>& getSwofTables() const;
     private:
+        void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
+
         void initTabdims(const Deck& deck);
 
 
+        template <class TableType>
+        void initSimpleTables(const Deck& deck,
+                              const std::string& keywordName,
+                              std::vector<TableType>& tableVector) {
+            if (!deck.hasKeyword(keywordName))
+                return; // the table is not featured by the deck...
+
+            if (deck.numKeywords(keywordName) > 1) {
+                complainAboutAmbiguousKeyword(deck, keywordName);
+                return;
+            }
+
+            const auto& tableKeyword = deck.getKeyword(keywordName);
+            for (size_t tableIdx = 0; tableIdx < tableKeyword->size(); ++tableIdx) {
+                if (tableKeyword->getRecord(tableIdx)->getItem(0)->size() == 0) {
+                    // for simple tables, an empty record indicates that the previous table
+                    // should be copied...
+                    if (tableIdx == 0) {
+                        std::string msg = "The first table for keyword "+keywordName+" must be explicitly defined! Ignoring keyword";
+                        OpmLog::addMessage(Log::MessageType::Warning , Log::fileMessage( tableKeyword->getFileName(), tableKeyword->getLineNumber(), msg));
+                        return;
+                    }
+                    tableVector.push_back(tableVector.back());
+                    continue;
+                }
+
+                tableVector.push_back(TableType());
+                tableVector[tableIdx].init(tableKeyword, tableIdx);
+            }
+        }
+
+
+        std::vector<SwofTable> m_swofTables;
         std::shared_ptr<Tabdims> m_tabdims;
     };
 }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -30,6 +30,9 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 
 
 namespace Opm {
@@ -47,6 +50,10 @@ namespace Opm {
         const std::vector<SlgofTable>& getSlgofTables() const;
         const std::vector<PvdgTable>& getPvdgTables() const;
         const std::vector<PvdoTable>& getPvdoTables() const;
+        const std::vector<SwfnTable>& getSwfnTables() const;
+        const std::vector<SgfnTable>& getSgfnTables() const;
+        const std::vector<SsfnTable>& getSsfnTables() const;
+
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
@@ -84,6 +91,9 @@ namespace Opm {
             }
         }
 
+        std::vector<SwfnTable> m_swfnTables;
+        std::vector<SgfnTable> m_sgfnTables;
+        std::vector<SsfnTable> m_ssfnTables;
         std::vector<PvdgTable> m_pvdgTables;
         std::vector<PvdoTable> m_pvdoTables;
         std::vector<Sof2Table> m_sof2Tables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -28,6 +28,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
 
 
 namespace Opm {
@@ -43,6 +45,8 @@ namespace Opm {
         const std::vector<SwofTable>& getSwofTables() const;
         const std::vector<SgofTable>& getSgofTables() const;
         const std::vector<SlgofTable>& getSlgofTables() const;
+        const std::vector<PvdgTable>& getPvdgTables() const;
+        const std::vector<PvdoTable>& getPvdoTables() const;
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
@@ -80,6 +84,8 @@ namespace Opm {
             }
         }
 
+        std::vector<PvdgTable> m_pvdgTables;
+        std::vector<PvdoTable> m_pvdoTables;
         std::vector<Sof2Table> m_sof2Tables;
         std::vector<Sof3Table> m_sof3Tables;
         std::vector<SgofTable> m_sgofTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -1,0 +1,36 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_TABLES_HPP
+#define OPM_TABLES_HPP
+
+
+namespace Opm {
+
+    class Tables {
+    public:
+        Tables( const Deck& deck );
+
+    private:
+        
+    };
+}
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -23,12 +23,12 @@
 
 namespace Opm {
     // forward declaration
-    class EclipseState;
+    class Tables;
 
     class WatvisctTable : protected SingleRecordTable {
         typedef SingleRecordTable ParentType;
 
-        friend class EclipseState;
+        friend class Tables;
         WatvisctTable() = default;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(tapp TableTests TabdimsTests)
+foreach(tapp TableTests TableManagerTests TabdimsTests)
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})
 endforeach()

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -69,6 +69,8 @@ std::shared_ptr<const Opm::Deck> createSingleRecordDeck() {
 BOOST_AUTO_TEST_CASE( CreateTables ) {
     std::shared_ptr<const Opm::Deck> deck = createSingleRecordDeck();
     Opm::Tables tables(*deck);
+    auto tabdims = tables.getTabdims();
+    BOOST_CHECK_EQUAL( tabdims->getNumSatTables() , 2 );
 }
 
 /*****************************************************************/

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -1,0 +1,1078 @@
+/*
+  Copyright (C) 2013 by Andreas Lauser
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE SingleRecordTableTests
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseMode.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+// generic table classes
+#include <opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/FullTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Tables.hpp>
+
+// keyword specific table classes
+#include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <boost/filesystem.hpp>
+
+#include <stdexcept>
+#include <iostream>
+
+
+std::shared_ptr<const Opm::Deck> createSingleRecordDeck() {
+    const char *deckData =
+        "TABDIMS\n"
+        " 2 /\n"
+        "\n"
+        "SWOF\n"
+        " 1 2 3 4\n"
+        " 5 6 7 8 /\n"
+        " 9 10 11 12 /\n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    return deck;
+}
+
+
+
+BOOST_AUTO_TEST_CASE( CreateTables ) {
+    std::shared_ptr<const Opm::Deck> deck = createSingleRecordDeck();
+    Opm::Tables tables(*deck);
+}
+
+/*****************************************************************/
+
+BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
+    const char *deckData =
+        "TABDIMS\n"
+        " 2 /\n"
+        "\n"
+        "SWOF\n"
+        " 1 2 3 4\n"
+        " 5 6 7 8 /\n"
+        " 9 10 11 12 /\n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+
+    std::vector<std::string> tooFewColumnNames{"A", "B", "C"};
+    std::vector<std::string> justRightColumnNames{"A", "B", "C", "D"};
+    std::vector<std::string> tooManyColumnNames{"A", "B", "C", "D", "E"};
+
+    BOOST_CHECK_EQUAL(Opm::SingleRecordTable::numTables(deck->getKeyword("SWOF")), 2);
+    Opm::SingleRecordTable tmpTable;
+    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+                                                   tooFewColumnNames,
+                                                   /*recordIdx=*/0,
+                                                   /*firstEntryOffset=*/0),
+                      std::runtime_error);
+    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+                                                   tooManyColumnNames,
+                                                   /*recordIdx=*/0,
+                                                   /*firstEntryOffset=*/0),
+                      std::runtime_error);
+
+    tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+                                 justRightColumnNames,
+                                 /*recordIdx=*/0,
+                                 /*firstEntryOffset=*/0);
+}
+
+BOOST_AUTO_TEST_CASE(CreateMultiTable) {
+    const char *deckData =
+        "TABDIMS\n"
+        "1 2 /\n"
+        "\n"
+        "PVTO\n"
+        " 1 2 3 4"
+        "   5 6 7/\n"
+        " 8 9 10 11 /\n"
+        "/\n"
+        "12 13 14 15\n"
+        "   16 17 18/\n"
+        "19 20 21 22/\n"
+        "/\n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+
+    std::vector<std::string> tooFewColumnNames{"A", "B", "C"};
+    std::vector<std::string> justRightColumnNames{"A", "B", "C", "D"};
+    std::vector<std::string> tooManyColumnNames{"A", "B", "C", "D", "E"};
+
+    BOOST_CHECK_EQUAL(Opm::MultiRecordTable::numTables(deck->getKeyword("PVTO")), 2);
+    // this mistake can't be detected as the MultiRecordTable takes
+    // the first $N items as the column names...
+    /*
+    BOOST_CHECK_THROW(Opm::MultiRecordTable(deck->getKeyword("PVTO"),
+                                                  tooFewColumnNames,
+                                                  0),
+                      std::runtime_error);
+    */
+    Opm::MultiRecordTable mrt;
+    BOOST_CHECK_THROW(mrt.initFORUNITTESTONLY(deck->getKeyword("PVTO"),
+                                              tooManyColumnNames,
+                                              /*tableIdx=*/0,
+                                              /*firstEntryOffset=*/0),
+                      std::runtime_error);
+
+    BOOST_CHECK_NO_THROW(mrt.initFORUNITTESTONLY(deck->getKeyword("PVTO"),
+                                                 justRightColumnNames,
+                                                 /*recordIdx=*/0,
+                                                 /*firstEntryOffset=*/0));
+}
+
+BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
+    const char *deckData =
+        "TABDIMS\n"
+        "2 /\n"
+        "\n"
+        "SWOF\n"
+        " 1 2 3 4\n"
+        " 5 6 7 8/\n"
+        "  9 10 11 12\n"
+        " 13 14 15 16\n"
+        " 17 18 19 20/\n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    Opm::DeckKeywordConstPtr swofKeyword = deck->getKeyword("SWOF");
+
+    BOOST_CHECK_EQUAL(Opm::SwofTable::numTables(swofKeyword), 2);
+
+    Opm::SwofTable swof1Table;
+    Opm::SwofTable swof2Table;
+
+    swof1Table.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*tableIdx=*/0);
+    swof2Table.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*tableIdx=*/1);
+
+    BOOST_CHECK_EQUAL(swof1Table.numRows(), 2);
+    BOOST_CHECK_EQUAL(swof2Table.numRows(), 3);
+
+    BOOST_CHECK_EQUAL(swof1Table.numColumns(), 4);
+    BOOST_CHECK_EQUAL(swof2Table.numColumns(), 4);
+
+    BOOST_CHECK_EQUAL(swof1Table.getSwColumn().front(), 1.0);
+    BOOST_CHECK_EQUAL(swof1Table.getSwColumn().back(), 5.0);
+
+    BOOST_CHECK_EQUAL(swof1Table.getKrwColumn().front(), 2.0);
+    BOOST_CHECK_EQUAL(swof1Table.getKrwColumn().back(), 6.0);
+
+    BOOST_CHECK_EQUAL(swof1Table.getKrowColumn().front(), 3.0);
+    BOOST_CHECK_EQUAL(swof1Table.getKrowColumn().back(), 7.0);
+
+    BOOST_CHECK_EQUAL(swof1Table.getPcowColumn().front(), 4.0e5);
+    BOOST_CHECK_EQUAL(swof1Table.getPcowColumn().back(), 8.0e5);
+
+    // for the second table, we only check the first column and trust
+    // that everything else is fine...
+    BOOST_CHECK_EQUAL(swof2Table.getSwColumn().front(), 9.0);
+    BOOST_CHECK_EQUAL(swof2Table.getSwColumn().back(), 17.0);
+}
+
+BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
+    const char *deckData =
+        "TABDIMS\n"
+        "2 /\n"
+        "\n"
+        "SGOF\n"
+        " 1 2 3 4\n"
+        " 5 6 7 8/\n"
+        "  9 10 11 12\n"
+        " 13 14 15 16\n"
+        " 17 18 19 20/\n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    Opm::DeckKeywordConstPtr sgofKeyword = deck->getKeyword("SGOF");
+
+    BOOST_CHECK_EQUAL(Opm::SgofTable::numTables(sgofKeyword), 2);
+
+    Opm::SgofTable sgof1Table;
+    Opm::SgofTable sgof2Table;
+
+    sgof1Table.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*tableIdx=*/0);
+    sgof2Table.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*tableIdx=*/1);
+
+    BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2);
+    BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3);
+
+    BOOST_CHECK_EQUAL(sgof1Table.numColumns(), 4);
+    BOOST_CHECK_EQUAL(sgof2Table.numColumns(), 4);
+
+    BOOST_CHECK_EQUAL(sgof1Table.getSgColumn().front(), 1.0);
+    BOOST_CHECK_EQUAL(sgof1Table.getSgColumn().back(), 5.0);
+
+    BOOST_CHECK_EQUAL(sgof1Table.getKrgColumn().front(), 2.0);
+    BOOST_CHECK_EQUAL(sgof1Table.getKrgColumn().back(), 6.0);
+
+    BOOST_CHECK_EQUAL(sgof1Table.getKrogColumn().front(), 3.0);
+    BOOST_CHECK_EQUAL(sgof1Table.getKrogColumn().back(), 7.0);
+
+    BOOST_CHECK_EQUAL(sgof1Table.getPcogColumn().front(), 4.0e5);
+    BOOST_CHECK_EQUAL(sgof1Table.getPcogColumn().back(), 8.0e5);
+
+    // for the second table, we only check the first column and trust
+    // that everything else is fine...
+    BOOST_CHECK_EQUAL(sgof2Table.getSgColumn().front(), 9.0);
+    BOOST_CHECK_EQUAL(sgof2Table.getSgColumn().back(), 17.0);
+}
+
+BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
+    {
+        const char *correctDeckData =
+            "TABDIMS\n"
+            "/\n"
+            "PLYADS\n"
+            "0.00    0.0 \n"
+            "0.25    0.000010\n"
+            "0.50    0.000018\n"
+            "0.75    0.000023\n"
+            "1.00    0.000027\n"
+            "1.25    0.000030\n"
+            "1.50    0.000030\n"
+            "1.75    0.000030\n"
+            "2.00    0.000030\n"
+            "3.00    0.000030 /\n";
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(correctDeckData, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr plyadsKeyword = deck->getKeyword("PLYADS");
+
+        BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
+
+        Opm::PlyadsTable plyadsTable;
+        plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0);
+
+        BOOST_CHECK_CLOSE(plyadsTable.getPolymerConcentrationColumn().front(), 0.0, 1e-6);
+        BOOST_CHECK_CLOSE(plyadsTable.getPolymerConcentrationColumn().back(), 3.0, 1e-6);
+
+        BOOST_CHECK_CLOSE(plyadsTable.getAdsorbedPolymerColumn().front(), 0.0, 1e-6);
+        BOOST_CHECK_CLOSE(plyadsTable.getAdsorbedPolymerColumn().back(), 0.000030, 1e-6);
+    }
+
+    {
+        // first column not strictly monotonic
+        const char *incorrectDeckData =
+            "TABDIMS\n"
+            "/\n"
+            "PLYADS\n"
+            "0.00    0.0 \n"
+            "0.00    0.000010\n"
+            "0.50    0.000018\n"
+            "0.75    0.000023\n"
+            "1.00    0.000027\n"
+            "1.25    0.000030\n"
+            "1.50    0.000030\n"
+            "1.75    0.000030\n"
+            "2.00    0.000030\n"
+            "3.00    0.000030 /\n";
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(incorrectDeckData, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr plyadsKeyword = deck->getKeyword("PLYADS");
+
+        BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
+
+        Opm::PlyadsTable plyadsTable;
+        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0), std::invalid_argument);
+    }
+
+    {
+        // second column not monotonic
+        const char *incorrectDeckData =
+            "TABDIMS\n"
+            "/\n"
+            "PLYADS\n"
+            "0.00    0.0 \n"
+            "0.25    0.000010\n"
+            "0.50    0.000018\n"
+            "0.75    0.000023\n"
+            "1.00    0.000027\n"
+            "1.25    0.000030\n"
+            "1.50    0.000030\n"
+            "1.75    0.000030\n"
+            "2.00    0.000030\n"
+            "3.00    0.000029 /\n";
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(incorrectDeckData, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr plyadsKeyword = deck->getKeyword("PLYADS");
+
+        BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
+
+        Opm::PlyadsTable plyadsTable;
+        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0), std::invalid_argument);
+    }
+}
+
+BOOST_AUTO_TEST_CASE(PvtoTable_Tests) {
+    const char *deckData =
+        "TABDIMS\n"
+        "1 2 /\n"
+        "\n"
+        "PVTO\n"
+        " 1 2 3 4"
+        "   5 6 7/\n"
+        " 8 9 10 11 /\n"
+        "/\n"
+        "12 13 14 15\n"
+        "   16 17 18/\n"
+        "19 20 21 22/\n"
+        "23 24 25 26/\n"
+        "/\n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    Opm::DeckKeywordConstPtr pvtoKeyword = deck->getKeyword("PVTO");
+
+    BOOST_CHECK_EQUAL(Opm::PvtoTable::numTables(pvtoKeyword), 2);
+
+    Opm::PvtoTable pvto1Table;
+    Opm::PvtoTable pvto2Table;
+
+    pvto1Table.initFORUNITTESTONLY(deck->getKeyword("PVTO"), /*tableIdx=*/0);
+    pvto2Table.initFORUNITTESTONLY(deck->getKeyword("PVTO"), /*tableIdx=*/1);
+
+    const auto pvto1OuterTable = pvto1Table.getOuterTable();
+    const auto pvto2OuterTable = pvto2Table.getOuterTable();
+
+    BOOST_CHECK_EQUAL(pvto1OuterTable->numRows(), 2);
+    BOOST_CHECK_EQUAL(pvto2OuterTable->numRows(), 3);
+
+    BOOST_CHECK_EQUAL(pvto1OuterTable->numColumns(), 4);
+    BOOST_CHECK_EQUAL(pvto2OuterTable->numColumns(), 4);
+
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getGasSolubilityColumn().front(), 1.0);
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getGasSolubilityColumn().back(), 8.0);
+
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getPressureColumn().front(), 2.0e5);
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getPressureColumn().back(), 9.0e5);
+
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getOilFormationFactorColumn().front(), 3.0);
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getOilFormationFactorColumn().back(), 10.0);
+
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getOilViscosityColumn().front(), 4.0e-3);
+    BOOST_CHECK_EQUAL(pvto1OuterTable->getOilViscosityColumn().back(), 11.0e-3);
+
+    // for the second table, we only check the first column and trust
+    // that everything else is fine...
+    BOOST_CHECK_EQUAL(pvto2OuterTable->getGasSolubilityColumn().front(), 12.0);
+    BOOST_CHECK_EQUAL(pvto2OuterTable->getGasSolubilityColumn().back(), 23.0);
+}
+
+
+/**
+ * Tests "happy path" for a VFPPROD table, i.e., when everything goes well
+ */
+BOOST_AUTO_TEST_CASE(VFPProdTable_happy_Test) {
+    const char *deckData = "\
+VFPPROD \n\
+-- Table Depth  Rate   WFR   GFR   TAB ALQ    UNITS  BODY    \n\
+-- ----- ----- ----- ----- ----- ----- --- -------- -----    \n\
+      5  32.9  'LIQ' 'WCT' 'GOR' 'THP' ' ' 'METRIC' 'BHP'  / \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+7 11 /       \n\
+-- WFR axis  \n\
+13 17 /      \n\
+-- GFR axis  \n\
+19 23 /      \n\
+-- ALQ axis  \n\
+29 31 /      \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+1 1 1 1 1.5 2.5 3.5 /    \n\
+2 1 1 1 4.5 5.5 6.5 /    \n\
+1 2 1 1 7.5 8.5 9.5 /    \n\
+2 2 1 1 10.5 11.5 12.5 / \n\
+1 1 2 1 13.5 14.5 15.5 / \n\
+2 1 2 1 16.5 17.5 18.5 / \n\
+1 2 2 1 19.5 20.5 21.5 / \n\
+2 2 2 1 22.5 23.5 24.5 / \n\
+1 1 1 2 25.5 26.5 27.5 / \n\
+2 1 1 2 28.5 29.5 30.5 / \n\
+1 2 1 2 31.5 32.5 33.5 / \n\
+2 2 1 2 34.5 35.5 36.5 / \n\
+1 1 2 2 37.5 38.5 39.5 / \n\
+2 1 2 2 40.5 41.5 42.5 / \n\
+1 2 2 2 43.5 44.5 45.5 / \n\
+2 2 2 2 46.5 47.5 48.5 / \n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+    std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+
+    BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+    Opm::VFPProdTable vfpprodTable;
+
+    vfpprodTable.init(vfpprodKeyword, units);
+
+    BOOST_CHECK_EQUAL(vfpprodTable.getTableNum(), 5);
+    BOOST_CHECK_EQUAL(vfpprodTable.getDatumDepth(), 32.9);
+    BOOST_CHECK_EQUAL(vfpprodTable.getFloType(), Opm::VFPProdTable::FLO_LIQ);
+    BOOST_CHECK_EQUAL(vfpprodTable.getWFRType(), Opm::VFPProdTable::WFR_WCT);
+    BOOST_CHECK_EQUAL(vfpprodTable.getGFRType(), Opm::VFPProdTable::GFR_GOR);
+    BOOST_CHECK_EQUAL(vfpprodTable.getALQType(), Opm::VFPProdTable::ALQ_UNDEF);
+
+    //Flo axis
+    {
+        const std::vector<double>& flo = vfpprodTable.getFloAxis();
+        BOOST_REQUIRE_EQUAL(flo.size(), 3);
+
+        //Unit of FLO is SM3/day, convert to SM3/second
+        double conversion_factor = 1.0 / (60*60*24);
+        BOOST_CHECK_EQUAL(flo[0], 1*conversion_factor);
+        BOOST_CHECK_EQUAL(flo[1], 3*conversion_factor);
+        BOOST_CHECK_EQUAL(flo[2], 5*conversion_factor);
+    }
+
+    //THP axis
+    {
+        const std::vector<double>& thp = vfpprodTable.getTHPAxis();
+        BOOST_REQUIRE_EQUAL(thp.size(), 2);
+
+        //Unit of THP is barsa => convert to pascal
+        double conversion_factor = 100000.0;
+        BOOST_CHECK_EQUAL(thp[0], 7*conversion_factor);
+        BOOST_CHECK_EQUAL(thp[1], 11*conversion_factor);
+    }
+
+    //WFR axis
+    {
+        const std::vector<double>& wfr = vfpprodTable.getWFRAxis();
+        BOOST_REQUIRE_EQUAL(wfr.size(), 2);
+
+        //Unit of WFR is SM3/SM3
+        BOOST_CHECK_EQUAL(wfr[0], 13);
+        BOOST_CHECK_EQUAL(wfr[1], 17);
+    }
+
+    //GFR axis
+    {
+        const std::vector<double>& gfr = vfpprodTable.getGFRAxis();
+        BOOST_REQUIRE_EQUAL(gfr.size(), 2);
+
+        //Unit of GFR is SM3/SM3
+        BOOST_CHECK_EQUAL(gfr[0], 19);
+        BOOST_CHECK_EQUAL(gfr[1], 23);
+    }
+
+    //ALQ axis
+    {
+        const std::vector<double>& alq = vfpprodTable.getALQAxis();
+        BOOST_REQUIRE_EQUAL(alq.size(), 2);
+
+        //Unit of ALQ undefined
+        BOOST_CHECK_EQUAL(alq[0], 29);
+        BOOST_CHECK_EQUAL(alq[1], 31);
+    }
+
+    //The data itself
+    {
+        typedef Opm::VFPProdTable::array_type::size_type size_type;
+        const Opm::VFPProdTable::array_type& data = vfpprodTable.getTable();
+        const size_type* size = data.shape();
+
+        BOOST_CHECK_EQUAL(size[0], 2);
+        BOOST_CHECK_EQUAL(size[1], 2);
+        BOOST_CHECK_EQUAL(size[2], 2);
+        BOOST_CHECK_EQUAL(size[3], 2);
+        BOOST_CHECK_EQUAL(size[4], 3);
+
+        //Table given as BHP => barsa. Convert to pascal
+        double conversion_factor = 100000.0;
+
+        double index = 0.5;
+        for (size_type a=0; a<size[3]; ++a) {
+            for (size_type g=0; g<size[2]; ++g) {
+                for (size_type w=0; w<size[1]; ++w) {
+                    for (size_type t=0; t<size[0]; ++t) {
+                        for (size_type f=0; f<size[4]; ++f) {
+                            index += 1.0;
+                            BOOST_CHECK_EQUAL(data[t][w][g][a][f], index*conversion_factor);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+
+/**
+ * Checks that the VFPPROD table will succeed with a minimal set of
+ * specified values.
+ */
+BOOST_AUTO_TEST_CASE(VFPProdTable_minimal_Test) {
+    const char *deckData = "\
+VFPPROD \n\
+-- Table Depth  Rate   WFR   GFR      \n\
+-- ----- ----- ----- ----- -----      \n\
+      5  32.9  'LIQ' 'WCT' 'GOR'    / \n\
+-- Rate axis \n\
+1 /          \n\
+-- THP axis  \n\
+7 /          \n\
+-- WFR axis  \n\
+13 /         \n\
+-- GFR axis  \n\
+19 /         \n\
+-- ALQ axis  \n\
+29 /         \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+1 1 1 1 1.5 /    \n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+    std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+
+    BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+    Opm::VFPProdTable vfpprodTable;
+
+    vfpprodTable.init(vfpprodKeyword, units);
+
+    BOOST_CHECK_EQUAL(vfpprodTable.getTableNum(), 5);
+    BOOST_CHECK_EQUAL(vfpprodTable.getDatumDepth(), 32.9);
+    BOOST_CHECK_EQUAL(vfpprodTable.getFloType(), Opm::VFPProdTable::FLO_LIQ);
+    BOOST_CHECK_EQUAL(vfpprodTable.getWFRType(), Opm::VFPProdTable::WFR_WCT);
+    BOOST_CHECK_EQUAL(vfpprodTable.getGFRType(), Opm::VFPProdTable::GFR_GOR);
+    BOOST_CHECK_EQUAL(vfpprodTable.getALQType(), Opm::VFPProdTable::ALQ_UNDEF);
+
+    //Flo axis
+    {
+        const std::vector<double>& flo = vfpprodTable.getFloAxis();
+        BOOST_REQUIRE_EQUAL(flo.size(), 1);
+
+        //Unit of FLO is SM3/day, convert to SM3/second
+        double conversion_factor = 1.0 / (60*60*24);
+        BOOST_CHECK_EQUAL(flo[0], 1*conversion_factor);
+    }
+
+    //THP axis
+    {
+        const std::vector<double>& thp = vfpprodTable.getTHPAxis();
+        BOOST_REQUIRE_EQUAL(thp.size(), 1);
+
+        //Unit of THP is barsa => convert to pascal
+        double conversion_factor = 100000.0;
+        BOOST_CHECK_EQUAL(thp[0], 7*conversion_factor);
+    }
+
+    //WFR axis
+    {
+        const std::vector<double>& wfr = vfpprodTable.getWFRAxis();
+        BOOST_REQUIRE_EQUAL(wfr.size(), 1);
+
+        //Unit of WFR is SM3/SM3
+        BOOST_CHECK_EQUAL(wfr[0], 13);
+    }
+
+    //GFR axis
+    {
+        const std::vector<double>& gfr = vfpprodTable.getGFRAxis();
+        BOOST_REQUIRE_EQUAL(gfr.size(), 1);
+
+        //Unit of GFR is SM3/SM3
+        BOOST_CHECK_EQUAL(gfr[0], 19);
+    }
+
+    //ALQ axis
+    {
+        const std::vector<double>& alq = vfpprodTable.getALQAxis();
+        BOOST_REQUIRE_EQUAL(alq.size(), 1);
+
+        //Unit of ALQ undefined
+        BOOST_CHECK_EQUAL(alq[0], 29);
+    }
+
+    //The data itself
+    {
+        typedef Opm::VFPProdTable::array_type::size_type size_type;
+        const Opm::VFPProdTable::array_type& data = vfpprodTable.getTable();
+        const size_type* size = data.shape();
+
+        //Table given as BHP => barsa. Convert to pascal
+        double conversion_factor = 100000.0;
+
+        BOOST_CHECK_EQUAL(size[0]*size[1]*size[2]*size[3]*size[4], 1);
+        BOOST_CHECK_EQUAL(data[0][0][0][0][0], 1.5*conversion_factor);
+    }
+}
+
+
+
+
+
+
+
+/**
+ * Spot checks that the VFPPROD table will fail nicely when given invalid data
+ */
+BOOST_AUTO_TEST_CASE(VFPProdTable_sad_Test) {
+    /**
+     * Missing value in table
+     */
+    {
+        const char *missing_values = "\
+VFPPROD \n\
+-- Table Depth  Rate   WFR   GFR      \n\
+-- ----- ----- ----- ----- -----      \n\
+      5  32.9  'LIQ' 'WCT' 'GOR'    / \n\
+-- Rate axis \n\
+1 2 /        \n\
+-- THP axis  \n\
+7 /          \n\
+-- WFR axis  \n\
+13 /         \n\
+-- GFR axis  \n\
+19 /         \n\
+-- ALQ axis  \n\
+29 /         \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+-- Will fail, as rate axis requires two elements            \n\
+1 1 1 1 1.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpprodKeyword, units), std::invalid_argument);
+    }
+
+
+
+    /**
+     * Missing value in table #2
+     */
+    {
+        const char *missing_values = "\
+VFPPROD \n\
+-- Table Depth  Rate   WFR   GFR      \n\
+-- ----- ----- ----- ----- -----      \n\
+      5  32.9  'LIQ' 'WCT' 'GOR'    / \n\
+-- Rate axis \n\
+1 /          \n\
+-- THP axis  \n\
+7 9 /        \n\
+-- WFR axis  \n\
+13 /         \n\
+-- GFR axis  \n\
+19 /         \n\
+-- ALQ axis  \n\
+29 /         \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+-- Will fail, as two entries are required                   \n\
+1 1 1 1 1.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpprodKeyword, units), std::invalid_argument);
+    }
+
+
+    /**
+     * Missing items in header
+     */
+    {
+        const char *missing_metadata = "\
+VFPPROD \n\
+-- Table Depth   \n\
+-- ----- -----   \n\
+      5  32.9  / \n\
+-- Rate axis \n\
+1 2 /        \n\
+-- THP axis  \n\
+7 /          \n\
+-- WFR axis  \n\
+13 /         \n\
+-- GFR axis  \n\
+19 /         \n\
+-- ALQ axis  \n\
+29 /         \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+1 1 1 1 1.5 2.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_metadata, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpprodKeyword, units), std::out_of_range);
+    }
+
+
+
+    /**
+     * Wrong items in header
+     */
+    {
+        const char *wrong_metadata = "\
+VFPPROD \n\
+-- Table Depth   \n\
+-- ----- -----   \n\
+      5  32.9  'WCT' 'LIC' 'GARBAGE'    / \n\
+-- Rate axis \n\
+1 2 /        \n\
+-- THP axis  \n\
+7 /          \n\
+-- WFR axis  \n\
+13 /         \n\
+-- GFR axis  \n\
+19 /         \n\
+-- ALQ axis  \n\
+29 /         \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+1 1 1 1 1.5 2.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(wrong_metadata, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpprodKeyword, units), std::invalid_argument);
+    }
+
+
+
+    /**
+     * Wrong axes in header
+     */
+    {
+        const char *missing_axes = "\
+VFPPROD \n\
+-- Table Depth   \n\
+-- ----- -----   \n\
+      5  32.9  'LIC' 'WCT' 'OGR'    / \n\
+-- Rate axis \n\
+1 2 /        \n\
+-- THP axis  \n\
+7 /          \n\
+-- WFR axis  \n\
+13 /         \n\
+-- GFR axis  \n\
+19 /         \n\
+-- ALQ axis  \n\
+-- Missing!  \n\
+-- Table data with THP# WFR# GFR# ALQ# <values 1-num_rates> \n\
+1 1 1 1 1.5 2.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_axes, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPPROD");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPPROD"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpprodKeyword, units), std::invalid_argument);
+    }
+}
+
+
+
+
+
+/**
+ * Tests "happy path" for a VFPPROD table, i.e., when everything goes well
+ */
+BOOST_AUTO_TEST_CASE(VFPInjTable_happy_Test) {
+    const char *deckData = "\
+VFPINJ \n\
+-- Table Depth  Rate   TAB  UNITS  BODY    \n\
+-- ----- ----- ----- ----- ------ -----    \n\
+       5  32.9   WAT   THP METRIC   BHP /  \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+7 11 /       \n\
+-- Table data with THP# <values 1-num_rates> \n\
+1 1.5 2.5 3.5 /    \n\
+2 4.5 5.5 6.5 /    \n";
+
+    Opm::ParserPtr parser(new Opm::Parser);
+    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseMode()));
+    Opm::DeckKeywordConstPtr vfpprodKeyword = deck->getKeyword("VFPINJ");
+    std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+
+    BOOST_CHECK_EQUAL(deck->numKeywords("VFPINJ"), 1);
+
+    Opm::VFPInjTable vfpinjTable;
+
+    vfpinjTable.init(vfpprodKeyword, units);
+
+    BOOST_CHECK_EQUAL(vfpinjTable.getTableNum(), 5);
+    BOOST_CHECK_EQUAL(vfpinjTable.getDatumDepth(), 32.9);
+    BOOST_CHECK_EQUAL(vfpinjTable.getFloType(), Opm::VFPInjTable::FLO_WAT);
+
+    //Flo axis
+    {
+        const std::vector<double>& flo = vfpinjTable.getFloAxis();
+        BOOST_REQUIRE_EQUAL(flo.size(), 3);
+
+        //Unit of FLO is SM3/day, convert to SM3/second
+        double conversion_factor = 1.0 / (60*60*24);
+        BOOST_CHECK_EQUAL(flo[0], 1*conversion_factor);
+        BOOST_CHECK_EQUAL(flo[1], 3*conversion_factor);
+        BOOST_CHECK_EQUAL(flo[2], 5*conversion_factor);
+    }
+
+    //THP axis
+    {
+        const std::vector<double>& thp = vfpinjTable.getTHPAxis();
+        BOOST_REQUIRE_EQUAL(thp.size(), 2);
+
+        //Unit of THP is barsa => convert to pascal
+        double conversion_factor = 100000.0;
+        BOOST_CHECK_EQUAL(thp[0], 7*conversion_factor);
+        BOOST_CHECK_EQUAL(thp[1], 11*conversion_factor);
+    }
+
+    //The data itself
+    {
+        typedef Opm::VFPInjTable::array_type::size_type size_type;
+        const Opm::VFPInjTable::array_type& data = vfpinjTable.getTable();
+        const size_type* size = data.shape();
+
+        BOOST_CHECK_EQUAL(size[0], 2);
+        BOOST_CHECK_EQUAL(size[1], 3);
+
+        //Table given as BHP => barsa. Convert to pascal
+        double conversion_factor = 100000.0;
+
+        double index = 0.5;
+        for (size_type t=0; t<size[0]; ++t) {
+            for (size_type f=0; f<size[1]; ++f) {
+                index += 1.0;
+                BOOST_CHECK_EQUAL(data[t][f], index*conversion_factor);
+            }
+        }
+    }
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+/**
+ * Spot checks that the VFPPROD table will fail nicely when given invalid data
+ */
+BOOST_AUTO_TEST_CASE(VFPInjTable_sad_Test) {
+    /**
+     * Missing value in table
+     */
+    {
+        const char *missing_values = "\
+VFPINJ \n\
+-- Table Depth  Rate   TAB  UNITS  BODY    \n\
+-- ----- ----- ----- ----- ------ -----    \n\
+       5  32.9   WAT   THP METRIC   BHP /  \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+7 11 /       \n\
+-- Table data with THP# <values 1-num_rates> \n\
+-- Will fail, as rate axis requires three elements  \n\
+1 1.5 2.5 /    \n\
+2 4.5 5.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpinjKeyword = deck->getKeyword("VFPINJ");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPINJ"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpinjKeyword, units), std::invalid_argument);
+    }
+
+
+
+    /**
+     * Missing value in table #2
+     */
+    {
+        const char *missing_values = "\
+VFPINJ \n\
+-- Table Depth  Rate   TAB  UNITS  BODY    \n\
+-- ----- ----- ----- ----- ------ -----    \n\
+       5  32.9   WAT   THP METRIC   BHP /  \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+7 11 /       \n\
+-- Table data with THP# <values 1-num_rates> \n\
+-- Will fail, as two entries are required                   \n\
+1 1.5 2.5 3.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpinjKeyword = deck->getKeyword("VFPINJ");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPINJ"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpinjKeyword, units), std::invalid_argument);
+    }
+
+
+    /**
+     * Missing items in header
+     */
+    {
+        const char *missing_metadata = "\
+VFPINJ \n\
+-- Table Depth      \n\
+-- ----- -----      \n\
+       5  32.9   /  \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+7 11 /       \n\
+-- Table data with THP# <values 1-num_rates> \n\
+1 1.5 2.5 3.5 /    \n\
+2 4.5 5.5 6.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_metadata, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpinjKeyword = deck->getKeyword("VFPINJ");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPINJ"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpinjKeyword, units), std::invalid_argument);
+    }
+
+
+
+    /**
+     * Wrong items in header
+     */
+    {
+        const char *wrong_metadata = "\
+VFPINJ \n\
+-- Table Depth  Rate   TAB  UNITS  BODY    \n\
+-- ----- ----- ----- ----- ------ -----    \n\
+       5  32.9   GOR   BHP    FOO  GAGA /  \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+7 11 /       \n\
+-- Table data with THP# <values 1-num_rates> \n\
+1 1.5 2.5 3.5 /    \n\
+2 4.5 5.5 6.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(wrong_metadata, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpinjKeyword = deck->getKeyword("VFPINJ");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPINJ"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpinjKeyword, units), std::invalid_argument);
+    }
+
+
+
+    /**
+     * Wrong axes in header
+     */
+    {
+        const char *missing_axes = "\
+VFPINJ \n\
+-- Table Depth  Rate   TAB  UNITS  BODY    \n\
+-- ----- ----- ----- ----- ------ -----    \n\
+       5  32.9   WAT   THP METRIC   BHP /  \n\
+-- Rate axis \n\
+1 3 5 /      \n\
+-- THP axis  \n\
+-- Missing!  \n\
+-- Table data with THP# <values 1-num_rates> \n\
+1 1.5 2.5 3.5 /    \n\
+2 4.5 5.5 6.5 /    \n";
+
+        Opm::ParserPtr parser(new Opm::Parser);
+        Opm::DeckConstPtr deck(parser->parseString(missing_axes, Opm::ParseMode()));
+        Opm::DeckKeywordConstPtr vfpinjKeyword = deck->getKeyword("VFPINJ");
+        std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
+        BOOST_CHECK_EQUAL(deck->numKeywords("VFPINJ"), 1);
+
+        Opm::VFPProdTable vfpprodTable;
+
+        BOOST_CHECK_THROW(vfpprodTable.init(vfpinjKeyword, units), std::invalid_argument);
+    }
+}
+
+
+
+
+
+
+


### PR DESCRIPTION
In this PR a simple class `Tables` is created, and all the tables in the `EclipseState` class are moved to the `Tables` class. The purpose of this is:

1. To be able to instantiate tables without instantiating a full EclipseState object.
2. A preparation for some refactoring of the table code.
3. Simplify the `EclipseState <-> Tables <-> GridProperties` dependency triangle.

The current PR *only* moves the table classes from `EclipseState` to `Tables` and does not yet address 2) or 3) above. In addition `std::shared_ptr<const Deck>` has been replaced with `const Deck&`.

Followup PR's to downstream modules are in the works. @andlaus: please guide me if you want PR's targetting one of your branches in opm-core/opm-material.