### PR TITLE
Minor table refactor

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -100,7 +100,7 @@ EclipseState/Schedule/GroupTree.cpp
 EclipseState/Schedule/Tuning.cpp
 EclipseState/Schedule/Events.cpp
 #
-EclipseState/Tables/SingleRecordTable.cpp
+EclipseState/Tables/SimpleTable.cpp
 EclipseState/Tables/MultiRecordTable.cpp
 EclipseState/Tables/VFPProdTable.cpp
 EclipseState/Tables/VFPInjTable.cpp
@@ -225,7 +225,7 @@ EclipseState/Tables/PvdoTable.hpp
 EclipseState/Tables/MultiRecordTable.hpp
 EclipseState/Tables/PvdgTable.hpp
 EclipseState/Tables/PvdsTable.hpp
-EclipseState/Tables/SingleRecordTable.hpp
+EclipseState/Tables/SimpleTable.hpp
 EclipseState/Tables/PlymaxTable.hpp
 EclipseState/Tables/PvtgTable.hpp
 EclipseState/Tables/PlyrockTable.hpp

--- a/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_ENKRVD_TABLE_HPP
 #define	OPM_PARSER_ENKRVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class EnkrvdTable : protected SingleRecordTable {
+    class EnkrvdTable : protected SimpleTable {
 
 
         friend class TableManager;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "KRWMAX",
                                      "KRGMAX",
@@ -48,74 +48,74 @@ namespace Opm {
                                      "KROCRITW" },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("DEPTH");
-            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("KRWMAX");
-            SingleRecordTable::applyDefaultsLinear("KRGMAX");
-            SingleRecordTable::applyDefaultsLinear("KROMAX");
-            SingleRecordTable::applyDefaultsLinear("KRWCRIT");
-            SingleRecordTable::applyDefaultsLinear("KRGCRIT");
-            SingleRecordTable::applyDefaultsLinear("KROCRITG");
-            SingleRecordTable::applyDefaultsLinear("KROCRITW");
+            SimpleTable::checkNonDefaultable("DEPTH");
+            SimpleTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("KRWMAX");
+            SimpleTable::applyDefaultsLinear("KRGMAX");
+            SimpleTable::applyDefaultsLinear("KROMAX");
+            SimpleTable::applyDefaultsLinear("KRWCRIT");
+            SimpleTable::applyDefaultsLinear("KRGCRIT");
+            SimpleTable::applyDefaultsLinear("KROCRITG");
+            SimpleTable::applyDefaultsLinear("KROCRITW");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         // using this method is strongly discouraged but the current endpoint scaling
         // code makes it hard to avoid
-        using SingleRecordTable::getColumn;
+        using SimpleTable::getColumn;
 
         /*!
          * \brief The datum depth for the remaining columns
          */
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         /*!
          * \brief Maximum relative permeability of water
          */
         const std::vector<double> &getKrwmaxColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         /*!
          * \brief Maximum relative permeability of gas
          */
         const std::vector<double> &getKrgmaxColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         /*!
          * \brief Maximum relative permeability of oil
          */
         const std::vector<double> &getKromaxColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
 
         /*!
          * \brief Relative permeability of water at the critical oil (or gas) saturation
          */
         const std::vector<double> &getKrwcritColumn() const
-        { return SingleRecordTable::getColumn(4); }
+        { return SimpleTable::getColumn(4); }
 
         /*!
          * \brief Relative permeability of gas at the critical oil (or water) saturation
          */
         const std::vector<double> &getKrgcritColumn() const
-        { return SingleRecordTable::getColumn(5); }
+        { return SimpleTable::getColumn(5); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical gas saturation
          */
         const std::vector<double> &getKrocritgColumn() const
-        { return SingleRecordTable::getColumn(6); }
+        { return SimpleTable::getColumn(6); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical water saturation
          */
         const std::vector<double> &getKrocritwColumn() const
-        { return SingleRecordTable::getColumn(7); }
+        { return SimpleTable::getColumn(7); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class EnkrvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         EnkrvdTable() = default;
@@ -38,7 +38,7 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"DEPTH",
                                      "KRWMAX",
                                      "KRGMAX",
@@ -50,74 +50,74 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("DEPTH");
-            ParentType::checkMonotonic("DEPTH", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("KRWMAX");
-            ParentType::applyDefaultsLinear("KRGMAX");
-            ParentType::applyDefaultsLinear("KROMAX");
-            ParentType::applyDefaultsLinear("KRWCRIT");
-            ParentType::applyDefaultsLinear("KRGCRIT");
-            ParentType::applyDefaultsLinear("KROCRITG");
-            ParentType::applyDefaultsLinear("KROCRITW");
+            SingleRecordTable::checkNonDefaultable("DEPTH");
+            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("KRWMAX");
+            SingleRecordTable::applyDefaultsLinear("KRGMAX");
+            SingleRecordTable::applyDefaultsLinear("KROMAX");
+            SingleRecordTable::applyDefaultsLinear("KRWCRIT");
+            SingleRecordTable::applyDefaultsLinear("KRGCRIT");
+            SingleRecordTable::applyDefaultsLinear("KROCRITG");
+            SingleRecordTable::applyDefaultsLinear("KROCRITW");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         // using this method is strongly discouraged but the current endpoint scaling
         // code makes it hard to avoid
-        using ParentType::getColumn;
+        using SingleRecordTable::getColumn;
 
         /*!
          * \brief The datum depth for the remaining columns
          */
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         /*!
          * \brief Maximum relative permeability of water
          */
         const std::vector<double> &getKrwmaxColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         /*!
          * \brief Maximum relative permeability of gas
          */
         const std::vector<double> &getKrgmaxColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         /*!
          * \brief Maximum relative permeability of oil
          */
         const std::vector<double> &getKromaxColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
 
         /*!
          * \brief Relative permeability of water at the critical oil (or gas) saturation
          */
         const std::vector<double> &getKrwcritColumn() const
-        { return ParentType::getColumn(4); }
+        { return SingleRecordTable::getColumn(4); }
 
         /*!
          * \brief Relative permeability of gas at the critical oil (or water) saturation
          */
         const std::vector<double> &getKrgcritColumn() const
-        { return ParentType::getColumn(5); }
+        { return SingleRecordTable::getColumn(5); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical gas saturation
          */
         const std::vector<double> &getKrocritgColumn() const
-        { return ParentType::getColumn(6); }
+        { return SingleRecordTable::getColumn(6); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical water saturation
          */
         const std::vector<double> &getKrocritwColumn() const
-        { return ParentType::getColumn(7); }
+        { return SingleRecordTable::getColumn(7); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class EnkrvdTable : protected SingleRecordTable {
-        
+
 
         friend class TableManager;
         EnkrvdTable() = default;
@@ -35,10 +35,9 @@ namespace Opm {
          * \brief Read the ENKRVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "KRWMAX",
                                      "KRGMAX",
@@ -47,7 +46,6 @@ namespace Opm {
                                      "KRGCRIT",
                                      "KROCRITG",
                                      "KROCRITW" },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("DEPTH");

--- a/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class EnptvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         EnptvdTable() = default;
@@ -38,7 +38,7 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"DEPTH",
                                      "SWCO",
                                      "SWCRIT",
@@ -51,78 +51,78 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("DEPTH");
-            ParentType::checkMonotonic("DEPTH", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("SWCO");
-            ParentType::applyDefaultsLinear("SWCRIT");
-            ParentType::applyDefaultsLinear("SWMAX");
-            ParentType::applyDefaultsLinear("SGCO");
-            ParentType::applyDefaultsLinear("SGCRIT");
-            ParentType::applyDefaultsLinear("SGMAX");
-            ParentType::applyDefaultsLinear("SOWCRIT");
-            ParentType::applyDefaultsLinear("SOGCRIT");
+            SingleRecordTable::checkNonDefaultable("DEPTH");
+            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("SWCO");
+            SingleRecordTable::applyDefaultsLinear("SWCRIT");
+            SingleRecordTable::applyDefaultsLinear("SWMAX");
+            SingleRecordTable::applyDefaultsLinear("SGCO");
+            SingleRecordTable::applyDefaultsLinear("SGCRIT");
+            SingleRecordTable::applyDefaultsLinear("SGMAX");
+            SingleRecordTable::applyDefaultsLinear("SOWCRIT");
+            SingleRecordTable::applyDefaultsLinear("SOGCRIT");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         // using this method is strongly discouraged but the current endpoint scaling
         // code makes it hard to avoid
-        using ParentType::getColumn;
+        using SingleRecordTable::getColumn;
 
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         /*!
          * \brief Connate water saturation
          */
         const std::vector<double> &getSwcoColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         /*!
          * \brief Critical water saturation
          */
         const std::vector<double> &getSwcritColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         /*!
          * \brief Maximum water saturation
          */
         const std::vector<double> &getSwmaxColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
 
         /*!
          * \brief Connate gas saturation
          */
         const std::vector<double> &getSgcoColumn() const
-        { return ParentType::getColumn(4); }
+        { return SingleRecordTable::getColumn(4); }
 
         /*!
          * \brief Critical gas saturation
          */
         const std::vector<double> &getSgcritColumn() const
-        { return ParentType::getColumn(5); }
+        { return SingleRecordTable::getColumn(5); }
 
         /*!
          * \brief Maximum gas saturation
          */
         const std::vector<double> &getSgmaxColumn() const
-        { return ParentType::getColumn(6); }
+        { return SingleRecordTable::getColumn(6); }
 
         /*!
          * \brief Critical oil-in-water saturation
          */
         const std::vector<double> &getSowcritColumn() const
-        { return ParentType::getColumn(7); }
+        { return SingleRecordTable::getColumn(7); }
 
         /*!
          * \brief Critical oil-in-gas saturation
          */
         const std::vector<double> &getSogcritColumn() const
-        { return ParentType::getColumn(8); }
+        { return SingleRecordTable::getColumn(8); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class EnptvdTable : protected SingleRecordTable {
-        
+
 
         friend class TableManager;
         EnptvdTable() = default;
@@ -35,10 +35,9 @@ namespace Opm {
          * \brief Read the ENPTVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "SWCO",
                                      "SWCRIT",
@@ -48,7 +47,6 @@ namespace Opm {
                                      "SGMAX",
                                      "SOWCRIT",
                                      "SOGCRIT"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("DEPTH");

--- a/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_ENPTVD_TABLE_HPP
 #define	OPM_PARSER_ENPTVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class EnptvdTable : protected SingleRecordTable {
+    class EnptvdTable : protected SimpleTable {
 
 
         friend class TableManager;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "SWCO",
                                      "SWCRIT",
@@ -49,78 +49,78 @@ namespace Opm {
                                      "SOGCRIT"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("DEPTH");
-            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("SWCO");
-            SingleRecordTable::applyDefaultsLinear("SWCRIT");
-            SingleRecordTable::applyDefaultsLinear("SWMAX");
-            SingleRecordTable::applyDefaultsLinear("SGCO");
-            SingleRecordTable::applyDefaultsLinear("SGCRIT");
-            SingleRecordTable::applyDefaultsLinear("SGMAX");
-            SingleRecordTable::applyDefaultsLinear("SOWCRIT");
-            SingleRecordTable::applyDefaultsLinear("SOGCRIT");
+            SimpleTable::checkNonDefaultable("DEPTH");
+            SimpleTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("SWCO");
+            SimpleTable::applyDefaultsLinear("SWCRIT");
+            SimpleTable::applyDefaultsLinear("SWMAX");
+            SimpleTable::applyDefaultsLinear("SGCO");
+            SimpleTable::applyDefaultsLinear("SGCRIT");
+            SimpleTable::applyDefaultsLinear("SGMAX");
+            SimpleTable::applyDefaultsLinear("SOWCRIT");
+            SimpleTable::applyDefaultsLinear("SOGCRIT");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         // using this method is strongly discouraged but the current endpoint scaling
         // code makes it hard to avoid
-        using SingleRecordTable::getColumn;
+        using SimpleTable::getColumn;
 
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         /*!
          * \brief Connate water saturation
          */
         const std::vector<double> &getSwcoColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         /*!
          * \brief Critical water saturation
          */
         const std::vector<double> &getSwcritColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         /*!
          * \brief Maximum water saturation
          */
         const std::vector<double> &getSwmaxColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
 
         /*!
          * \brief Connate gas saturation
          */
         const std::vector<double> &getSgcoColumn() const
-        { return SingleRecordTable::getColumn(4); }
+        { return SimpleTable::getColumn(4); }
 
         /*!
          * \brief Critical gas saturation
          */
         const std::vector<double> &getSgcritColumn() const
-        { return SingleRecordTable::getColumn(5); }
+        { return SimpleTable::getColumn(5); }
 
         /*!
          * \brief Maximum gas saturation
          */
         const std::vector<double> &getSgmaxColumn() const
-        { return SingleRecordTable::getColumn(6); }
+        { return SimpleTable::getColumn(6); }
 
         /*!
          * \brief Critical oil-in-water saturation
          */
         const std::vector<double> &getSowcritColumn() const
-        { return SingleRecordTable::getColumn(7); }
+        { return SimpleTable::getColumn(7); }
 
         /*!
          * \brief Critical oil-in-gas saturation
          */
         const std::vector<double> &getSogcritColumn() const
-        { return SingleRecordTable::getColumn(8); }
+        { return SimpleTable::getColumn(8); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/FullTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/FullTable.hpp
@@ -20,7 +20,7 @@
 #define	OPM_PARSER_FULL_TABLE_HPP
 
 #include <opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
 #include <map>
@@ -91,8 +91,8 @@ namespace Opm {
 
     };
 
-    typedef FullTable<Opm::MultiRecordTable, Opm::SingleRecordTable>::Pointer FullTablePtr;
-    typedef FullTable<Opm::MultiRecordTable, Opm::SingleRecordTable>::ConstPointer FullTableConstPtr;
+    typedef FullTable<Opm::MultiRecordTable, Opm::SimpleTable>::Pointer FullTablePtr;
+    typedef FullTable<Opm::MultiRecordTable, Opm::SimpleTable>::ConstPointer FullTableConstPtr;
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Tables/FullTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/FullTable.hpp
@@ -61,8 +61,8 @@ namespace Opm {
 
             for (size_t rowIdx = 0; rowIdx < m_outerTable->numRecords(); ++rowIdx) {
                 InnerTable *curRow = new InnerTable;
-                curRow->init(keyword,
-                             /*recordIdx=*/m_outerTable->firstRecordIndex() + rowIdx);
+                auto record = keyword->getRecord( m_outerTable->firstRecordIndex() + rowIdx );
+                curRow->init(record);
                 m_innerTables.push_back(std::shared_ptr<const InnerTable>(curRow));
             }
         }

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_GASVISCT_TABLE_HPP
 #define	OPM_PARSER_GASVISCT_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class GasvisctTable : protected SingleRecordTable {
+    class GasvisctTable : protected SimpleTable {
 
         friend class TableManager;
         GasvisctTable() = default;
@@ -48,7 +48,7 @@ namespace Opm {
             for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
                 columnNames.push_back("Viscosity" + std::to_string(static_cast<long long>(compIdx)));
 
-            SingleRecordTable::createColumns(columnNames);
+            SimpleTable::createColumns(columnNames);
 
             // extract the actual data from the deck
             size_t numFlatItems = getNumFlatItems(deckRecord);
@@ -87,29 +87,29 @@ namespace Opm {
             // reference manual. (actually, the documentation does not say anyting about
             // whether items of these columns are defaultable or not, so we assume here
             // that they are not.)
-            SingleRecordTable::checkNonDefaultable("Temperature");
-            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("Temperature");
+            SimpleTable::checkMonotonic("Temperature", /*isAscending=*/true);
 
             for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
                 std::string columnName = "Viscosity" + std::to_string(static_cast<long long>(compIdx));
-                SingleRecordTable::checkNonDefaultable(columnName);
-                SingleRecordTable::checkMonotonic(columnName,
+                SimpleTable::checkNonDefaultable(columnName);
+                SimpleTable::checkMonotonic(columnName,
                                            /*isAscending=*/true,
                                            /*strictlyMonotonic=*/false);
             }
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getGasViscosityColumn(size_t compIdx) const
-        { return SingleRecordTable::getColumn(1 + compIdx); }
+        { return SimpleTable::getColumn(1 + compIdx); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class GasvisctTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         GasvisctTable() = default;
@@ -49,7 +49,7 @@ namespace Opm {
             for (int compIdx = 0; compIdx < numComponents; ++ compIdx)
                 columnNames.push_back("Viscosity" + std::to_string(static_cast<long long>(compIdx)));
 
-            ParentType::createColumns(columnNames);
+            SingleRecordTable::createColumns(columnNames);
 
             // extract the actual data from the deck
             Opm::DeckRecordConstPtr deckRecord =
@@ -91,29 +91,29 @@ namespace Opm {
             // reference manual. (actually, the documentation does not say anyting about
             // whether items of these columns are defaultable or not, so we assume here
             // that they are not.)
-            ParentType::checkNonDefaultable("Temperature");
-            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("Temperature");
+            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
 
             for (int compIdx = 0; compIdx < numComponents; ++compIdx) {
                 std::string columnName = "Viscosity" + std::to_string(static_cast<long long>(compIdx));
-                ParentType::checkNonDefaultable(columnName);
-                ParentType::checkMonotonic(columnName,
+                SingleRecordTable::checkNonDefaultable(columnName);
+                SingleRecordTable::checkMonotonic(columnName,
                                            /*isAscending=*/true,
                                            /*strictlyMonotonic=*/false);
             }
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getGasViscosityColumn(size_t compIdx) const
-        { return ParentType::getColumn(1 + compIdx); }
+        { return SingleRecordTable::getColumn(1 + compIdx); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class GasvisctTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         GasvisctTable() = default;
@@ -35,7 +34,7 @@ namespace Opm {
          * \brief Read the GASVISCT keyword and provide some convenience
          *        methods for it.
          */
-        void init(const Deck& deck, Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(const Deck& deck, Opm::DeckRecordConstPtr deckRecord)
         {
             int numComponents = deck.getKeyword("COMPS")->getRecord(0)->getItem(0)->getInt(0);
 
@@ -52,9 +51,6 @@ namespace Opm {
             SingleRecordTable::createColumns(columnNames);
 
             // extract the actual data from the deck
-            Opm::DeckRecordConstPtr deckRecord =
-                keyword->getRecord(recordIdx);
-
             size_t numFlatItems = getNumFlatItems(deckRecord);
             if ( numFlatItems % numColumns() != 0)
                 throw std::runtime_error("Number of columns in the data file is inconsistent "

--- a/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class ImkrvdTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         ImkrvdTable() = default;
@@ -35,10 +34,9 @@ namespace Opm {
          * \brief Read the IMKRVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "KRWMAX",
                                      "KRGMAX",
@@ -47,7 +45,6 @@ namespace Opm {
                                      "KRGCRIT",
                                      "KROCRITG",
                                      "KROCRITW" },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("DEPTH");

--- a/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_IMKRVD_TABLE_HPP
 #define	OPM_PARSER_IMKRVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class ImkrvdTable : protected SingleRecordTable {
+    class ImkrvdTable : protected SimpleTable {
 
         friend class TableManager;
         ImkrvdTable() = default;
@@ -36,7 +36,7 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "KRWMAX",
                                      "KRGMAX",
@@ -47,70 +47,70 @@ namespace Opm {
                                      "KROCRITW" },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("DEPTH");
-            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("KRWMAX");
-            SingleRecordTable::applyDefaultsLinear("KRGMAX");
-            SingleRecordTable::applyDefaultsLinear("KROMAX");
-            SingleRecordTable::applyDefaultsLinear("KRWCRIT");
-            SingleRecordTable::applyDefaultsLinear("KRGCRIT");
-            SingleRecordTable::applyDefaultsLinear("KROCRITG");
-            SingleRecordTable::applyDefaultsLinear("KROCRITW");
+            SimpleTable::checkNonDefaultable("DEPTH");
+            SimpleTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("KRWMAX");
+            SimpleTable::applyDefaultsLinear("KRGMAX");
+            SimpleTable::applyDefaultsLinear("KROMAX");
+            SimpleTable::applyDefaultsLinear("KRWCRIT");
+            SimpleTable::applyDefaultsLinear("KRGCRIT");
+            SimpleTable::applyDefaultsLinear("KROCRITG");
+            SimpleTable::applyDefaultsLinear("KROCRITW");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         /*!
          * \brief The datum depth for the remaining columns
          */
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         /*!
          * \brief Maximum relative permeability of water
          */
         const std::vector<double> &getKrwmaxColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         /*!
          * \brief Maximum relative permeability of gas
          */
         const std::vector<double> &getKrgmaxColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         /*!
          * \brief Maximum relative permeability of oil
          */
         const std::vector<double> &getKromaxColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
 
         /*!
          * \brief Relative permeability of water at the critical oil (or gas) saturation
          */
         const std::vector<double> &getKrwcritColumn() const
-        { return SingleRecordTable::getColumn(4); }
+        { return SimpleTable::getColumn(4); }
 
         /*!
          * \brief Relative permeability of gas at the critical oil (or water) saturation
          */
         const std::vector<double> &getKrgcritColumn() const
-        { return SingleRecordTable::getColumn(5); }
+        { return SimpleTable::getColumn(5); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical gas saturation
          */
         const std::vector<double> &getKrocritgColumn() const
-        { return SingleRecordTable::getColumn(6); }
+        { return SimpleTable::getColumn(6); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical water saturation
          */
         const std::vector<double> &getKrocritwColumn() const
-        { return SingleRecordTable::getColumn(7); }
+        { return SimpleTable::getColumn(7); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class ImkrvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         ImkrvdTable() = default;
@@ -38,7 +38,7 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"DEPTH",
                                      "KRWMAX",
                                      "KRGMAX",
@@ -50,70 +50,70 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("DEPTH");
-            ParentType::checkMonotonic("DEPTH", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("KRWMAX");
-            ParentType::applyDefaultsLinear("KRGMAX");
-            ParentType::applyDefaultsLinear("KROMAX");
-            ParentType::applyDefaultsLinear("KRWCRIT");
-            ParentType::applyDefaultsLinear("KRGCRIT");
-            ParentType::applyDefaultsLinear("KROCRITG");
-            ParentType::applyDefaultsLinear("KROCRITW");
+            SingleRecordTable::checkNonDefaultable("DEPTH");
+            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("KRWMAX");
+            SingleRecordTable::applyDefaultsLinear("KRGMAX");
+            SingleRecordTable::applyDefaultsLinear("KROMAX");
+            SingleRecordTable::applyDefaultsLinear("KRWCRIT");
+            SingleRecordTable::applyDefaultsLinear("KRGCRIT");
+            SingleRecordTable::applyDefaultsLinear("KROCRITG");
+            SingleRecordTable::applyDefaultsLinear("KROCRITW");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         /*!
          * \brief The datum depth for the remaining columns
          */
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         /*!
          * \brief Maximum relative permeability of water
          */
         const std::vector<double> &getKrwmaxColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         /*!
          * \brief Maximum relative permeability of gas
          */
         const std::vector<double> &getKrgmaxColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         /*!
          * \brief Maximum relative permeability of oil
          */
         const std::vector<double> &getKromaxColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
 
         /*!
          * \brief Relative permeability of water at the critical oil (or gas) saturation
          */
         const std::vector<double> &getKrwcritColumn() const
-        { return ParentType::getColumn(4); }
+        { return SingleRecordTable::getColumn(4); }
 
         /*!
          * \brief Relative permeability of gas at the critical oil (or water) saturation
          */
         const std::vector<double> &getKrgcritColumn() const
-        { return ParentType::getColumn(5); }
+        { return SingleRecordTable::getColumn(5); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical gas saturation
          */
         const std::vector<double> &getKrocritgColumn() const
-        { return ParentType::getColumn(6); }
+        { return SingleRecordTable::getColumn(6); }
 
         /*!
          * \brief Oil relative permeability of oil at the critical water saturation
          */
         const std::vector<double> &getKrocritwColumn() const
-        { return ParentType::getColumn(7); }
+        { return SingleRecordTable::getColumn(7); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_IMPTVD_TABLE_HPP
 #define	OPM_PARSER_IMPTVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class ImptvdTable : protected SingleRecordTable {
+    class ImptvdTable : protected SimpleTable {
 
 
         friend class TableManager;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "SWCO",
                                      "SWCRIT",
@@ -48,74 +48,74 @@ namespace Opm {
                                      "SOWCRIT",
                                      "SOGCRIT"},
                                     /*firstEntityOffset=*/0);
-            SingleRecordTable::checkNonDefaultable("DEPTH");
-            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("SWCO");
-            SingleRecordTable::applyDefaultsLinear("SWCRIT");
-            SingleRecordTable::applyDefaultsLinear("SWMAX");
-            SingleRecordTable::applyDefaultsLinear("SGCO");
-            SingleRecordTable::applyDefaultsLinear("SGCRIT");
-            SingleRecordTable::applyDefaultsLinear("SGMAX");
-            SingleRecordTable::applyDefaultsLinear("SOWCRIT");
-            SingleRecordTable::applyDefaultsLinear("SOGCRIT");
+            SimpleTable::checkNonDefaultable("DEPTH");
+            SimpleTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("SWCO");
+            SimpleTable::applyDefaultsLinear("SWCRIT");
+            SimpleTable::applyDefaultsLinear("SWMAX");
+            SimpleTable::applyDefaultsLinear("SGCO");
+            SimpleTable::applyDefaultsLinear("SGCRIT");
+            SimpleTable::applyDefaultsLinear("SGMAX");
+            SimpleTable::applyDefaultsLinear("SOWCRIT");
+            SimpleTable::applyDefaultsLinear("SOGCRIT");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         /*!
          * \brief Connate water saturation
          */
         const std::vector<double> &getSwcoColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         /*!
          * \brief Critical water saturation
          */
         const std::vector<double> &getSwcritColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         /*!
          * \brief Maximum water saturation
          */
         const std::vector<double> &getSwmaxColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
 
         /*!
          * \brief Connate gas saturation
          */
         const std::vector<double> &getSgcoColumn() const
-        { return SingleRecordTable::getColumn(4); }
+        { return SimpleTable::getColumn(4); }
 
         /*!
          * \brief Critical gas saturation
          */
         const std::vector<double> &getSgcritColumn() const
-        { return SingleRecordTable::getColumn(5); }
+        { return SimpleTable::getColumn(5); }
 
         /*!
          * \brief Maximum gas saturation
          */
         const std::vector<double> &getSgmaxColumn() const
-        { return SingleRecordTable::getColumn(6); }
+        { return SimpleTable::getColumn(6); }
 
         /*!
          * \brief Critical oil-in-water saturation
          */
         const std::vector<double> &getSowcritColumn() const
-        { return SingleRecordTable::getColumn(7); }
+        { return SimpleTable::getColumn(7); }
 
         /*!
          * \brief Critical oil-in-gas saturation
          */
         const std::vector<double> &getSogcritColumn() const
-        { return SingleRecordTable::getColumn(8); }
+        { return SimpleTable::getColumn(8); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class ImptvdTable : protected SingleRecordTable {
-        
+
 
         friend class TableManager;
         ImptvdTable() = default;
@@ -35,10 +35,9 @@ namespace Opm {
          * \brief Read the IMPTVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"DEPTH",
                                      "SWCO",
                                      "SWCRIT",
@@ -48,8 +47,7 @@ namespace Opm {
                                      "SGMAX",
                                      "SOWCRIT",
                                      "SOGCRIT"},
-                             recordIdx,
-                             /*firstEntityOffset=*/0);
+                                    /*firstEntityOffset=*/0);
             SingleRecordTable::checkNonDefaultable("DEPTH");
             SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
             SingleRecordTable::applyDefaultsLinear("SWCO");

--- a/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class ImptvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         ImptvdTable() = default;
@@ -38,7 +38,7 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"DEPTH",
                                      "SWCO",
                                      "SWCRIT",
@@ -50,74 +50,74 @@ namespace Opm {
                                      "SOGCRIT"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
-            ParentType::checkNonDefaultable("DEPTH");
-            ParentType::checkMonotonic("DEPTH", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("SWCO");
-            ParentType::applyDefaultsLinear("SWCRIT");
-            ParentType::applyDefaultsLinear("SWMAX");
-            ParentType::applyDefaultsLinear("SGCO");
-            ParentType::applyDefaultsLinear("SGCRIT");
-            ParentType::applyDefaultsLinear("SGMAX");
-            ParentType::applyDefaultsLinear("SOWCRIT");
-            ParentType::applyDefaultsLinear("SOGCRIT");
+            SingleRecordTable::checkNonDefaultable("DEPTH");
+            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("SWCO");
+            SingleRecordTable::applyDefaultsLinear("SWCRIT");
+            SingleRecordTable::applyDefaultsLinear("SWMAX");
+            SingleRecordTable::applyDefaultsLinear("SGCO");
+            SingleRecordTable::applyDefaultsLinear("SGCRIT");
+            SingleRecordTable::applyDefaultsLinear("SGMAX");
+            SingleRecordTable::applyDefaultsLinear("SOWCRIT");
+            SingleRecordTable::applyDefaultsLinear("SOGCRIT");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         /*!
          * \brief Connate water saturation
          */
         const std::vector<double> &getSwcoColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         /*!
          * \brief Critical water saturation
          */
         const std::vector<double> &getSwcritColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         /*!
          * \brief Maximum water saturation
          */
         const std::vector<double> &getSwmaxColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
 
         /*!
          * \brief Connate gas saturation
          */
         const std::vector<double> &getSgcoColumn() const
-        { return ParentType::getColumn(4); }
+        { return SingleRecordTable::getColumn(4); }
 
         /*!
          * \brief Critical gas saturation
          */
         const std::vector<double> &getSgcritColumn() const
-        { return ParentType::getColumn(5); }
+        { return SingleRecordTable::getColumn(5); }
 
         /*!
          * \brief Maximum gas saturation
          */
         const std::vector<double> &getSgmaxColumn() const
-        { return ParentType::getColumn(6); }
+        { return SingleRecordTable::getColumn(6); }
 
         /*!
          * \brief Critical oil-in-water saturation
          */
         const std::vector<double> &getSowcritColumn() const
-        { return ParentType::getColumn(7); }
+        { return SingleRecordTable::getColumn(7); }
 
         /*!
          * \brief Critical oil-in-gas saturation
          */
         const std::vector<double> &getSogcritColumn() const
-        { return ParentType::getColumn(8); }
+        { return SingleRecordTable::getColumn(8); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp
@@ -19,7 +19,7 @@
 #ifndef OPM_PARSER_MULTI_RECORD_TABLE_HPP
 #define	OPM_PARSER_MULTI_RECORD_TABLE_HPP
 
-#include <opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
@@ -34,7 +34,7 @@ namespace Opm {
     class EclipseState;
 
     // create table from first few items of multiple records (i.e. getSIDoubleData() throws an exception)
-    class MultiRecordTable : public SingleRecordTable {
+    class MultiRecordTable : public SimpleTable {
     protected:
         /*!
          * \brief Read simple tables from multi-item keywords like PVTW

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -35,14 +35,13 @@ namespace Opm {
          * \brief Read the OILVISCT keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
-                             std::vector<std::string>{
-                                 "Temperature",
-                                 "Viscosity"
-                             },
-                             recordIdx,
+            SingleRecordTable::init(record ,
+                                    std::vector<std::string>{
+                                        "Temperature",
+                                        "Viscosity"
+                                            },
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("Temperature");

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_OILVISCT_TABLE_HPP
 #define	OPM_PARSER_OILVISCT_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class OilvisctTable : protected SingleRecordTable {
+    class OilvisctTable : protected SimpleTable {
         
 
         friend class TableManager;
@@ -37,31 +37,31 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record ,
+            SimpleTable::init(record ,
                                     std::vector<std::string>{
                                         "Temperature",
                                         "Viscosity"
                                             },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("Temperature");
-            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("Temperature");
+            SimpleTable::checkMonotonic("Temperature", /*isAscending=*/true);
 
-            SingleRecordTable::checkNonDefaultable("Viscosity");
-            SingleRecordTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SimpleTable::checkNonDefaultable("Viscosity");
+            SimpleTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getOilViscosityColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class OilvisctTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         OilvisctTable() = default;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "Temperature",
                                  "Viscosity"
@@ -45,24 +45,24 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("Temperature");
-            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("Temperature");
+            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
 
-            ParentType::checkNonDefaultable("Viscosity");
-            ParentType::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SingleRecordTable::checkNonDefaultable("Viscosity");
+            SingleRecordTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getOilViscosityColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PLYADS_TABLE_HPP
 #define	OPM_PARSER_PLYADS_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyadsTable : protected SingleRecordTable {
+    class PlyadsTable : protected SimpleTable {
 
 
         friend class TableManager;
@@ -36,17 +36,17 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "PolymerConcentration",
                                  "AdsorbedPolymer"
                              },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("PolymerConcentration");
-            SingleRecordTable::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("AdsorbedPolymer");
-            SingleRecordTable::checkMonotonic("AdsorbedPolymer", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SimpleTable::checkNonDefaultable("PolymerConcentration");
+            SimpleTable::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("AdsorbedPolymer");
+            SimpleTable::checkMonotonic("AdsorbedPolymer", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
@@ -58,16 +58,16 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPolymerConcentrationColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getAdsorbedPolymerColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PlyadsTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -36,7 +36,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "PolymerConcentration",
                                  "AdsorbedPolymer"
@@ -44,10 +44,10 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("PolymerConcentration");
-            ParentType::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
-            ParentType::checkNonDefaultable("AdsorbedPolymer");
-            ParentType::checkMonotonic("AdsorbedPolymer", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SingleRecordTable::checkNonDefaultable("PolymerConcentration");
+            SingleRecordTable::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("AdsorbedPolymer");
+            SingleRecordTable::checkMonotonic("AdsorbedPolymer", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
@@ -59,16 +59,16 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPolymerConcentrationColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getAdsorbedPolymerColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PlyadsTable : protected SingleRecordTable {
-        
+
 
         friend class TableManager;
 
@@ -34,14 +34,13 @@ namespace Opm {
          * \brief Read the PLYADS keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "PolymerConcentration",
                                  "AdsorbedPolymer"
                              },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("PolymerConcentration");
@@ -55,8 +54,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PLYDHFLF_TABLE_HPP
 #define	OPM_PARSER_PLYDHFLF_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlydhflfTable : protected SingleRecordTable {
+    class PlydhflfTable : protected SimpleTable {
         
 
         friend class TableManager;
@@ -37,30 +37,30 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "Temperature",
                                  "PolymerHalflife"
                              },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("Temperetura");
-            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("PolymerHalflife");
-            SingleRecordTable::checkMonotonic("PolymerHalflife", /*isAscending=*/false);
+            SimpleTable::checkNonDefaultable("Temperetura");
+            SimpleTable::checkMonotonic("Temperature", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("PolymerHalflife");
+            SimpleTable::checkMonotonic("PolymerHalflife", /*isAscending=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getPolymerHalflifeColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
@@ -35,14 +35,13 @@ namespace Opm {
          * \brief Read the PLYDHFLF keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "Temperature",
                                  "PolymerHalflife"
                              },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("Temperetura");

--- a/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PlydhflfTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         PlydhflfTable() = default;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "Temperature",
                                  "PolymerHalflife"
@@ -45,23 +45,23 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("Temperetura");
-            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
-            ParentType::checkNonDefaultable("PolymerHalflife");
-            ParentType::checkMonotonic("PolymerHalflife", /*isAscending=*/false);
+            SingleRecordTable::checkNonDefaultable("Temperetura");
+            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("PolymerHalflife");
+            SingleRecordTable::checkMonotonic("PolymerHalflife", /*isAscending=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getPolymerHalflifeColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class PlymaxTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         PlymaxTable() = default;
@@ -35,11 +34,10 @@ namespace Opm {
          * \brief Read the PLYMAX keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"C_POLYMER", "C_POLYMER_MAX"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("C_POLYMER");

--- a/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PlymaxTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         PlymaxTable() = default;
@@ -37,28 +37,28 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"C_POLYMER", "C_POLYMER_MAX"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("C_POLYMER");
-            ParentType::checkMonotonic("C_POLYMER", /*isAscending=*/false);
-            ParentType::checkNonDefaultable("C_POLYMER_MAX");
-            ParentType::checkMonotonic("C_POLYMER_MAX", /*isAscending=*/false);
+            SingleRecordTable::checkNonDefaultable("C_POLYMER");
+            SingleRecordTable::checkMonotonic("C_POLYMER", /*isAscending=*/false);
+            SingleRecordTable::checkNonDefaultable("C_POLYMER_MAX");
+            SingleRecordTable::checkMonotonic("C_POLYMER_MAX", /*isAscending=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPolymerConcentrationColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getMaxPolymerConcentrationColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PLYMAX_TABLE_HPP
 #define	OPM_PARSER_PLYMAX_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlymaxTable : protected SingleRecordTable {
+    class PlymaxTable : protected SimpleTable {
 
         friend class TableManager;
         PlymaxTable() = default;
@@ -36,27 +36,27 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"C_POLYMER", "C_POLYMER_MAX"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("C_POLYMER");
-            SingleRecordTable::checkMonotonic("C_POLYMER", /*isAscending=*/false);
-            SingleRecordTable::checkNonDefaultable("C_POLYMER_MAX");
-            SingleRecordTable::checkMonotonic("C_POLYMER_MAX", /*isAscending=*/false);
+            SimpleTable::checkNonDefaultable("C_POLYMER");
+            SimpleTable::checkMonotonic("C_POLYMER", /*isAscending=*/false);
+            SimpleTable::checkNonDefaultable("C_POLYMER_MAX");
+            SimpleTable::checkMonotonic("C_POLYMER_MAX", /*isAscending=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPolymerConcentrationColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getMaxPolymerConcentrationColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PLYROCK_TABLE_HPP
 #define	OPM_PARSER_PLYROCK_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyrockTable : protected SingleRecordTable {
+    class PlyrockTable : protected SimpleTable {
 
         friend class TableManager;
         PlyrockTable() = default;
@@ -36,7 +36,7 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "DeadPoreVolume",
                                  "ResidualResistanceFactor",
@@ -65,21 +65,21 @@ namespace Opm {
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
 
         // since this keyword is not necessarily monotonic, it cannot be evaluated!
-        //using SingleRecordTable::evaluate;
+        //using SimpleTable::evaluate;
 
         const std::vector<double> &getDeadPoreVolumeColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getResidualResistanceFactorColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getRockDensityFactorColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         // is column is actually an integer, but this is not yet
         // supported by opm-parser (yet?) as it would require quite a
@@ -90,10 +90,10 @@ namespace Opm {
         // calling code. (Make sure, that you don't interpolate
         // indices, though!)
         const std::vector<double> &getAdsorbtionIndexColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
 
         const std::vector<double> &getMaxAdsorbtionColumn() const
-        { return SingleRecordTable::getColumn(4); }
+        { return SimpleTable::getColumn(4); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PlyrockTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         PlyrockTable() = default;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "DeadPoreVolume",
                                  "ResidualResistanceFactor",
@@ -67,21 +67,21 @@ namespace Opm {
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
 
         // since this keyword is not necessarily monotonic, it cannot be evaluated!
-        //using ParentType::evaluate;
+        //using SingleRecordTable::evaluate;
 
         const std::vector<double> &getDeadPoreVolumeColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getResidualResistanceFactorColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getRockDensityFactorColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         // is column is actually an integer, but this is not yet
         // supported by opm-parser (yet?) as it would require quite a
@@ -92,10 +92,10 @@ namespace Opm {
         // calling code. (Make sure, that you don't interpolate
         // indices, though!)
         const std::vector<double> &getAdsorbtionIndexColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
 
         const std::vector<double> &getMaxAdsorbtionColumn() const
-        { return ParentType::getColumn(4); }
+        { return SingleRecordTable::getColumn(4); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class PlyrockTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         PlyrockTable() = default;
@@ -35,9 +34,9 @@ namespace Opm {
          * \brief Read the PLYROCK keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "DeadPoreVolume",
                                  "ResidualResistanceFactor",
@@ -45,7 +44,6 @@ namespace Opm {
                                  "AdsorbtionIndex",
                                  "MaxAdsorbtion"
                              },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             // the entries of this keyword cannot be defaulted except for the

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -19,7 +19,7 @@
 #ifndef OPM_PARSER_PLYSHLOG_TABLE_HPP
 #define	OPM_PARSER_PLYSHLOG_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
@@ -64,7 +64,7 @@ namespace Opm {
                 setHasRefTemperature(false);
             }
 
-            m_data = new SingleRecordTable();
+            m_data = new SimpleTable();
 
             m_data->init(dataRecord,
                          std::vector<std::string>{
@@ -135,7 +135,7 @@ namespace Opm {
         bool m_hasRefSalinity;
         bool m_hasRefTemperature;
 
-        SingleRecordTable *m_data;
+        SimpleTable *m_data;
 
     };
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -35,10 +35,9 @@ namespace Opm {
          *        methods for it.
          */
         void init(Opm::DeckKeywordConstPtr keyword) {
-
-            // the reference conditions
-            DeckRecordConstPtr record1 = keyword->getRecord(0);
-
+            Opm::DeckRecordConstPtr record1 = keyword->getRecord(0);
+            Opm::DeckRecordConstPtr dataRecord = keyword->getRecord(1);
+            
             const auto itemRefPolymerConcentration = record1->getItem("REF_POLYMER_CONCENTRATION");
             const auto itemRefSalinity = record1->getItem("REF_SALINITY");
             const auto itemRefTemperature = record1->getItem("REF_TEMPERATURE");
@@ -67,12 +66,11 @@ namespace Opm {
 
             m_data = new SingleRecordTable();
 
-            m_data->init(keyword,
+            m_data->init(dataRecord,
                          std::vector<std::string>{
                                 "WaterVelocity",
                                 "ShearMultiplier"
                              },
-                             /*recordIdx*/ 1,
                              /*firstEntityOffset=*/0);
 
             m_data->checkNonDefaultable("WaterVelocity");

--- a/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
@@ -35,14 +35,13 @@ namespace Opm {
          * \brief Read the PLYVISC keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "PolymerConcentration",
                                  "ViscosityMultiplier"
                              },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("PolymerConcentration");

--- a/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PlyviscTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         PlyviscTable() = default;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "PolymerConcentration",
                                  "ViscosityMultiplier"
@@ -45,23 +45,23 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("PolymerConcentration");
-            ParentType::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
-            ParentType::checkNonDefaultable("ViscosityMultiplier");
-            ParentType::checkMonotonic("ViscosityMultiplier", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("PolymerConcentration");
+            SingleRecordTable::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("ViscosityMultiplier");
+            SingleRecordTable::checkMonotonic("ViscosityMultiplier", /*isAscending=*/true);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPolymerConcentrationColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getViscosityMultiplierColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PLYVISC_TABLE_HPP
 #define	OPM_PARSER_PLYVISC_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyviscTable : protected SingleRecordTable {
+    class PlyviscTable : protected SimpleTable {
         
 
         friend class TableManager;
@@ -37,30 +37,30 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "PolymerConcentration",
                                  "ViscosityMultiplier"
                              },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("PolymerConcentration");
-            SingleRecordTable::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("ViscosityMultiplier");
-            SingleRecordTable::checkMonotonic("ViscosityMultiplier", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("PolymerConcentration");
+            SimpleTable::checkMonotonic("PolymerConcentration", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("ViscosityMultiplier");
+            SimpleTable::checkMonotonic("ViscosityMultiplier", /*isAscending=*/true);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPolymerConcentrationColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getViscosityMultiplierColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PvdgTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -39,35 +39,35 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"P", "BG", "MUG"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("P");
-            ParentType::checkMonotonic("P", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("P");
+            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
 
-            ParentType::applyDefaultsLinear("BG");
-            ParentType::checkMonotonic("BG", /*isAscending=*/false);
+            SingleRecordTable::applyDefaultsLinear("BG");
+            SingleRecordTable::checkMonotonic("BG", /*isAscending=*/false);
 
-            ParentType::applyDefaultsLinear("MUG");
-            ParentType::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SingleRecordTable::applyDefaultsLinear("MUG");
+            SingleRecordTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getFormationFactorColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getViscosityColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
@@ -36,12 +36,10 @@ namespace Opm {
          * \brief Read the PVDG keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"P", "BG", "MUG"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("P");

--- a/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PVDG_TABLE_HPP
 #define	OPM_PARSER_PVDG_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PvdgTable : protected SingleRecordTable {
+    class PvdgTable : protected SimpleTable {
         
 
         friend class TableManager;
@@ -38,34 +38,34 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"P", "BG", "MUG"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("P");
-            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("P");
+            SimpleTable::checkMonotonic("P", /*isAscending=*/true);
 
-            SingleRecordTable::applyDefaultsLinear("BG");
-            SingleRecordTable::checkMonotonic("BG", /*isAscending=*/false);
+            SimpleTable::applyDefaultsLinear("BG");
+            SimpleTable::checkMonotonic("BG", /*isAscending=*/false);
 
-            SingleRecordTable::applyDefaultsLinear("MUG");
-            SingleRecordTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SimpleTable::applyDefaultsLinear("MUG");
+            SimpleTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getFormationFactorColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getViscosityColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
@@ -35,12 +35,10 @@ namespace Opm {
          * \brief Read the PVDO keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"P", "BO", "MUO"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("P");

--- a/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class PvdoTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         PvdoTable() = default;
@@ -38,35 +38,35 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"P", "BO", "MUO"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("P");
-            ParentType::checkMonotonic("P", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("P");
+            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
 
-            ParentType::applyDefaultsLinear("BO");
-            ParentType::checkMonotonic("BO", /*isAscending=*/false);
+            SingleRecordTable::applyDefaultsLinear("BO");
+            SingleRecordTable::checkMonotonic("BO", /*isAscending=*/false);
 
-            ParentType::applyDefaultsLinear("MUO");
-            ParentType::checkMonotonic("MUO", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SingleRecordTable::applyDefaultsLinear("MUO");
+            SingleRecordTable::checkMonotonic("MUO", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getFormationFactorColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getViscosityColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_PVDO_TABLE_HPP
 #define	OPM_PARSER_PVDO_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PvdoTable : protected SingleRecordTable {
+    class PvdoTable : protected SimpleTable {
         
 
         friend class TableManager;
@@ -37,34 +37,34 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"P", "BO", "MUO"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("P");
-            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("P");
+            SimpleTable::checkMonotonic("P", /*isAscending=*/true);
 
-            SingleRecordTable::applyDefaultsLinear("BO");
-            SingleRecordTable::checkMonotonic("BO", /*isAscending=*/false);
+            SimpleTable::applyDefaultsLinear("BO");
+            SimpleTable::checkMonotonic("BO", /*isAscending=*/false);
 
-            SingleRecordTable::applyDefaultsLinear("MUO");
-            SingleRecordTable::checkMonotonic("MUO", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SimpleTable::applyDefaultsLinear("MUO");
+            SimpleTable::checkMonotonic("MUO", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getFormationFactorColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getViscosityColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
@@ -20,13 +20,13 @@
 #ifndef OPM_PARSER_PVDS_TABLE_HPP
 #define OPM_PARSER_PVDS_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PvdsTable : protected SingleRecordTable {
+    class PvdsTable : protected SimpleTable {
         
 
         friend class TableManager;
@@ -39,34 +39,34 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"P", "BG", "MUG"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("P");
-            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("P");
+            SimpleTable::checkMonotonic("P", /*isAscending=*/true);
 
-            SingleRecordTable::applyDefaultsLinear("BG");
-            SingleRecordTable::checkMonotonic("BG", /*isAscending=*/false);
+            SimpleTable::applyDefaultsLinear("BG");
+            SimpleTable::checkMonotonic("BG", /*isAscending=*/false);
 
-            SingleRecordTable::applyDefaultsLinear("MUG");
-            SingleRecordTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SimpleTable::applyDefaultsLinear("MUG");
+            SimpleTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getFormationFactorColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getViscosityColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
@@ -27,7 +27,7 @@ namespace Opm {
     class TableManager;
 
     class PvdsTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -40,35 +40,35 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"P", "BG", "MUG"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("P");
-            ParentType::checkMonotonic("P", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("P");
+            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
 
-            ParentType::applyDefaultsLinear("BG");
-            ParentType::checkMonotonic("BG", /*isAscending=*/false);
+            SingleRecordTable::applyDefaultsLinear("BG");
+            SingleRecordTable::checkMonotonic("BG", /*isAscending=*/false);
 
-            ParentType::applyDefaultsLinear("MUG");
-            ParentType::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SingleRecordTable::applyDefaultsLinear("MUG");
+            SingleRecordTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getFormationFactorColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getViscosityColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
@@ -37,12 +37,10 @@ namespace Opm {
          * \brief Read the PVDS keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"P", "BG", "MUG"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("P");

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
     class PvtgInnerTable;
 
     class PvtgInnerTable : protected MultiRecordTable {
-        
+
 
         friend class PvtgTable;
         friend class FullTable<PvtgOuterTable, PvtgInnerTable>;
@@ -42,11 +42,11 @@ namespace Opm {
          *
          * The first value of the record (-> Rv) is skipped.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, size_t recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"RV", "BG", "MUG"},
-                             recordIdx, 1U);
+                             1U);
 
             SingleRecordTable::checkNonDefaultable("RV");
             SingleRecordTable::checkMonotonic("RV", /*isAscending=*/false);

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
     class PvtgInnerTable;
 
     class PvtgInnerTable : protected MultiRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class PvtgTable;
         friend class FullTable<PvtgOuterTable, PvtgInnerTable>;
@@ -44,30 +44,30 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, size_t recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"RV", "BG", "MUG"},
                              recordIdx, 1U);
 
-            ParentType::checkNonDefaultable("RV");
-            ParentType::checkMonotonic("RV", /*isAscending=*/false);
-            ParentType::applyDefaultsLinear("BG");
-            ParentType::applyDefaultsLinear("MUG");
+            SingleRecordTable::checkNonDefaultable("RV");
+            SingleRecordTable::checkMonotonic("RV", /*isAscending=*/false);
+            SingleRecordTable::applyDefaultsLinear("BG");
+            SingleRecordTable::applyDefaultsLinear("MUG");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getOilSolubilityColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getGasFormationFactorColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getGasViscosityColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtgInnerTable.hpp
@@ -19,7 +19,7 @@
 #ifndef OPM_PARSER_PVTG_INNER_TABLE_HPP
 #define	OPM_PARSER_PVTG_INNER_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declarations
@@ -44,30 +44,30 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"RV", "BG", "MUG"},
                              1U);
 
-            SingleRecordTable::checkNonDefaultable("RV");
-            SingleRecordTable::checkMonotonic("RV", /*isAscending=*/false);
-            SingleRecordTable::applyDefaultsLinear("BG");
-            SingleRecordTable::applyDefaultsLinear("MUG");
+            SimpleTable::checkNonDefaultable("RV");
+            SimpleTable::checkMonotonic("RV", /*isAscending=*/false);
+            SimpleTable::applyDefaultsLinear("BG");
+            SimpleTable::applyDefaultsLinear("MUG");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getOilSolubilityColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getGasFormationFactorColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getGasViscosityColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
@@ -19,7 +19,7 @@
 #ifndef OPM_PARSER_PVTO_INNER_TABLE_HPP
 #define	OPM_PARSER_PVTO_INNER_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declarations
@@ -43,30 +43,30 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"P", "BO", "MU"},
                              /*firstEntityOffset=*/1);
 
-            SingleRecordTable::checkNonDefaultable("P");
-            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("BO");
-            SingleRecordTable::applyDefaultsLinear("MU");
+            SimpleTable::checkNonDefaultable("P");
+            SimpleTable::checkMonotonic("P", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("BO");
+            SimpleTable::applyDefaultsLinear("MU");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getOilFormationFactorColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getOilViscosityColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
     class PvtoInnerTable;
 
     class PvtoInnerTable : protected MultiRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class PvtoTable;
         friend class FullTable<PvtoOuterTable, PvtoInnerTable>;
@@ -44,31 +44,31 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"P", "BO", "MU"},
                              recordIdx,
                              /*firstEntityOffset=*/1);
 
-            ParentType::checkNonDefaultable("P");
-            ParentType::checkMonotonic("P", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("BO");
-            ParentType::applyDefaultsLinear("MU");
+            SingleRecordTable::checkNonDefaultable("P");
+            SingleRecordTable::checkMonotonic("P", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("BO");
+            SingleRecordTable::applyDefaultsLinear("MU");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getOilFormationFactorColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getOilViscosityColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvtoInnerTable.hpp
@@ -30,7 +30,6 @@ namespace Opm {
     class PvtoInnerTable;
 
     class PvtoInnerTable : protected MultiRecordTable {
-        
 
         friend class PvtoTable;
         friend class FullTable<PvtoOuterTable, PvtoInnerTable>;
@@ -42,11 +41,10 @@ namespace Opm {
          *
          * The first value of the record (-> Rs) is skipped.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"P", "BO", "MU"},
-                             recordIdx,
                              /*firstEntityOffset=*/1);
 
             SingleRecordTable::checkNonDefaultable("P");

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class RocktabTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         RocktabTable() = default;
@@ -40,7 +40,7 @@ namespace Opm {
                   bool hasStressOption,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              isDirectional
                              ? std::vector<std::string>{"PO", "PV_MULT", "TRANSMIS_MULT_X", "TRANSMIS_MULT_Y", "TRANSMIS_MULT_Z"}
                              : std::vector<std::string>{"PO", "PV_MULT", "TRANSMIS_MULT"},
@@ -48,48 +48,48 @@ namespace Opm {
                              /*firstEntityOffset=*/0);
             m_isDirectional = isDirectional;
 
-            ParentType::checkNonDefaultable("PO");
-            ParentType::checkMonotonic("PO", /*isAscending=*/hasStressOption);
-            ParentType::applyDefaultsLinear("PV_MULT");
+            SingleRecordTable::checkNonDefaultable("PO");
+            SingleRecordTable::checkMonotonic("PO", /*isAscending=*/hasStressOption);
+            SingleRecordTable::applyDefaultsLinear("PV_MULT");
             if (isDirectional) {
-                ParentType::applyDefaultsLinear("TRANSMIS_MULT");
+                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT");
             } else {
-                ParentType::applyDefaultsLinear("TRANSMIS_MULT_X");
-                ParentType::applyDefaultsLinear("TRANSMIS_MULT_Y");
-                ParentType::applyDefaultsLinear("TRANSMIS_MULT_Z");
+                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT_X");
+                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT_Y");
+                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT_Z");
             }
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getPoreVolumeMultiplierColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getTransmissibilityMultiplierColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         const std::vector<double> &getTransmissibilityMultiplierXColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         const std::vector<double> &getTransmissibilityMultiplierYColumn() const
         {
             if (!m_isDirectional)
-                return ParentType::getColumn(2);
-            return ParentType::getColumn(3);
+                return SingleRecordTable::getColumn(2);
+            return SingleRecordTable::getColumn(3);
         }
 
         const std::vector<double> &getTransmissibilityMultiplierZColumn() const
         {
             if (!m_isDirectional)
-                return ParentType::getColumn(2);
-            return ParentType::getColumn(4);
+                return SingleRecordTable::getColumn(2);
+            return SingleRecordTable::getColumn(4);
         }
 
     private:

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class RocktabTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         RocktabTable() = default;
@@ -35,16 +34,14 @@ namespace Opm {
          * \brief Read the ROCKTAB keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
+        void init(Opm::DeckRecordConstPtr record,
                   bool isDirectional,
-                  bool hasStressOption,
-                  int recordIdx)
+                  bool hasStressOption)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              isDirectional
                              ? std::vector<std::string>{"PO", "PV_MULT", "TRANSMIS_MULT_X", "TRANSMIS_MULT_Y", "TRANSMIS_MULT_Z"}
                              : std::vector<std::string>{"PO", "PV_MULT", "TRANSMIS_MULT"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
             m_isDirectional = isDirectional;
 

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_ROCKTAB_TABLE_HPP
 #define	OPM_PARSER_ROCKTAB_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RocktabTable : protected SingleRecordTable {
+    class RocktabTable : protected SimpleTable {
 
         friend class TableManager;
         RocktabTable() = default;
@@ -38,55 +38,55 @@ namespace Opm {
                   bool isDirectional,
                   bool hasStressOption)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              isDirectional
                              ? std::vector<std::string>{"PO", "PV_MULT", "TRANSMIS_MULT_X", "TRANSMIS_MULT_Y", "TRANSMIS_MULT_Z"}
                              : std::vector<std::string>{"PO", "PV_MULT", "TRANSMIS_MULT"},
                              /*firstEntityOffset=*/0);
             m_isDirectional = isDirectional;
 
-            SingleRecordTable::checkNonDefaultable("PO");
-            SingleRecordTable::checkMonotonic("PO", /*isAscending=*/hasStressOption);
-            SingleRecordTable::applyDefaultsLinear("PV_MULT");
+            SimpleTable::checkNonDefaultable("PO");
+            SimpleTable::checkMonotonic("PO", /*isAscending=*/hasStressOption);
+            SimpleTable::applyDefaultsLinear("PV_MULT");
             if (isDirectional) {
-                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT");
+                SimpleTable::applyDefaultsLinear("TRANSMIS_MULT");
             } else {
-                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT_X");
-                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT_Y");
-                SingleRecordTable::applyDefaultsLinear("TRANSMIS_MULT_Z");
+                SimpleTable::applyDefaultsLinear("TRANSMIS_MULT_X");
+                SimpleTable::applyDefaultsLinear("TRANSMIS_MULT_Y");
+                SimpleTable::applyDefaultsLinear("TRANSMIS_MULT_Z");
             }
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getPressureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getPoreVolumeMultiplierColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getTransmissibilityMultiplierColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         const std::vector<double> &getTransmissibilityMultiplierXColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         const std::vector<double> &getTransmissibilityMultiplierYColumn() const
         {
             if (!m_isDirectional)
-                return SingleRecordTable::getColumn(2);
-            return SingleRecordTable::getColumn(3);
+                return SimpleTable::getColumn(2);
+            return SimpleTable::getColumn(3);
         }
 
         const std::vector<double> &getTransmissibilityMultiplierZColumn() const
         {
             if (!m_isDirectional)
-                return SingleRecordTable::getColumn(2);
-            return SingleRecordTable::getColumn(4);
+                return SimpleTable::getColumn(2);
+            return SimpleTable::getColumn(4);
         }
 
     private:

--- a/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class RsvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         RsvdTable() = default;
@@ -37,27 +37,27 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"DEPTH", "RS"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("DEPTH");
-            ParentType::checkMonotonic("DEPTH", /*isAscending=*/true);
-            ParentType::checkNonDefaultable("RS");
+            SingleRecordTable::checkNonDefaultable("DEPTH");
+            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("RS");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getRsColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class RsvdTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         RsvdTable() = default;
@@ -35,12 +34,11 @@ namespace Opm {
          * \brief Read the RSVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"DEPTH", "RS"},
-                             recordIdx,
-                             /*firstEntityOffset=*/0);
+                                    /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("DEPTH");
             SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);

--- a/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_RSVD_TABLE_HPP
 #define OPM_PARSER_RSVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RsvdTable : protected SingleRecordTable {
+    class RsvdTable : protected SimpleTable {
 
         friend class TableManager;
         RsvdTable() = default;
@@ -36,26 +36,26 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"DEPTH", "RS"},
                                     /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("DEPTH");
-            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("RS");
+            SimpleTable::checkNonDefaultable("DEPTH");
+            SimpleTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("RS");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getRsColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class RtempvdTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         RtempvdTable() = default;
@@ -35,14 +34,13 @@ namespace Opm {
          * \brief Read the RTEMPVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "Depth",
                                  "Temperature"
                              },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("Depth");

--- a/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_RTEMPVD_TABLE_HPP
 #define	OPM_PARSER_RTEMPVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RtempvdTable : protected SingleRecordTable {
+    class RtempvdTable : protected SimpleTable {
 
         friend class TableManager;
         RtempvdTable() = default;
@@ -36,30 +36,30 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "Depth",
                                  "Temperature"
                              },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("Depth");
-            SingleRecordTable::checkMonotonic("Depth", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("Depth");
+            SimpleTable::checkMonotonic("Depth", /*isAscending=*/true);
 
-            SingleRecordTable::checkNonDefaultable("Temperature");
+            SimpleTable::checkNonDefaultable("Temperature");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getTemperatureColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class RtempvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         RtempvdTable() = default;
@@ -37,7 +37,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "Depth",
                                  "Temperature"
@@ -45,23 +45,23 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("Depth");
-            ParentType::checkMonotonic("Depth", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("Depth");
+            SingleRecordTable::checkMonotonic("Depth", /*isAscending=*/true);
 
-            ParentType::checkNonDefaultable("Temperature");
+            SingleRecordTable::checkNonDefaultable("Temperature");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getTemperatureColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class RvvdTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -38,27 +38,27 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"DEPTH", "RV"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("DEPTH");
-            ParentType::checkMonotonic("DEPTH", /*isAscending=*/true);
-            ParentType::checkNonDefaultable("RV");
+            SingleRecordTable::checkNonDefaultable("DEPTH");
+            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("RV");
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getRvColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_RVVD_TABLE_HPP
 #define OPM_PARSER_RVVD_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RvvdTable : protected SingleRecordTable {
+    class RvvdTable : protected SimpleTable {
 
         friend class TableManager;
 
@@ -37,26 +37,26 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"DEPTH", "RV"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("DEPTH");
-            SingleRecordTable::checkMonotonic("DEPTH", /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("RV");
+            SimpleTable::checkNonDefaultable("DEPTH");
+            SimpleTable::checkMonotonic("DEPTH", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("RV");
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getDepthColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getRvColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class RvvdTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
 
@@ -36,11 +35,10 @@ namespace Opm {
          * \brief Read the RSVD keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"DEPTH", "RV"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("DEPTH");

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SGFN_TABLE_HPP
 #define OPM_PARSER_SGFN_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SgfnTable : protected SingleRecordTable {
+    class SgfnTable : protected SimpleTable {
 
         friend class TableManager;
 
@@ -35,16 +35,16 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"SG", "KRG", "PCOG"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SG");
-            SingleRecordTable::checkMonotonic("SG",   /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("KRG");
-            SingleRecordTable::applyDefaultsLinear("PCOG");
-            SingleRecordTable::checkMonotonic("KRG",  /*isAscending=*/true,  /*strict=*/false);
-            SingleRecordTable::checkMonotonic("PCOG", /*isAscending=*/true, /*strict=*/false);
+            SimpleTable::checkNonDefaultable("SG");
+            SimpleTable::checkMonotonic("SG",   /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("KRG");
+            SimpleTable::applyDefaultsLinear("PCOG");
+            SimpleTable::checkMonotonic("KRG",  /*isAscending=*/true,  /*strict=*/false);
+            SimpleTable::checkMonotonic("PCOG", /*isAscending=*/true, /*strict=*/false);
         }
 
     public:
@@ -56,21 +56,21 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSgColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKrgColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         // this column is p_g - p_o (non-wetting phase pressure minus
         // wetting phase pressure for a given gas saturation)
         const std::vector<double> &getPcogColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class SgfnTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
 
@@ -34,12 +33,10 @@ namespace Opm {
          * \brief Read the SGFN keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"SG", "KRG", "PCOG"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SG");
@@ -55,8 +52,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class SgfnTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -37,17 +37,17 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SG", "KRG", "PCOG"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SG");
-            ParentType::checkMonotonic("SG",   /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("KRG");
-            ParentType::applyDefaultsLinear("PCOG");
-            ParentType::checkMonotonic("KRG",  /*isAscending=*/true,  /*strict=*/false);
-            ParentType::checkMonotonic("PCOG", /*isAscending=*/true, /*strict=*/false);
+            SingleRecordTable::checkNonDefaultable("SG");
+            SingleRecordTable::checkMonotonic("SG",   /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("KRG");
+            SingleRecordTable::applyDefaultsLinear("PCOG");
+            SingleRecordTable::checkMonotonic("KRG",  /*isAscending=*/true,  /*strict=*/false);
+            SingleRecordTable::checkMonotonic("PCOG", /*isAscending=*/true, /*strict=*/false);
         }
 
     public:
@@ -59,21 +59,21 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSgColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKrgColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         // this column is p_g - p_o (non-wetting phase pressure minus
         // wetting phase pressure for a given gas saturation)
         const std::vector<double> &getPcogColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SGOF_TABLE_HPP
 #define	OPM_PARSER_SGOF_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SgofTable : protected SingleRecordTable {
+    class SgofTable : protected SimpleTable {
         friend class TableManager;
 
         /*!
@@ -34,15 +34,15 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"SG", "KRG", "KROG", "PCOG"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SG");
-            SingleRecordTable::checkMonotonic("SG", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("KRG");
-            SingleRecordTable::applyDefaultsLinear("KROG");
-            SingleRecordTable::applyDefaultsLinear("PCOG");
+            SimpleTable::checkNonDefaultable("SG");
+            SimpleTable::checkMonotonic("SG", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("KRG");
+            SimpleTable::applyDefaultsLinear("KROG");
+            SimpleTable::applyDefaultsLinear("PCOG");
         }
 
     public:
@@ -54,26 +54,26 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSgColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKrgColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getKrogColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         // this column is p_g - p_o (non-wetting phase pressure minus
         // wetting phase pressure for a given gas saturation. the name
         // is inconsistent, but it is the one used in the Eclipse
         // manual...)
         const std::vector<double> &getPcogColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -26,8 +26,6 @@ namespace Opm {
     class TableManager;
 
     class SgofTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
-
         friend class TableManager;
 
         /*!
@@ -37,16 +35,16 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SG", "KRG", "KROG", "PCOG"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SG");
-            ParentType::checkMonotonic("SG", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("KRG");
-            ParentType::applyDefaultsLinear("KROG");
-            ParentType::applyDefaultsLinear("PCOG");
+            SingleRecordTable::checkNonDefaultable("SG");
+            SingleRecordTable::checkMonotonic("SG", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("KRG");
+            SingleRecordTable::applyDefaultsLinear("KROG");
+            SingleRecordTable::applyDefaultsLinear("PCOG");
         }
 
     public:
@@ -58,26 +56,26 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSgColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKrgColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getKrogColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         // this column is p_g - p_o (non-wetting phase pressure minus
         // wetting phase pressure for a given gas saturation. the name
         // is inconsistent, but it is the one used in the Eclipse
         // manual...)
         const std::vector<double> &getPcogColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -32,12 +32,10 @@ namespace Opm {
          * \brief Read the SGOF keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"SG", "KRG", "KROG", "PCOG"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SG");
@@ -52,8 +50,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -16,16 +16,16 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
-#include <opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 
 namespace Opm {
-size_t SingleRecordTable::numTables(Opm::DeckKeywordConstPtr keyword)
+size_t SimpleTable::numTables(Opm::DeckKeywordConstPtr keyword)
 {
     return keyword->size();
 }
 
 // create table from single record
-void SingleRecordTable::init(Opm::DeckRecordConstPtr deckRecord,
+void SimpleTable::init(Opm::DeckRecordConstPtr deckRecord,
                              const std::vector<std::string> &columnNames,
                              size_t firstEntityOffset)
 {
@@ -48,13 +48,13 @@ void SingleRecordTable::init(Opm::DeckRecordConstPtr deckRecord,
     }
 }
 
-size_t SingleRecordTable::numColumns() const
+size_t SimpleTable::numColumns() const
 { return m_columns.size(); }
 
-size_t SingleRecordTable::numRows() const
+size_t SimpleTable::numRows() const
 { return m_columns[0].size(); }
 
-const std::vector<double> &SingleRecordTable::getColumn(const std::string &name) const
+const std::vector<double> &SimpleTable::getColumn(const std::string &name) const
 {
     const auto &colIt = m_columnNames.find(name);
     if (colIt == m_columnNames.end())
@@ -64,13 +64,13 @@ const std::vector<double> &SingleRecordTable::getColumn(const std::string &name)
     assert(colIdx < static_cast<size_t>(m_columns.size()));
     return m_columns[colIdx];
 }
-const std::vector<double> &SingleRecordTable::getColumn(size_t colIdx) const
+const std::vector<double> &SimpleTable::getColumn(size_t colIdx) const
 {
     assert(colIdx < static_cast<size_t>(m_columns.size()));
     return m_columns[colIdx];
 }
 
-double SingleRecordTable::evaluate(const std::string& columnName, double xPos) const
+double SimpleTable::evaluate(const std::string& columnName, double xPos) const
 {
     const std::vector<double>& xColumn = getColumn(0);
     const std::vector<double>& yColumn = getColumn(columnName);
@@ -120,7 +120,7 @@ double SingleRecordTable::evaluate(const std::string& columnName, double xPos) c
     return yColumn[intervalIdx]*(1-alpha) + yColumn[intervalIdx + 1]*alpha;
 }
 
-void SingleRecordTable::checkNonDefaultable(const std::string& columnName)
+void SimpleTable::checkNonDefaultable(const std::string& columnName)
 {
     int columnIdx = m_columnNames.at(columnName);
 
@@ -133,7 +133,7 @@ void SingleRecordTable::checkNonDefaultable(const std::string& columnName)
 }
 
 
-void SingleRecordTable::checkMonotonic(const std::string& columnName,
+void SimpleTable::checkMonotonic(const std::string& columnName,
                                         bool isAscending,
                                         bool isStrictlyMonotonic)
 {
@@ -156,7 +156,7 @@ void SingleRecordTable::checkMonotonic(const std::string& columnName,
     }
 }
 
-void SingleRecordTable::applyDefaultsConstant(const std::string& columnName, double value)
+void SimpleTable::applyDefaultsConstant(const std::string& columnName, double value)
 {
     int columnIdx = m_columnNames.at(columnName);
     int nRows = numRows();
@@ -169,7 +169,7 @@ void SingleRecordTable::applyDefaultsConstant(const std::string& columnName, dou
     }
 }
 
-void SingleRecordTable::applyDefaultsLinear(const std::string& columnName)
+void SimpleTable::applyDefaultsLinear(const std::string& columnName)
 {
     int columnIdx = m_columnNames.at(columnName);
     const std::vector<double>& xColumn = m_columns[0];
@@ -214,7 +214,7 @@ void SingleRecordTable::applyDefaultsLinear(const std::string& columnName)
     }
 }
 
-void SingleRecordTable::createColumns(const std::vector<std::string> &columnNames)
+void SimpleTable::createColumns(const std::vector<std::string> &columnNames)
 {
     // Allocate column names. TODO (?): move the column names into
     // the json description of the keyword.
@@ -228,7 +228,7 @@ void SingleRecordTable::createColumns(const std::vector<std::string> &columnName
     m_valueDefaulted.resize(columnIdx);
 }
 
-size_t SingleRecordTable::getNumFlatItems(Opm::DeckRecordConstPtr deckRecord) const
+size_t SimpleTable::getNumFlatItems(Opm::DeckRecordConstPtr deckRecord) const
 {
     size_t result = 0;
     for (size_t i = 0; i < deckRecord->size(); ++ i) {
@@ -238,7 +238,7 @@ size_t SingleRecordTable::getNumFlatItems(Opm::DeckRecordConstPtr deckRecord) co
     return result;
 }
 
-double SingleRecordTable::getFlatRawDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
+double SimpleTable::getFlatRawDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
 {
     size_t itemFirstFlatIdx = 0;
     for (unsigned i = 0; i < deckRecord->size(); ++ i) {
@@ -252,7 +252,7 @@ double SingleRecordTable::getFlatRawDoubleData(Opm::DeckRecordConstPtr deckRecor
     throw std::range_error("Tried to access out-of-range flat item");
 }
 
-double SingleRecordTable::getFlatSiDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
+double SimpleTable::getFlatSiDoubleData(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
 {
     size_t itemFirstFlatIdx = 0;
     for (unsigned i = 0; i < deckRecord->size(); ++ i) {
@@ -266,7 +266,7 @@ double SingleRecordTable::getFlatSiDoubleData(Opm::DeckRecordConstPtr deckRecord
     throw std::range_error("Tried to access out-of-range flat item");
 }
 
-bool SingleRecordTable::getFlatIsDefaulted(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
+bool SimpleTable::getFlatIsDefaulted(Opm::DeckRecordConstPtr deckRecord, size_t flatItemIdx) const
 {
     size_t itemFirstFlatIdx = 0;
     for (unsigned i = 0; i < deckRecord->size(); ++ i) {

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -16,8 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
-#ifndef OPM_PARSER_SINGLE_RECORD_TABLE_HPP
-#define	OPM_PARSER_SINGLE_RECORD_TABLE_HPP
+#ifndef OPM_PARSER_SIMPLE_TABLE_HPP
+#define	OPM_PARSER_SIMPLE_TABLE_HPP
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 
@@ -29,10 +29,10 @@
 
 namespace Opm {
     class PlyshlogTable;
-    class SingleRecordTable {
+    class SimpleTable {
         friend class PlyshlogTable;
     protected:
-        SingleRecordTable(const SingleRecordTable&) = default;
+        SimpleTable(const SimpleTable&) = default;
 
         /*!
          * \brief Read simple tables from keywords like SWOF
@@ -45,7 +45,7 @@ namespace Opm {
                   size_t firstEntityOffset);
 
     public:
-        SingleRecordTable() = default;
+        SimpleTable() = default;
 
         /*!
          * \brief Returns the number of tables in a keyword.
@@ -94,8 +94,8 @@ namespace Opm {
         std::vector<std::vector<bool> > m_valueDefaulted;
     };
 
-    typedef std::shared_ptr<SingleRecordTable> SingleRecordTablePtr;
-    typedef std::shared_ptr<const SingleRecordTable> SingleRecordTableConstPtr;
+    typedef std::shared_ptr<SimpleTable> SimpleTablePtr;
+    typedef std::shared_ptr<const SimpleTable> SimpleTableConstPtr;
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.cpp
@@ -25,16 +25,11 @@ size_t SingleRecordTable::numTables(Opm::DeckKeywordConstPtr keyword)
 }
 
 // create table from single record
-void SingleRecordTable::init(Opm::DeckKeywordConstPtr keyword,
+void SingleRecordTable::init(Opm::DeckRecordConstPtr deckRecord,
                              const std::vector<std::string> &columnNames,
-                             size_t recordIdx,
                              size_t firstEntityOffset)
 {
     createColumns(columnNames);
-
-    // extract the actual data from the deck
-    Opm::DeckRecordConstPtr deckRecord =
-        keyword->getRecord(recordIdx);
 
     size_t numFlatItems = getNumFlatItems(deckRecord);
     if ( (numFlatItems - firstEntityOffset) % numColumns() != 0)

--- a/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp
@@ -40,9 +40,8 @@ namespace Opm {
          * This requires all data to be a list of doubles in the first
          * item of a given record index.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
+        void init(Opm::DeckRecordConstPtr record,
                   const std::vector<std::string> &columnNames,
-                  size_t recordIdx,
                   size_t firstEntityOffset);
 
     public:
@@ -58,11 +57,10 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword,
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record,
                   const std::vector<std::string> &columnNames,
-                  size_t recordIdx,
                   size_t firstEntityOffset)
-        { init(keyword, columnNames, recordIdx, firstEntityOffset); }
+        { init(record , columnNames, firstEntityOffset); }
 #endif
 
         size_t numColumns() const;

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SLGOF_TABLE_HPP
 #define	OPM_PARSER_SLGOF_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SlgofTable : protected SingleRecordTable {
+    class SlgofTable : protected SimpleTable {
         friend class TableManager;
 
         /*!
@@ -34,18 +34,18 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"SL", "KRG", "KROG", "PCOG"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SL");
-            SingleRecordTable::checkMonotonic("SL", /*isAscending=*/true);
-            SingleRecordTable::checkMonotonic("KRG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
-            SingleRecordTable::checkMonotonic("KROG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
-            SingleRecordTable::checkMonotonic("PCOG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
-            SingleRecordTable::applyDefaultsLinear("KRG");
-            SingleRecordTable::applyDefaultsLinear("KROG");
-            SingleRecordTable::applyDefaultsLinear("PCOG");
+            SimpleTable::checkNonDefaultable("SL");
+            SimpleTable::checkMonotonic("SL", /*isAscending=*/true);
+            SimpleTable::checkMonotonic("KRG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SimpleTable::checkMonotonic("KROG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SimpleTable::checkMonotonic("PCOG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SimpleTable::applyDefaultsLinear("KRG");
+            SimpleTable::applyDefaultsLinear("KROG");
+            SimpleTable::applyDefaultsLinear("PCOG");
 
             if (getSlColumn().back() != 1.0) {
                 throw std::invalid_argument("The last saturation of the SLGOF keyword must be 1!");
@@ -61,26 +61,26 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSlColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKrgColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getKrogColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         // this column is p_g - p_o (non-wetting phase pressure minus
         // wetting phase pressure for a given gas saturation. the name
         // is inconsistent, but it is the one used in the Eclipse
         // manual...)
         const std::vector<double> &getPcogColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class SlgofTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -37,19 +37,19 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SL", "KRG", "KROG", "PCOG"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SL");
-            ParentType::checkMonotonic("SL", /*isAscending=*/true);
-            ParentType::checkMonotonic("KRG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
-            ParentType::checkMonotonic("KROG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
-            ParentType::checkMonotonic("PCOG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
-            ParentType::applyDefaultsLinear("KRG");
-            ParentType::applyDefaultsLinear("KROG");
-            ParentType::applyDefaultsLinear("PCOG");
+            SingleRecordTable::checkNonDefaultable("SL");
+            SingleRecordTable::checkMonotonic("SL", /*isAscending=*/true);
+            SingleRecordTable::checkMonotonic("KRG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SingleRecordTable::checkMonotonic("KROG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
+            SingleRecordTable::checkMonotonic("PCOG", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SingleRecordTable::applyDefaultsLinear("KRG");
+            SingleRecordTable::applyDefaultsLinear("KROG");
+            SingleRecordTable::applyDefaultsLinear("PCOG");
 
             if (getSlColumn().back() != 1.0) {
                 throw std::invalid_argument("The last saturation of the SLGOF keyword must be 1!");
@@ -65,26 +65,26 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSlColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKrgColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getKrogColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         // this column is p_g - p_o (non-wetting phase pressure minus
         // wetting phase pressure for a given gas saturation. the name
         // is inconsistent, but it is the one used in the Eclipse
         // manual...)
         const std::vector<double> &getPcogColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -26,20 +26,16 @@ namespace Opm {
     class TableManager;
 
     class SlgofTable : protected SingleRecordTable {
-        
-
         friend class TableManager;
 
         /*!
          * \brief Read the SGOF keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"SL", "KRG", "KROG", "PCOG"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SL");
@@ -61,8 +57,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class Sof2Table : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -37,15 +37,15 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SO", "KRO" },
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SO");
-            ParentType::checkNonDefaultable("KRO");
-            ParentType::checkMonotonic("SO", /*isAscending=*/true);
-            ParentType::checkMonotonic("KRO", /*isAscending=*/true, /*strict*/false);
+            SingleRecordTable::checkNonDefaultable("SO");
+            SingleRecordTable::checkNonDefaultable("KRO");
+            SingleRecordTable::checkMonotonic("SO", /*isAscending=*/true);
+            SingleRecordTable::checkMonotonic("KRO", /*isAscending=*/true, /*strict*/false);
         }
 
     public:
@@ -57,16 +57,16 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSoColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKroColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SOF2_TABLE_HPP
 #define OPM_PARSER_SOF2_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class Sof2Table : protected SingleRecordTable {
+    class Sof2Table : protected SimpleTable {
         friend class TableManager;
 
         /*!
@@ -34,14 +34,14 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                                     std::vector<std::string>{"SO", "KRO" },
                                     /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SO");
-            SingleRecordTable::checkNonDefaultable("KRO");
-            SingleRecordTable::checkMonotonic("SO", /*isAscending=*/true);
-            SingleRecordTable::checkMonotonic("KRO", /*isAscending=*/true, /*strict*/false);
+            SimpleTable::checkNonDefaultable("SO");
+            SimpleTable::checkNonDefaultable("KRO");
+            SimpleTable::checkMonotonic("SO", /*isAscending=*/true);
+            SimpleTable::checkMonotonic("KRO", /*isAscending=*/true, /*strict*/false);
         }
 
     public:
@@ -53,16 +53,16 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSoColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKroColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -26,21 +26,17 @@ namespace Opm {
     class TableManager;
 
     class Sof2Table : protected SingleRecordTable {
-        
-
         friend class TableManager;
 
         /*!
          * \brief Read the SOF2 keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
-                             std::vector<std::string>{"SO", "KRO" },
-                             recordIdx,
-                             /*firstEntityOffset=*/0);
+            SingleRecordTable::init(record,
+                                    std::vector<std::string>{"SO", "KRO" },
+                                    /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SO");
             SingleRecordTable::checkNonDefaultable("KRO");
@@ -53,8 +49,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
@@ -26,20 +26,16 @@ namespace Opm {
     class TableManager;
 
     class Sof3Table : protected SingleRecordTable {
-        
-
         friend class TableManager;
 
         /*!
          * \brief Read the SOF3 keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"SO", "KROW", "KROG"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SO");
@@ -55,8 +51,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SOF3_TABLE_HPP
 #define OPM_PARSER_SOF3_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class Sof3Table : protected SingleRecordTable {
+    class Sof3Table : protected SimpleTable {
         friend class TableManager;
 
         /*!
@@ -34,16 +34,16 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"SO", "KROW", "KROG"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SO");
-            SingleRecordTable::applyDefaultsLinear("KROW");
-            SingleRecordTable::applyDefaultsLinear("KROG");
-            SingleRecordTable::checkMonotonic("SO", /*isAscending=*/true);
-            SingleRecordTable::checkMonotonic("KROW", /*isAscending=*/true, /*strict*/false);
-            SingleRecordTable::checkMonotonic("KROG", /*isAscending=*/true, /*strict*/false);
+            SimpleTable::checkNonDefaultable("SO");
+            SimpleTable::applyDefaultsLinear("KROW");
+            SimpleTable::applyDefaultsLinear("KROG");
+            SimpleTable::checkMonotonic("SO", /*isAscending=*/true);
+            SimpleTable::checkMonotonic("KROW", /*isAscending=*/true, /*strict*/false);
+            SimpleTable::checkMonotonic("KROG", /*isAscending=*/true, /*strict*/false);
         }
 
     public:
@@ -55,19 +55,19 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSoColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKrowColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getKrogColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class Sof3Table : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -37,17 +37,17 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SO", "KROW", "KROG"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SO");
-            ParentType::applyDefaultsLinear("KROW");
-            ParentType::applyDefaultsLinear("KROG");
-            ParentType::checkMonotonic("SO", /*isAscending=*/true);
-            ParentType::checkMonotonic("KROW", /*isAscending=*/true, /*strict*/false);
-            ParentType::checkMonotonic("KROG", /*isAscending=*/true, /*strict*/false);
+            SingleRecordTable::checkNonDefaultable("SO");
+            SingleRecordTable::applyDefaultsLinear("KROW");
+            SingleRecordTable::applyDefaultsLinear("KROG");
+            SingleRecordTable::checkMonotonic("SO", /*isAscending=*/true);
+            SingleRecordTable::checkMonotonic("KROW", /*isAscending=*/true, /*strict*/false);
+            SingleRecordTable::checkMonotonic("KROG", /*isAscending=*/true, /*strict*/false);
         }
 
     public:
@@ -59,19 +59,19 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSoColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKrowColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getKrogColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class SsfnTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
         SsfnTable() = default;
@@ -38,7 +38,7 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "SolventFraction",
                                  "GasRelPermMultiplier",
@@ -46,28 +46,28 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SolventFraction");
-            ParentType::checkMonotonic("SolventFraction",   /*isAscending=*/true);
-            ParentType::checkNonDefaultable("GasRelPermMultiplier");
-            ParentType::checkMonotonic("GasRelPermMultiplier",  /*isAscending=*/true);
-            ParentType::checkNonDefaultable("SolventRelPermMultiplier");
-            ParentType::checkMonotonic("SolventRelPermMultiplier", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("SolventFraction");
+            SingleRecordTable::checkMonotonic("SolventFraction",   /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("GasRelPermMultiplier");
+            SingleRecordTable::checkMonotonic("GasRelPermMultiplier",  /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("SolventRelPermMultiplier");
+            SingleRecordTable::checkMonotonic("SolventRelPermMultiplier", /*isAscending=*/true);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSolventFractionColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getGasRelPermMultiplierColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getSolventRelPermMultiplierColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class SsfnTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
         SsfnTable() = default;
@@ -35,15 +34,13 @@ namespace Opm {
          * \brief Read the SSFN keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "SolventFraction",
                                  "GasRelPermMultiplier",
                                  "SolventRelPermMultiplier"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SolventFraction");

--- a/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SSFN_TABLE_HPP
 #define OPM_PARSER_SSFN_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SsfnTable : protected SingleRecordTable {
+    class SsfnTable : protected SimpleTable {
 
         friend class TableManager;
         SsfnTable() = default;
@@ -36,35 +36,35 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "SolventFraction",
                                  "GasRelPermMultiplier",
                                  "SolventRelPermMultiplier"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SolventFraction");
-            SingleRecordTable::checkMonotonic("SolventFraction",   /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("GasRelPermMultiplier");
-            SingleRecordTable::checkMonotonic("GasRelPermMultiplier",  /*isAscending=*/true);
-            SingleRecordTable::checkNonDefaultable("SolventRelPermMultiplier");
-            SingleRecordTable::checkMonotonic("SolventRelPermMultiplier", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("SolventFraction");
+            SimpleTable::checkMonotonic("SolventFraction",   /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("GasRelPermMultiplier");
+            SimpleTable::checkMonotonic("GasRelPermMultiplier",  /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("SolventRelPermMultiplier");
+            SimpleTable::checkMonotonic("SolventRelPermMultiplier", /*isAscending=*/true);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSolventFractionColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getGasRelPermMultiplierColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getSolventRelPermMultiplierColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class SwfnTable : protected SingleRecordTable {
-        
+
 
         friend class TableManager;
 
@@ -34,12 +34,10 @@ namespace Opm {
          * \brief Read the SWFN keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{"SW", "KRW", "PCOW"},
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SW");
@@ -55,8 +53,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class SwfnTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -37,17 +37,17 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SW", "KRW", "PCOW"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SW");
-            ParentType::checkMonotonic("SW",   /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("KRW");
-            ParentType::applyDefaultsLinear("PCOW");
-            ParentType::checkMonotonic("KRW",  /*isAscending=*/true,  /*strict=*/false);
-            ParentType::checkMonotonic("PCOW", /*isAscending=*/false, /*strict=*/false);
+            SingleRecordTable::checkNonDefaultable("SW");
+            SingleRecordTable::checkMonotonic("SW",   /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("KRW");
+            SingleRecordTable::applyDefaultsLinear("PCOW");
+            SingleRecordTable::checkMonotonic("KRW",  /*isAscending=*/true,  /*strict=*/false);
+            SingleRecordTable::checkMonotonic("PCOW", /*isAscending=*/false, /*strict=*/false);
         }
 
     public:
@@ -59,21 +59,21 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSwColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKrwColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         // this column is p_o - p_w (non-wetting phase pressure minus
         // wetting phase pressure for a given water saturation)
         const std::vector<double> &getPcowColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SWFN_TABLE_HPP
 #define OPM_PARSER_SWFN_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SwfnTable : protected SingleRecordTable {
+    class SwfnTable : protected SimpleTable {
 
 
         friend class TableManager;
@@ -36,16 +36,16 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{"SW", "KRW", "PCOW"},
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SW");
-            SingleRecordTable::checkMonotonic("SW",   /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("KRW");
-            SingleRecordTable::applyDefaultsLinear("PCOW");
-            SingleRecordTable::checkMonotonic("KRW",  /*isAscending=*/true,  /*strict=*/false);
-            SingleRecordTable::checkMonotonic("PCOW", /*isAscending=*/false, /*strict=*/false);
+            SimpleTable::checkNonDefaultable("SW");
+            SimpleTable::checkMonotonic("SW",   /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("KRW");
+            SimpleTable::applyDefaultsLinear("PCOW");
+            SimpleTable::checkMonotonic("KRW",  /*isAscending=*/true,  /*strict=*/false);
+            SimpleTable::checkMonotonic("PCOW", /*isAscending=*/false, /*strict=*/false);
         }
 
     public:
@@ -57,21 +57,21 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSwColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKrwColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         // this column is p_o - p_w (non-wetting phase pressure minus
         // wetting phase pressure for a given water saturation)
         const std::vector<double> &getPcowColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_SWOF_TABLE_HPP
 #define	OPM_PARSER_SWOF_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SwofTable : protected SingleRecordTable {
+    class SwofTable : protected SimpleTable {
 
         friend class TableManager;
 
@@ -35,15 +35,15 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                                     std::vector<std::string>{"SW", "KRW", "KROW", "PCOW"},
                                     /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("SW");
-            SingleRecordTable::checkMonotonic("SW", /*isAscending=*/true);
-            SingleRecordTable::applyDefaultsLinear("KRW");
-            SingleRecordTable::applyDefaultsLinear("KROW");
-            SingleRecordTable::applyDefaultsLinear("PCOW");
+            SimpleTable::checkNonDefaultable("SW");
+            SimpleTable::checkMonotonic("SW", /*isAscending=*/true);
+            SimpleTable::applyDefaultsLinear("KRW");
+            SimpleTable::applyDefaultsLinear("KROW");
+            SimpleTable::applyDefaultsLinear("PCOW");
         }
 
     public:
@@ -55,24 +55,24 @@ namespace Opm {
         { init(record); }
 #endif
 
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getSwColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getKrwColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
 
         const std::vector<double> &getKrowColumn() const
-        { return SingleRecordTable::getColumn(2); }
+        { return SimpleTable::getColumn(2); }
 
         // this column is p_o - p_w (non-wetting phase pressure minus
         // wetting phase pressure for a given water saturation)
         const std::vector<double> &getPcowColumn() const
-        { return SingleRecordTable::getColumn(3); }
+        { return SimpleTable::getColumn(3); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class SwofTable : protected SingleRecordTable {
-        
 
         friend class TableManager;
 
@@ -34,13 +33,11 @@ namespace Opm {
          * \brief Read the SWOF keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword,
-                  int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
-                             std::vector<std::string>{"SW", "KRW", "KROW", "PCOW"},
-                             recordIdx,
-                             /*firstEntityOffset=*/0);
+            SingleRecordTable::init(record,
+                                    std::vector<std::string>{"SW", "KRW", "KROW", "PCOW"},
+                                    /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("SW");
             SingleRecordTable::checkMonotonic("SW", /*isAscending=*/true);
@@ -54,8 +51,8 @@ namespace Opm {
 
 #ifdef BOOST_TEST_MODULE
         // DO NOT TRY TO CALL THIS METHOD! it is only for the unit tests!
-        void initFORUNITTESTONLY(Opm::DeckKeywordConstPtr keyword, size_t tableIdx)
-        { init(keyword, tableIdx); }
+        void initFORUNITTESTONLY(Opm::DeckRecordConstPtr record)
+        { init(record); }
 #endif
 
         using SingleRecordTable::numTables;

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -26,7 +26,7 @@ namespace Opm {
     class TableManager;
 
     class SwofTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
+        
 
         friend class TableManager;
 
@@ -37,16 +37,16 @@ namespace Opm {
         void init(Opm::DeckKeywordConstPtr keyword,
                   int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{"SW", "KRW", "KROW", "PCOW"},
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("SW");
-            ParentType::checkMonotonic("SW", /*isAscending=*/true);
-            ParentType::applyDefaultsLinear("KRW");
-            ParentType::applyDefaultsLinear("KROW");
-            ParentType::applyDefaultsLinear("PCOW");
+            SingleRecordTable::checkNonDefaultable("SW");
+            SingleRecordTable::checkMonotonic("SW", /*isAscending=*/true);
+            SingleRecordTable::applyDefaultsLinear("KRW");
+            SingleRecordTable::applyDefaultsLinear("KROW");
+            SingleRecordTable::applyDefaultsLinear("PCOW");
         }
 
     public:
@@ -58,24 +58,24 @@ namespace Opm {
         { init(keyword, tableIdx); }
 #endif
 
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getSwColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getKrwColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
 
         const std::vector<double> &getKrowColumn() const
-        { return ParentType::getColumn(2); }
+        { return SingleRecordTable::getColumn(2); }
 
         // this column is p_o - p_w (non-wetting phase pressure minus
         // wetting phase pressure for a given water saturation)
         const std::vector<double> &getPcowColumn() const
-        { return ParentType::getColumn(3); }
+        { return SingleRecordTable::getColumn(3); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -134,7 +134,7 @@ namespace Opm {
             }
 
             tableVector.push_back(GasvisctTable());
-            tableVector[tableIdx].init(deck, tableKeyword, tableIdx);
+            tableVector[tableIdx].init(deck, tableKeyword->getRecord(tableIdx));
         }
     }
 
@@ -192,10 +192,9 @@ namespace Opm {
             }
 
             m_rocktabTables.push_back(RocktabTable());
-            m_rocktabTables[tableIdx].init(rocktabKeyword,
+            m_rocktabTables[tableIdx].init(rocktabKeyword->getRecord( tableIdx ),
                                            isDirectional,
-                                           useStressOption,
-                                           tableIdx);
+                                           useStressOption);
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -137,7 +137,8 @@ namespace Opm {
 
             const auto& tableKeyword = deck.getKeyword(keywordName);
             for (size_t tableIdx = 0; tableIdx < tableKeyword->size(); ++tableIdx) {
-                if (tableKeyword->getRecord(tableIdx)->getItem(0)->size() == 0) {
+                const auto tableRecord = tableKeyword->getRecord( tableIdx );
+                if (tableRecord->getItem(0)->size() == 0) {
                     // for simple tables, an empty record indicates that the previous table
                     // should be copied...
                     if (tableIdx == 0) {
@@ -150,7 +151,7 @@ namespace Opm {
                 }
 
                 tableVector.push_back(TableType());
-                tableVector[tableIdx].init(tableKeyword, tableIdx);
+                tableVector[tableIdx].init(tableRecord);
             }
         }
 

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -34,14 +34,13 @@ namespace Opm {
          * \brief Read the WATVISCT keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
+        void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(keyword,
+            SingleRecordTable::init(record,
                              std::vector<std::string>{
                                  "Temperature",
                                  "Viscosity"
                              },
-                             recordIdx,
                              /*firstEntityOffset=*/0);
 
             SingleRecordTable::checkNonDefaultable("Temperature");

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -19,13 +19,13 @@
 #ifndef OPM_PARSER_WATVISCT_TABLE_HPP
 #define	OPM_PARSER_WATVISCT_TABLE_HPP
 
-#include "SingleRecordTable.hpp"
+#include "SimpleTable.hpp"
 
 namespace Opm {
     // forward declaration
     class TableManager;
 
-    class WatvisctTable : protected SingleRecordTable {
+    class WatvisctTable : protected SimpleTable {
 
         friend class TableManager;
         WatvisctTable() = default;
@@ -36,31 +36,31 @@ namespace Opm {
          */
         void init(Opm::DeckRecordConstPtr record)
         {
-            SingleRecordTable::init(record,
+            SimpleTable::init(record,
                              std::vector<std::string>{
                                  "Temperature",
                                  "Viscosity"
                              },
                              /*firstEntityOffset=*/0);
 
-            SingleRecordTable::checkNonDefaultable("Temperature");
-            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("Temperature");
+            SimpleTable::checkMonotonic("Temperature", /*isAscending=*/true);
 
-            SingleRecordTable::checkNonDefaultable("Viscosity");
-            SingleRecordTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SimpleTable::checkNonDefaultable("Viscosity");
+            SimpleTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using SingleRecordTable::numTables;
-        using SingleRecordTable::numRows;
-        using SingleRecordTable::numColumns;
-        using SingleRecordTable::evaluate;
+        using SimpleTable::numTables;
+        using SimpleTable::numRows;
+        using SimpleTable::numColumns;
+        using SimpleTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return SingleRecordTable::getColumn(0); }
+        { return SimpleTable::getColumn(0); }
 
         const std::vector<double> &getWaterViscosityColumn() const
-        { return SingleRecordTable::getColumn(1); }
+        { return SimpleTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -26,7 +26,6 @@ namespace Opm {
     class TableManager;
 
     class WatvisctTable : protected SingleRecordTable {
-        typedef SingleRecordTable ParentType;
 
         friend class TableManager;
         WatvisctTable() = default;
@@ -37,7 +36,7 @@ namespace Opm {
          */
         void init(Opm::DeckKeywordConstPtr keyword, int recordIdx)
         {
-            ParentType::init(keyword,
+            SingleRecordTable::init(keyword,
                              std::vector<std::string>{
                                  "Temperature",
                                  "Viscosity"
@@ -45,24 +44,24 @@ namespace Opm {
                              recordIdx,
                              /*firstEntityOffset=*/0);
 
-            ParentType::checkNonDefaultable("Temperature");
-            ParentType::checkMonotonic("Temperature", /*isAscending=*/true);
+            SingleRecordTable::checkNonDefaultable("Temperature");
+            SingleRecordTable::checkMonotonic("Temperature", /*isAscending=*/true);
 
-            ParentType::checkNonDefaultable("Viscosity");
-            ParentType::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
+            SingleRecordTable::checkNonDefaultable("Viscosity");
+            SingleRecordTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
     public:
-        using ParentType::numTables;
-        using ParentType::numRows;
-        using ParentType::numColumns;
-        using ParentType::evaluate;
+        using SingleRecordTable::numTables;
+        using SingleRecordTable::numRows;
+        using SingleRecordTable::numColumns;
+        using SingleRecordTable::evaluate;
 
         const std::vector<double> &getTemperatureColumn() const
-        { return ParentType::getColumn(0); }
+        { return SingleRecordTable::getColumn(0); }
 
         const std::vector<double> &getWaterViscosityColumn() const
-        { return ParentType::getColumn(1); }
+        { return SingleRecordTable::getColumn(1); }
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -17,7 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE SingleRecordTableTests
+#define BOOST_TEST_MODULE SimpleTableTests
 
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
@@ -28,7 +28,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 // generic table classes
-#include <opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/FullTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
@@ -75,7 +75,7 @@ BOOST_AUTO_TEST_CASE( CreateTables ) {
 
 /*****************************************************************/
 
-BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
+BOOST_AUTO_TEST_CASE(CreateSimpleTable) {
     const char *deckData =
         "TABDIMS\n"
         " 2 /\n"
@@ -92,8 +92,8 @@ BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
     std::vector<std::string> justRightColumnNames{"A", "B", "C", "D"};
     std::vector<std::string> tooManyColumnNames{"A", "B", "C", "D", "E"};
 
-    BOOST_CHECK_EQUAL(Opm::SingleRecordTable::numTables(deck->getKeyword("SWOF")), 2);
-    Opm::SingleRecordTable tmpTable;
+    BOOST_CHECK_EQUAL(Opm::SimpleTable::numTables(deck->getKeyword("SWOF")), 2);
+    Opm::SimpleTable tmpTable;
     BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                                    tooFewColumnNames,
                                                    /*firstEntryOffset=*/0),

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -94,20 +94,17 @@ BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
 
     BOOST_CHECK_EQUAL(Opm::SingleRecordTable::numTables(deck->getKeyword("SWOF")), 2);
     Opm::SingleRecordTable tmpTable;
-    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                                    tooFewColumnNames,
-                                                   /*recordIdx=*/0,
                                                    /*firstEntryOffset=*/0),
                       std::runtime_error);
-    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                                    tooManyColumnNames,
-                                                   /*recordIdx=*/0,
                                                    /*firstEntryOffset=*/0),
                       std::runtime_error);
 
-    tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+    tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                  justRightColumnNames,
-                                 /*recordIdx=*/0,
                                  /*firstEntryOffset=*/0);
 }
 
@@ -176,8 +173,8 @@ BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
     Opm::SwofTable swof1Table;
     Opm::SwofTable swof2Table;
 
-    swof1Table.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*tableIdx=*/0);
-    swof2Table.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*tableIdx=*/1);
+    swof1Table.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0));
+    swof2Table.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(1));
 
     BOOST_CHECK_EQUAL(swof1Table.numRows(), 2);
     BOOST_CHECK_EQUAL(swof2Table.numRows(), 3);
@@ -224,8 +221,8 @@ BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
     Opm::SgofTable sgof1Table;
     Opm::SgofTable sgof2Table;
 
-    sgof1Table.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*tableIdx=*/0);
-    sgof2Table.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*tableIdx=*/1);
+    sgof1Table.initFORUNITTESTONLY(deck->getKeyword("SGOF")->getRecord(0));
+    sgof2Table.initFORUNITTESTONLY(deck->getKeyword("SGOF")->getRecord(1));
 
     BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2);
     BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3);
@@ -274,7 +271,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
         BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
 
         Opm::PlyadsTable plyadsTable;
-        plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0);
+        plyadsTable.initFORUNITTESTONLY(plyadsKeyword->getRecord(0));
 
         BOOST_CHECK_CLOSE(plyadsTable.getPolymerConcentrationColumn().front(), 0.0, 1e-6);
         BOOST_CHECK_CLOSE(plyadsTable.getPolymerConcentrationColumn().back(), 3.0, 1e-6);
@@ -306,7 +303,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
         BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
 
         Opm::PlyadsTable plyadsTable;
-        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0), std::invalid_argument);
+        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword->getRecord(0)), std::invalid_argument);
     }
 
     {
@@ -332,7 +329,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
         BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
 
         Opm::PlyadsTable plyadsTable;
-        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0), std::invalid_argument);
+        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword->getRecord(0)), std::invalid_argument);
     }
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableTests.cpp
@@ -66,20 +66,17 @@ BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
 
     BOOST_CHECK_EQUAL(Opm::SingleRecordTable::numTables(deck->getKeyword("SWOF")), 2);
     Opm::SingleRecordTable tmpTable;
-    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                                    tooFewColumnNames,
-                                                   /*recordIdx=*/0,
                                                    /*firstEntryOffset=*/0),
                       std::runtime_error);
-    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+    BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                                    tooManyColumnNames,
-                                                   /*recordIdx=*/0,
                                                    /*firstEntryOffset=*/0),
                       std::runtime_error);
 
-    tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"),
+    tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                  justRightColumnNames,
-                                 /*recordIdx=*/0,
                                  /*firstEntryOffset=*/0);
 }
 
@@ -148,8 +145,8 @@ BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
     Opm::SwofTable swof1Table;
     Opm::SwofTable swof2Table;
 
-    swof1Table.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*tableIdx=*/0);
-    swof2Table.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*tableIdx=*/1);
+    swof1Table.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0));
+    swof2Table.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(1));
 
     BOOST_CHECK_EQUAL(swof1Table.numRows(), 2);
     BOOST_CHECK_EQUAL(swof2Table.numRows(), 3);
@@ -196,8 +193,8 @@ BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
     Opm::SgofTable sgof1Table;
     Opm::SgofTable sgof2Table;
 
-    sgof1Table.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*tableIdx=*/0);
-    sgof2Table.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*tableIdx=*/1);
+    sgof1Table.initFORUNITTESTONLY(deck->getKeyword("SGOF")->getRecord(0));
+    sgof2Table.initFORUNITTESTONLY(deck->getKeyword("SGOF")->getRecord(1));
 
     BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2);
     BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3);
@@ -246,7 +243,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
         BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
 
         Opm::PlyadsTable plyadsTable;
-        plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0);
+        plyadsTable.initFORUNITTESTONLY(plyadsKeyword->getRecord(0));
 
         BOOST_CHECK_CLOSE(plyadsTable.getPolymerConcentrationColumn().front(), 0.0, 1e-6);
         BOOST_CHECK_CLOSE(plyadsTable.getPolymerConcentrationColumn().back(), 3.0, 1e-6);
@@ -278,7 +275,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
         BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
 
         Opm::PlyadsTable plyadsTable;
-        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0), std::invalid_argument);
+        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword->getRecord(0)), std::invalid_argument);
     }
 
     {
@@ -304,7 +301,7 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
         BOOST_CHECK_EQUAL(Opm::PlyadsTable::numTables(plyadsKeyword), 1);
 
         Opm::PlyadsTable plyadsTable;
-        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword, /*tableIdx=*/0), std::invalid_argument);
+        BOOST_CHECK_THROW(plyadsTable.initFORUNITTESTONLY(plyadsKeyword->getRecord(0)), std::invalid_argument);
     }
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableTests.cpp
@@ -17,7 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE SingleRecordTableTests
+#define BOOST_TEST_MODULE SimpleTableTests
 
 #include <opm/core/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
@@ -28,7 +28,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
 // generic table classes
-#include <opm/parser/eclipse/EclipseState/Tables/SingleRecordTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/FullTable.hpp>
 
@@ -47,7 +47,7 @@
 #include <stdexcept>
 #include <iostream>
 
-BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
+BOOST_AUTO_TEST_CASE(CreateSimpleTable) {
     const char *deckData =
         "TABDIMS\n"
         " 2 /\n"
@@ -64,8 +64,8 @@ BOOST_AUTO_TEST_CASE(CreateSingleRecordTable) {
     std::vector<std::string> justRightColumnNames{"A", "B", "C", "D"};
     std::vector<std::string> tooManyColumnNames{"A", "B", "C", "D", "E"};
 
-    BOOST_CHECK_EQUAL(Opm::SingleRecordTable::numTables(deck->getKeyword("SWOF")), 2);
-    Opm::SingleRecordTable tmpTable;
+    BOOST_CHECK_EQUAL(Opm::SimpleTable::numTables(deck->getKeyword("SWOF")), 2);
+    Opm::SimpleTable tmpTable;
     BOOST_CHECK_THROW(tmpTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0),
                                                    tooFewColumnNames,
                                                    /*firstEntryOffset=*/0),

--- a/opm/parser/eclipse/IntegrationTests/ParseSGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSGOF.cpp
@@ -50,7 +50,7 @@ static void check_parser(ParserPtr parser) {
 static void check_SgofTable(ParserPtr parser) {
     DeckPtr deck =  parser->parseString(parserData, ParseMode());
     Opm::SgofTable sgofTable;
-    sgofTable.initFORUNITTESTONLY(deck->getKeyword("SGOF"), /*recordIdx=*/0);
+    sgofTable.initFORUNITTESTONLY(deck->getKeyword("SGOF")->getRecord(0));
 
     BOOST_CHECK_EQUAL(10U, sgofTable.getSgColumn().size());
     BOOST_CHECK_EQUAL(0.1, sgofTable.getSgColumn()[0]);

--- a/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
@@ -50,7 +50,7 @@ static void check_parser(ParserPtr parser) {
 static void check_SlgofTable(ParserPtr parser) {
     DeckPtr deck =  parser->parseString(parserData, ParseMode());
     Opm::SlgofTable slgofTable;
-    slgofTable.initFORUNITTESTONLY(deck->getKeyword("SLGOF"), /*recordIdx=*/0);
+    slgofTable.initFORUNITTESTONLY(deck->getKeyword("SLGOF")->getRecord(0));
 
     BOOST_CHECK_EQUAL(10U, slgofTable.getSlColumn().size());
     BOOST_CHECK_EQUAL(0.1, slgofTable.getSlColumn()[0]);

--- a/opm/parser/eclipse/IntegrationTests/ParseSWOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSWOF.cpp
@@ -70,7 +70,7 @@ static void check_parser(ParserPtr parser) {
 static void check_SwofTable(ParserPtr parser) {
     DeckPtr deck =  parser->parseString(parserData, ParseMode());
     Opm::SwofTable swofTable;
-    swofTable.initFORUNITTESTONLY(deck->getKeyword("SWOF"), /*recordIdx=*/0);
+    swofTable.initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0));
 
     BOOST_CHECK_EQUAL(10U, swofTable.getSwColumn().size());
     BOOST_CHECK_CLOSE(0.1, swofTable.getSwColumn()[0], 1e-8);


### PR DESCRIPTION
1. Removed superfluous `typedef  SingleRecordTable ParentType; `
2. `SIngleRecordTable::init( )` takes `DeckRecord` instead `( DeckKeyword , recordIndex )` pair as input. 

No downstream changes.