### PR TITLE
Added BEFORE attribute to include_directories( )

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,9 @@ include(UseWarnings)
 # Requires BOOST filesystem version 3, thus 1.44 is necessary.
 add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
 find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_framework regex REQUIRED)
-include_directories(${PROJECT_SOURCE_DIR} ${Boost_INCLUDE_DIRS})
+include_directories(${Boost_INCLUDE_DIRS})
+
+include_directories(BEFORE ${PROJECT_SOURCE_DIR})
 
 # if we are using dynamic boost, the header file must generate a main() function
 if (NOT Boost_USE_STATIC_LIBS)

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${PROJECT_BINARY_DIR}/generated-source/include)
+include_directories(BEFORE ${PROJECT_BINARY_DIR}/generated-source/include)
 
 add_subdirectory(OpmLog/tests)
 add_subdirectory(Parser/tests)


### PR DESCRIPTION
The 'deploy flow' workflow I currently use is as follows:

```python
for module in [opm-common, opm-parser, opm-material, ....] 
     git fetch & checkout
     cmake -DCMAKE_INSTALL_PREFIX=/path/to/install -DCMAKE_PREFIX_PATH=/path/to/install ...
     make install
```

I.e. the modules are built and installed in order, where each downstream module typically finds it's dependencies in the already installed location. This works reasonably well - but I just had problems compiling the parser - because instead of using the in-source version of an include file, it found an old version in the installation directory. So to solve(?) this I have added `BEFORE` when configuring the include directories for the parser:

1. Is this frowned upon?
2. If it is indeed a valid way to do it - I guess the same could be applied to the rest of the modules?

Yes: I know the best way would probably be to wipe the installation directory prior to installing; but I do make programming mistakes every now and then - and feel quite uncomfortable having something akin to `rm -rf *` in a jenkins script. 
