### PR TITLE
OPM-222: Fixed error in completionorder enum conversion method

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -102,11 +102,11 @@ namespace Opm {
 
         const std::string CompletionOrderEnum2String( CompletionOrderEnum enumValue ) {
             switch( enumValue ) {
-            case OPEN:
+            case DEPTH:
                 return "DEPTH";
-            case AUTO:
+            case INPUT:
                 return "INPUT";
-            case SHUT:
+            case TRACK:
                 return "TRACK";
             default:
                 throw std::invalid_argument("Unhandled enum value");


### PR DESCRIPTION
Unfortunately checked in error in (not yet used) enum conversion method. Now fixed.
