### PR TITLE
Table container

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,9 @@ endif()
 include( cmake/Modules/CheckCaseSensitiveFileSystem.cmake )
 add_definitions("-DHAVE_CASE_SENSITIVE_FILESYSTEM=${HAVE_CASE_SENSITIVE_FILESYSTEM}")
 
+find_package(opm-common REQUIRED)
 include( Findopm-data )
+
 find_package(ERT)
 include_directories( ${ERT_INCLUDE_DIRS} )   
 

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -107,6 +107,7 @@ EclipseState/Tables/MultiRecordTable.cpp
 EclipseState/Tables/VFPProdTable.cpp
 EclipseState/Tables/VFPInjTable.cpp
 EclipseState/Tables/TableManager.cpp
+EclipseState/Tables/TableContainer.cpp
 #
 EclipseState/Grid/GridProperty.cpp
 EclipseState/Grid/Box.cpp
@@ -259,6 +260,7 @@ EclipseState/Tables/PvtgOuterTable.hpp
 EclipseState/Tables/VFPProdTable.hpp
 EclipseState/Tables/VFPInjTable.hpp
 EclipseState/Tables/TableManager.hpp
+EclipseState/Tables/TableContainer.hpp
 #
 Utility/WconinjeWrapper.hpp
 Utility/CompdatWrapper.hpp

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -220,6 +220,7 @@ EclipseState/SimulationConfig/ThresholdPressure.hpp
 EclipseState/IOConfig/IOConfig.hpp
 #
 EclipseState/Tables/Tabdims.hpp
+EclipseState/Tables/Eqldims.hpp
 EclipseState/Tables/PlyadsTable.hpp
 EclipseState/Tables/PvtoOuterTable.hpp
 EclipseState/Tables/RocktabTable.hpp

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -221,6 +221,7 @@ EclipseState/IOConfig/IOConfig.hpp
 #
 EclipseState/Tables/Tabdims.hpp
 EclipseState/Tables/Eqldims.hpp
+EclipseState/Tables/Regdims.hpp
 EclipseState/Tables/PlyadsTable.hpp
 EclipseState/Tables/PvtoOuterTable.hpp
 EclipseState/Tables/RocktabTable.hpp

--- a/opm/parser/eclipse/EclipseState/Grid/GridPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridPropertyInitializers.hpp
@@ -30,6 +30,8 @@
 #include <cassert>
 
 #include <opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 
 
@@ -104,12 +106,12 @@ public:
 
         auto tables = m_eclipseState.getTableManager();
         auto eclipseGrid = m_eclipseState.getEclipseGrid();
-        const std::vector<RtempvdTable>& rtempvdTables = tables->getRtempvdTables();
+        const TableContainer& rtempvdTables = tables->getRtempvdTables();
         const std::vector<int>& eqlNum = m_eclipseState.getIntGridProperty("EQLNUM")->getData();
 
         for (size_t cellIdx = 0; cellIdx < eqlNum.size(); ++ cellIdx) {
             int cellEquilNum = eqlNum[cellIdx];
-            const RtempvdTable& rtempvdTable = rtempvdTables[cellEquilNum];
+            const RtempvdTable& rtempvdTable = rtempvdTables.getTable<RtempvdTable>(cellEquilNum);
             double cellDepth = std::get<2>(eclipseGrid->getCellCenter(cellIdx));
             values[cellIdx] = rtempvdTable.evaluate("Temperature", cellDepth);
         }

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -468,8 +468,8 @@ protected:
     }
 
 
-    template <class TableType>
-    double selectValue(const std::vector<TableType>& depthTables,
+
+    double selectValue(const TableContainer& depthTables,
                        int tableIdx,
                        const std::string& columnName,
                        double cellDepth,
@@ -478,11 +478,12 @@ protected:
         double value = fallbackValue;
 
         if (tableIdx >= 0) {
+            const SimpleTable& table = depthTables.getTable( tableIdx );
             if (tableIdx >= static_cast<int>(depthTables.size()))
                 throw std::invalid_argument("Not enough tables!");
 
             // evaluate the table at the cell depth
-            value = depthTables[tableIdx].evaluate(columnName, cellDepth);
+            value = table.evaluate(columnName, cellDepth);
 
             if (!std::isfinite(value))
                 // a column can be fully defaulted. In this case, eval() returns a NaN
@@ -616,7 +617,7 @@ public:
         // sampling points. Both of these are outside the scope of opm-parser, so we just
         // assign a NaN in this case...
         bool useImptvd = this->m_deck.hasKeyword("IMPTVD");
-        const auto& imptvdTables = tables->getImptvdTables();
+        const TableContainer& imptvdTables = tables->getImptvdTables();
         for (size_t cellIdx = 0; cellIdx < eclipseGrid->getCartesianSize(); cellIdx++) {
             int imbTableIdx = imbnum->iget( cellIdx ) - 1;
             int endNum = endnum->iget( cellIdx ) - 1;

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -92,30 +92,30 @@ protected:
         switch (getSaturationFunctionFamily()) {
         case SaturationFunctionFamily::FamilyI:
         {
-            const std::vector<SwofTable>& swofTables = tables->getSwofTables();
-            assert(swofTables.size() == numSatTables);
+            const TableContainer& swofTables = tables->getSwofTables();
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
-                m_minWaterSat[tableIdx] = swofTables[tableIdx].getSwColumn().front();
-                m_maxWaterSat[tableIdx] = swofTables[tableIdx].getSwColumn().back();
+                const SwofTable& swofTable = swofTables.getTable<SwofTable>(tableIdx);
+                m_minWaterSat[tableIdx] = swofTable.getSwColumn().front();
+                m_maxWaterSat[tableIdx] = swofTable.getSwColumn().back();
             }
 
             {
-                const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-                const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
+                const TableContainer& sgofTables  = tables->getSgofTables();
+                const TableContainer& slgofTables = tables->getSlgofTables();
 
                 if (!sgofTables.empty()) {
-                    assert(sgofTables.size() == numSatTables);
                     for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
-                        m_minGasSat[tableIdx] = sgofTables[tableIdx].getSgColumn().front();
-                        m_maxGasSat[tableIdx] = sgofTables[tableIdx].getSgColumn().back();
+                        const SgofTable& sgofTable = sgofTables.getTable<SgofTable>( tableIdx );
+                        m_minGasSat[tableIdx] = sgofTable.getSgColumn().front();
+                        m_maxGasSat[tableIdx] = sgofTable.getSgColumn().back();
                     }
                 }
                 else {
                     assert(!slgofTables.empty());
-                    assert(slgofTables.size() == numSatTables);
                     for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
-                        m_minGasSat[tableIdx] = 1.0 - slgofTables[tableIdx].getSlColumn().back();
-                        m_maxGasSat[tableIdx] = 1.0 - slgofTables[tableIdx].getSlColumn().front();
+                        const SlgofTable& slgofTable = slgofTables.getTable<SlgofTable>( tableIdx );
+                        m_minGasSat[tableIdx] = 1.0 - slgofTable.getSlColumn().back();
+                        m_maxGasSat[tableIdx] = 1.0 - slgofTable.getSlColumn().front();
                     }
                 }
             }
@@ -156,27 +156,28 @@ protected:
         switch (getSaturationFunctionFamily()) {
         case SaturationFunctionFamily::FamilyI:
         {
-            const std::vector<SwofTable>& swofTables = tables->getSwofTables();
+            const TableContainer& swofTables = tables->getSwofTables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 // find the critical water saturation
-                int numRows = swofTables[tableIdx].numRows();
-                const auto &krwCol = swofTables[tableIdx].getKrwColumn();
+                const SwofTable& swofTable = swofTables.getTable<SwofTable>( tableIdx );
+                int numRows = swofTable.numRows();
+                const auto &krwCol = swofTable.getKrwColumn();
                 for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
                     if (krwCol[rowIdx] > 0.0) {
                         double Sw = 0.0;
                         if (rowIdx > 0)
-                            Sw = swofTables[tableIdx].getSwColumn()[rowIdx - 1];
+                            Sw = swofTable.getSwColumn()[rowIdx - 1];
                         m_criticalWaterSat[tableIdx] = Sw;
                         break;
                     }
                 }
 
                 // find the critical oil saturation of the water-oil system
-                const auto &kroOWCol = swofTables[tableIdx].getKrowColumn();
+                const auto &kroOWCol = swofTable.getKrowColumn();
                 for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
                     if (kroOWCol[rowIdx] > 0.0) {
-                        double Sw = swofTables[tableIdx].getSwColumn()[rowIdx + 1];
+                        double Sw = swofTable.getSwColumn()[rowIdx + 1];
                         m_criticalOilOWSat[tableIdx] = 1 - Sw;
                         break;
                     }
@@ -184,29 +185,30 @@ protected:
             }
 
             {
-                const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-                const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
+                const TableContainer& sgofTables = tables->getSgofTables();
+                const TableContainer& slgofTables = tables->getSlgofTables();
 
                 if (!sgofTables.empty()) {
                     for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                        const SgofTable& sgofTable = sgofTables.getTable<SgofTable>( tableIdx );
                         // find the critical gas saturation
-                        int numRows = sgofTables[tableIdx].numRows();
-                        const auto &krgCol = sgofTables[tableIdx].getKrgColumn();
+                        int numRows = sgofTable.numRows();
+                        const auto &krgCol = sgofTable.getKrgColumn();
                         for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
                             if (krgCol[rowIdx] > 0.0) {
                                 double Sg = 0.0;
                                 if (rowIdx > 0)
-                                    Sg = sgofTables[tableIdx].getSgColumn()[rowIdx - 1];
+                                    Sg = sgofTable.getSgColumn()[rowIdx - 1];
                                 m_criticalGasSat[tableIdx] = Sg;
                                 break;
                             }
                         }
 
                         // find the critical oil saturation of the oil-gas system
-                        const auto &kroOGCol = sgofTables[tableIdx].getKrogColumn();
+                        const auto &kroOGCol = sgofTable.getKrogColumn();
                         for (int rowIdx = numRows - 1; rowIdx >= 0; --rowIdx) {
                             if (kroOGCol[rowIdx] > 0.0) {
-                                double Sg = sgofTables[tableIdx].getSgColumn()[rowIdx + 1];
+                                double Sg = sgofTable.getSgColumn()[rowIdx + 1];
                                 m_criticalOilOGSat[tableIdx] = 1 - Sg;
                                 break;
                             }
@@ -215,26 +217,26 @@ protected:
                 }
                 else {
                     assert(!slgofTables.empty());
-                    assert(slgofTables.size() == numSatTables);
                     for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                        const SlgofTable& slgofTable = slgofTables.getTable<SlgofTable>( tableIdx );
                         // find the critical gas saturation
-                        int numRows = slgofTables[tableIdx].numRows();
-                        const auto &krgCol = slgofTables[tableIdx].getKrgColumn();
+                        int numRows = slgofTable.numRows();
+                        const auto &krgCol = slgofTable.getKrgColumn();
                         for (int rowIdx = numRows - 1; rowIdx >= 0; -- rowIdx) {
                             if (krgCol[rowIdx] > 0.0) {
                                 assert(rowIdx < numRows - 1);
                                 m_criticalGasSat[tableIdx] =
-                                    1.0 - slgofTables[tableIdx].getSlColumn()[rowIdx + 1];
+                                    1.0 - slgofTable.getSlColumn()[rowIdx + 1];
                                 break;
                             }
                         }
 
                         // find the critical oil saturation of the oil-gas system
-                        const auto &kroOGCol = slgofTables[tableIdx].getKrogColumn();
+                        const auto &kroOGCol = slgofTable.getKrogColumn();
                         for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
                             if (kroOGCol[rowIdx] > 0.0) {
                                 m_criticalOilOGSat[tableIdx] =
-                                    slgofTables[tableIdx].getSlColumn()[rowIdx + 1];
+                                    slgofTable.getSlColumn()[rowIdx + 1];
                                 break;
                             }
                         }
@@ -248,7 +250,7 @@ protected:
         case SaturationFunctionFamily::FamilyII: {
             const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
             const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
-            const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
+            const TableContainer& sof3Tables = tables->getSof3Tables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
                 // find the critical water saturation
@@ -278,24 +280,26 @@ protected:
                 }
 
                 // find the critical oil saturation of the oil-gas system
-                numRows = sof3Tables[tableIdx].numRows();
-                const auto &kroOGCol = sof3Tables[tableIdx].getKrogColumn();
-                for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-                    if (kroOGCol[rowIdx] > 0.0) {
-                        double So = sof3Tables[tableIdx].getSoColumn()[rowIdx - 1];
-                        m_criticalOilOGSat[tableIdx] = So;
-                        break;
+                {
+                    const Sof3Table& sof3Table = sof3Tables.getTable<Sof3Table>( tableIdx );
+                    size_t numRows = sof3Table.numRows();
+                    const auto &kroOGCol = sof3Table.getKrogColumn();
+                    for (size_t rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+                        if (kroOGCol[rowIdx] > 0.0) {
+                            double So = sof3Table.getSoColumn()[rowIdx - 1];
+                            m_criticalOilOGSat[tableIdx] = So;
+                            break;
+                        }
                     }
-                }
 
-                // find the critical oil saturation of the water-oil system
-                numRows = sof3Tables[tableIdx].numRows();
-                const auto &kroOWCol = sof3Tables[tableIdx].getKrowColumn();
-                for (int rowIdx = 0; rowIdx < numRows; ++rowIdx) {
-                    if (kroOWCol[rowIdx] > 0.0) {
-                        double So = sof3Tables[tableIdx].getSoColumn()[rowIdx - 1];
-                        m_criticalOilOWSat[tableIdx] = So;
-                        break;
+                    // find the critical oil saturation of the water-oil system
+                    const auto &kroOWCol = sof3Table.getKrowColumn();
+                    for (size_t rowIdx = 0; rowIdx < numRows; ++rowIdx) {
+                        if (kroOWCol[rowIdx] > 0.0) {
+                            double So = sof3Table.getSoColumn()[rowIdx - 1];
+                            m_criticalOilOWSat[tableIdx] = So;
+                            break;
+                        }
                     }
                 }
             }
@@ -327,20 +331,22 @@ protected:
         switch (getSaturationFunctionFamily()) {
         case SaturationFunctionFamily::FamilyI:
         {
-            const std::vector<SwofTable>& swofTables = tables->getSwofTables();
-            const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
+            const TableContainer& swofTables = tables->getSwofTables();
+            const TableContainer& sgofTables = tables->getSgofTables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                const SwofTable& swofTable = swofTables.getTable<SwofTable>(tableIdx);
+                const SgofTable& sgofTable = sgofTables.getTable<SgofTable>(tableIdx);
                 // find the maximum output values of the oil-gas system
-                m_maxPcog[tableIdx] = sgofTables[tableIdx].getPcogColumn().front();
-                m_maxKrg[tableIdx] = sgofTables[tableIdx].getKrgColumn().back();
+                m_maxPcog[tableIdx] = sgofTable.getPcogColumn().front();
+                m_maxKrg[tableIdx] = sgofTable.getKrgColumn().back();
 
-                m_krgr[tableIdx] = sgofTables[tableIdx].getKrgColumn().front();
-                m_krwr[tableIdx] = swofTables[tableIdx].getKrwColumn().front();
+                m_krgr[tableIdx] = sgofTable.getKrgColumn().front();
+                m_krwr[tableIdx] = swofTable.getKrwColumn().front();
 
                 // find the oil relperm which corresponds to the critical water saturation
-                const auto &krwCol = swofTables[tableIdx].getKrwColumn();
-                const auto &krowCol = swofTables[tableIdx].getKrowColumn();
+                const auto &krwCol = swofTable.getKrwColumn();
+                const auto &krowCol = swofTable.getKrowColumn();
                 for (size_t rowIdx = 0; rowIdx < krwCol.size(); ++rowIdx) {
                     if (krwCol[rowIdx] > 0.0) {
                         m_krorw[tableIdx] = krowCol[rowIdx - 1];
@@ -349,8 +355,8 @@ protected:
                 }
 
                 // find the oil relperm which corresponds to the critical gas saturation
-                const auto &krgCol = sgofTables[tableIdx].getKrgColumn();
-                const auto &krogCol = sgofTables[tableIdx].getKrogColumn();
+                const auto &krgCol = sgofTable.getKrgColumn();
+                const auto &krogCol = sgofTable.getKrogColumn();
                 for (size_t rowIdx = 0; rowIdx < krgCol.size(); ++rowIdx) {
                     if (krgCol[rowIdx] > 0.0) {
                         m_krorg[tableIdx] = krogCol[rowIdx - 1];
@@ -366,18 +372,20 @@ protected:
                 // scaling the resultant threephase oil relperm, but then the gas saturation
                 // is not taken into account which means that some twophase quantity must be
                 // scaled.
-                m_maxPcow[tableIdx] = swofTables[tableIdx].getPcowColumn().front();
-                m_maxKro[tableIdx] = swofTables[tableIdx].getKrowColumn().front();
-                m_maxKrw[tableIdx] = swofTables[tableIdx].getKrwColumn().back();
+                m_maxPcow[tableIdx] = swofTable.getPcowColumn().front();
+                m_maxKro[tableIdx] = swofTable.getKrowColumn().front();
+                m_maxKrw[tableIdx] = swofTable.getKrwColumn().back();
             }
             break;
         }
         case SaturationFunctionFamily::FamilyII: {
             const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
             const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
-            const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
+            const TableContainer& sof3Tables = tables->getSof3Tables();
 
             for (size_t tableIdx = 0; tableIdx < numSatTables; ++tableIdx) {
+                const Sof3Table& sof3Table = sof3Tables.getTable<Sof3Table>( tableIdx );
+
                 // find the maximum output values of the oil-gas system
                 m_maxPcog[tableIdx] = sgfnTables[tableIdx].getPcogColumn().back();
                 m_maxKrg[tableIdx] = sgfnTables[tableIdx].getKrgColumn().back();
@@ -388,11 +396,11 @@ protected:
 
                 // find the oil relperm which corresponds to the critical water saturation
                 const double OilSatAtcritialWaterSat = 1.0 - m_criticalWaterSat[tableIdx] - m_minGasSat[tableIdx];
-                m_krorw[tableIdx] = sof3Tables[tableIdx].evaluate("KROW", OilSatAtcritialWaterSat);
+                m_krorw[tableIdx] = sof3Table.evaluate("KROW", OilSatAtcritialWaterSat);
 
                 // find the oil relperm which corresponds to the critical gas saturation
                 const double OilSatAtCritialGasSat = 1.0 - m_criticalGasSat[tableIdx] - m_minWaterSat[tableIdx];
-                m_krorg[tableIdx] = sof3Tables[tableIdx].evaluate("KROG", OilSatAtCritialGasSat);
+                m_krorg[tableIdx] = sof3Table.evaluate("KROG", OilSatAtCritialGasSat);
 
                 // find the maximum output values of the water-oil system. the maximum oil
                 // relperm is possibly wrong because we have two oil relperms in a threephase
@@ -403,7 +411,7 @@ protected:
                 // is not taken into account which means that some twophase quantity must be
                 // scaled.
                 m_maxPcow[tableIdx] = swfnTables[tableIdx].getPcowColumn().front();
-                m_maxKro[tableIdx] = sof3Tables[tableIdx].getKrowColumn().back();
+                m_maxKro[tableIdx] = sof3Table.getKrowColumn().back();
                 m_maxKrw[tableIdx] = swfnTables[tableIdx].getKrwColumn().back();
             }
             break;
@@ -420,13 +428,15 @@ protected:
     // If keywords are missing or mixed, an error is given.
     const SaturationFunctionFamily getSaturationFunctionFamily() const{
         auto tables = m_eclipseState.getTableManager( );
-        const std::vector<SwofTable>& swofTables = tables->getSwofTables();
-        const std::vector<SgofTable>& sgofTables = tables->getSgofTables();
-        const std::vector<SlgofTable>& slgofTables = tables->getSlgofTables();
+        const TableContainer& swofTables = tables->getSwofTables();
+        const TableContainer& sgofTables = tables->getSgofTables();
+        const TableContainer& slgofTables = tables->getSlgofTables();
+        const TableContainer& sof3Tables = tables->getSof3Tables();
         const std::vector<SwfnTable>& swfnTables = tables->getSwfnTables();
         const std::vector<SgfnTable>& sgfnTables = tables->getSgfnTables();
-        const std::vector<Sof3Table>& sof3Tables = tables->getSof3Tables();
 
+
+        std::cout << "SGOF.empty() " << sgofTables.empty() << " SWOF.empty() " << swofTables.empty() << std::endl;
         bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
 

--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -445,7 +445,6 @@ protected:
         const TableContainer& sgfnTables = tables->getSgfnTables();
 
 
-        std::cout << "SGOF.empty() " << sgofTables.empty() << " SWOF.empty() " << swofTables.empty() << std::endl;
         bool family1 = (!sgofTables.empty() || !slgofTables.empty()) && !swofTables.empty();
         bool family2 = !swfnTables.empty() && !sgfnTables.empty() && !sof3Tables.empty();
 

--- a/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class EnkrvdTable : protected SimpleTable {
-
+    class EnkrvdTable : public SimpleTable {
+    public:
 
         friend class TableManager;
         EnkrvdTable() = default;
@@ -58,7 +58,6 @@ namespace Opm {
             SimpleTable::applyDefaultsLinear("KROCRITW");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/EnptvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class EnptvdTable : protected SimpleTable {
-
+    class EnptvdTable : public SimpleTable {
+    public:
 
         friend class TableManager;
         EnptvdTable() = default;
@@ -60,7 +60,6 @@ namespace Opm {
             SimpleTable::applyDefaultsLinear("SOGCRIT");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
@@ -1,0 +1,83 @@
+/*
+  Copyright (C) 2015 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef EQLDIMS_HPP
+#define EQLDIMS_HPP
+
+/*
+  The Eqldims class is a small utility class designed to hold on to
+  the values from the EQLDIMS keyword.
+*/
+
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+
+namespace Opm {
+    class Eqldims {
+    public:
+
+        Eqldims() :
+            m_ntequl( ParserKeywords::EQLDIMS::NTEQUL::defaultValue ),
+            m_depth_nodes_p( ParserKeywords::EQLDIMS::DEPTH_NODES_P::defaultValue ),
+            m_depth_nodes_tab( ParserKeywords::EQLDIMS::DEPTH_NODES_TAB::defaultValue ),
+            m_nttrvd(  ParserKeywords::EQLDIMS::NTTRVD::defaultValue ),
+            m_nstrvd(  ParserKeywords::EQLDIMS::NSTRVD::defaultValue )
+        { }
+
+
+        Eqldims( size_t ntequl , size_t depth_nodes_p , size_t depth_nodes_tab , size_t nttrvd , size_t nstrvd) :
+            m_ntequl( ntequl ),
+            m_depth_nodes_p( depth_nodes_p ),
+            m_depth_nodes_tab( depth_nodes_tab ),
+            m_nttrvd( nttrvd ),
+            m_nstrvd( nstrvd )
+        { }
+
+        size_t getNumEquilRegions() const
+        {
+            return m_ntequl;
+        }
+
+        size_t getNumDepthNodesP() const
+        {
+            return m_depth_nodes_p;
+        }
+
+
+        size_t getNumDepthNodesTable() const
+        {
+            return m_depth_nodes_tab;
+        }
+
+        size_t getNumTracerTables() const
+        {
+            return m_nttrvd;
+        }
+
+        size_t getNumDepthNodesTracer() const
+        {
+            return m_nstrvd;
+        }
+    private:
+        size_t m_ntequl , m_depth_nodes_p , m_depth_nodes_tab , m_nttrvd , m_nstrvd;
+
+    };
+}
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/GasvisctTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class GasvisctTable : protected SimpleTable {
-
+    class GasvisctTable : public SimpleTable {
+    public:
         friend class TableManager;
         GasvisctTable() = default;
 
@@ -99,7 +99,6 @@ namespace Opm {
             }
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImkrvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class ImkrvdTable : protected SimpleTable {
-
+    class ImkrvdTable : public SimpleTable {
+    public:
         friend class TableManager;
         ImkrvdTable() = default;
 
@@ -58,7 +58,6 @@ namespace Opm {
             SimpleTable::applyDefaultsLinear("KROCRITW");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ImptvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class ImptvdTable : protected SimpleTable {
-
+    class ImptvdTable : public SimpleTable {
+    public:
 
         friend class TableManager;
         ImptvdTable() = default;
@@ -60,7 +60,6 @@ namespace Opm {
             SimpleTable::applyDefaultsLinear("SOGCRIT");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/OilvisctTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class OilvisctTable : protected SimpleTable {
-        
+    class OilvisctTable : public SimpleTable {
+    public:
 
         friend class TableManager;
         OilvisctTable() = default;
@@ -50,7 +50,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyadsTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyadsTable : protected SimpleTable {
-
+    class PlyadsTable : public SimpleTable {
+    public:
 
         friend class TableManager;
 
@@ -49,7 +49,6 @@ namespace Opm {
         }
 
 
-    public:
         PlyadsTable() = default;
 
 #ifdef BOOST_TEST_MODULE

--- a/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlydhflfTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlydhflfTable : protected SimpleTable {
-        
+    class PlydhflfTable : public SimpleTable {
+    public:
 
         friend class TableManager;
         PlydhflfTable() = default;
@@ -42,14 +42,13 @@ namespace Opm {
                                  "Temperature",
                                  "PolymerHalflife"
                                      });
-            
+
             SimpleTable::checkNonDefaultable("Temperetura");
             SimpleTable::checkMonotonic("Temperature", /*isAscending=*/true);
             SimpleTable::checkNonDefaultable("PolymerHalflife");
             SimpleTable::checkMonotonic("PolymerHalflife", /*isAscending=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlymaxTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlymaxTable : protected SimpleTable {
-
+    class PlymaxTable : public SimpleTable {
+    public:
         friend class TableManager;
         PlymaxTable() = default;
 
@@ -48,7 +48,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("C_POLYMER_MAX", /*isAscending=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyrockTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyrockTable : protected SimpleTable {
-
+    class PlyrockTable : public SimpleTable {
+    public:
         friend class TableManager;
         PlyrockTable() = default;
 
@@ -48,7 +48,6 @@ namespace Opm {
             }
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp
@@ -27,19 +27,17 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyshlogTable {
-
+    class PlyshlogTable : public SimpleTable {
+    public:
         friend class TableManager;
         PlyshlogTable() = default;
+
 
         /*!
          * \brief Read the PLYSHLOG keyword and provide some convenience
          *        methods for it.
          */
-        void init(Opm::DeckKeywordConstPtr keyword) {
-            Opm::DeckRecordConstPtr indexRecord = keyword->getRecord(0);
-            Opm::DeckRecordConstPtr dataRecord = keyword->getRecord(1);
-
+        void init(Opm::DeckRecordConstPtr indexRecord, Opm::DeckRecordConstPtr dataRecord) {
             {
                 const auto item = indexRecord->getItem<ParserKeywords::PLYSHLOG::REF_POLYMER_CONCENTRATION>();
                 setRefPolymerConcentration(item->getRawDouble(0));
@@ -63,16 +61,11 @@ namespace Opm {
                     setHasRefTemperature(false);
             }
 
-            m_data = new SimpleTable();
-            m_data->init(dataRecord->getItem<ParserKeywords::PLYSHLOG::DATA>(),
-                         std::vector<std::string>{
-                                "WaterVelocity",
-                                "ShearMultiplier"
-                                    });
-
-            m_data->checkNonDefaultable("WaterVelocity");
-            m_data->checkMonotonic("WaterVelocity", /*isAscending=*/true);
-            m_data->checkNonDefaultable("ShearMultiplier");
+            SimpleTable::init( dataRecord->getItem<ParserKeywords::PLYSHLOG::DATA>(),
+                               std::vector<std::string>{ "WaterVelocity", "ShearMultiplier" } );
+            SimpleTable::checkNonDefaultable("WaterVelocity");
+            SimpleTable::checkMonotonic("WaterVelocity", /*isAscending=*/true);
+            SimpleTable::checkNonDefaultable("ShearMultiplier");
 
         }
 
@@ -118,10 +111,10 @@ namespace Opm {
         }
 
         const std::vector<double> &getWaterVelocityColumn() const
-        { return m_data->getColumn(0); }
+        { return getColumn(0); }
 
         const std::vector<double> &getShearMultiplierColumn() const
-        { return m_data->getColumn(1); }
+        { return getColumn(1); }
 
 
     private:
@@ -131,9 +124,6 @@ namespace Opm {
 
         bool m_hasRefSalinity;
         bool m_hasRefTemperature;
-
-        SimpleTable *m_data;
-
     };
 
 }

--- a/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PlyviscTable : protected SimpleTable {
-        
+    class PlyviscTable : public SimpleTable {
+    public:
 
         friend class TableManager;
         PlyviscTable() = default;

--- a/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp
@@ -25,9 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PvdgTable : protected SimpleTable {
-        
-
+    class PvdgTable : public SimpleTable {
+    public:
         friend class TableManager;
 
         PvdgTable() = default;
@@ -51,7 +50,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp
@@ -25,9 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PvdoTable : protected SimpleTable {
-        
-
+    class PvdoTable : public SimpleTable {
+    public:
         friend class TableManager;
         PvdoTable() = default;
 
@@ -50,7 +49,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("MUO", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp
@@ -26,9 +26,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class PvdsTable : protected SimpleTable {
-        
-
+    class PvdsTable : public SimpleTable {
+    public:
         friend class TableManager;
 
         PvdsTable() = default;
@@ -52,7 +51,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("MUG", /*isAscending=*/true, /*strictlyMonotonic=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
@@ -1,0 +1,66 @@
+/*
+  Copyright (C) 2015 Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANREGILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef REGDIMS_HPP
+#define REGDIMS_HPP
+
+/*
+  The Regdims class is a small utility class designed to hold on to
+  the values from the REGDIMS keyword.
+*/
+
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
+
+namespace Opm {
+    class Regdims {
+    public:
+
+        Regdims() :
+            m_NTFIP( ParserKeywords::REGDIMS::NTFIP::defaultValue ),
+            m_NMFIPR( ParserKeywords::REGDIMS::NMFIPR::defaultValue ),
+            m_NRFREG( ParserKeywords::REGDIMS::NRFREG::defaultValue ),
+            m_NTFREG( ParserKeywords::REGDIMS::NTFREG::defaultValue ),
+            m_NPLMIX( ParserKeywords::REGDIMS::NPLMIX::defaultValue )
+        { }
+
+        Regdims(size_t ntfip , size_t nmfipr , size_t nrfregr , size_t ntfreg , size_t nplmix) :
+            m_NTFIP( ntfip ),
+            m_NMFIPR( nmfipr ),
+            m_NRFREG( nrfregr ),
+            m_NTFREG(  ntfreg ),
+            m_NPLMIX( nplmix )
+        {}
+
+
+        size_t getNPLMIX() const {
+            return m_NPLMIX;
+        }
+
+
+    private:
+        size_t m_NTFIP;
+        size_t m_NMFIPR;
+        size_t m_NRFREG;
+        size_t m_NTFREG;
+        size_t m_NPLMIX;
+    };
+}
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RocktabTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RocktabTable : protected SimpleTable {
-
+    class RocktabTable : public  SimpleTable {
+    public:
         friend class TableManager;
         RocktabTable() = default;
 
@@ -56,7 +56,6 @@ namespace Opm {
             }
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RsvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RsvdTable : protected SimpleTable {
-
+    class RsvdTable : public SimpleTable {
+    public:
         friend class TableManager;
         RsvdTable() = default;
 
@@ -45,7 +45,6 @@ namespace Opm {
             SimpleTable::checkNonDefaultable("RS");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RtempvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RtempvdTable : protected SimpleTable {
-
+    class RtempvdTable : public SimpleTable {
+    public:
         friend class TableManager;
         RtempvdTable() = default;
 
@@ -48,7 +48,6 @@ namespace Opm {
             SimpleTable::checkNonDefaultable("Temperature");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/RvvdTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class RvvdTable : protected SimpleTable {
-
+    class RvvdTable : public SimpleTable {
+    public:
         friend class TableManager;
 
         RvvdTable() = default;
@@ -46,7 +46,6 @@ namespace Opm {
             SimpleTable::checkNonDefaultable("RV");
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SgfnTable : protected SimpleTable {
+    class SgfnTable : public SimpleTable {
 
         friend class TableManager;
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SgofTable : protected SimpleTable {
+    class SgofTable : public SimpleTable {
         friend class TableManager;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SlgofTable : protected SimpleTable {
+    class SlgofTable : public SimpleTable {
         friend class TableManager;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof2Table.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class Sof2Table : protected SimpleTable {
+    class Sof2Table : public SimpleTable {
         friend class TableManager;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Sof3Table.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class Sof3Table : protected SimpleTable {
+    class Sof3Table : public SimpleTable {
         friend class TableManager;
 
         /*!

--- a/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SsfnTable : protected SimpleTable {
-
+    class SsfnTable : public SimpleTable {
+    public:
         friend class TableManager;
         SsfnTable() = default;
 
@@ -50,7 +50,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("SolventRelPermMultiplier", /*isAscending=*/true);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SwfnTable : protected SimpleTable {
+    class SwfnTable : public SimpleTable {
 
 
         friend class TableManager;

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class SwofTable : protected SimpleTable {
+    class SwofTable : public SimpleTable {
 
         friend class TableManager;
 

--- a/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -25,6 +25,7 @@
   the values from the TABDIMS keyword.
 */
 
+#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
 
 namespace Opm {
     class Tabdims {
@@ -35,6 +36,16 @@ namespace Opm {
           are ECLIPSE300 only and quite exotic. Here we only
           internalize the most common items.
         */
+        Tabdims() :
+            m_ntsfun( ParserKeywords::TABDIMS::NTSFUN::defaultValue ),
+            m_ntpvt( ParserKeywords::TABDIMS::NTPVT::defaultValue ),
+            m_nssfun( ParserKeywords::TABDIMS::NSSFUN::defaultValue ),
+            m_nppvt(  ParserKeywords::TABDIMS::NPPVT::defaultValue ),
+            m_ntfip(  ParserKeywords::TABDIMS::NTFIP::defaultValue ),
+            m_nrpvt(  ParserKeywords::TABDIMS::NRPVT::defaultValue )
+        { }
+
+
         Tabdims(size_t ntsfun, size_t ntpvt, size_t nssfun , size_t nppvt, size_t ntfip , size_t nrpvt) :
             m_ntsfun( ntsfun ),
             m_ntpvt( ntpvt ),
@@ -67,7 +78,6 @@ namespace Opm {
         size_t getNumRSNodes() const {
             return m_nrpvt;
         }
-
 
     private:
         size_t m_ntsfun,m_ntpvt,m_nssfun,m_nppvt,m_ntfip,m_nrpvt;

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -1,0 +1,75 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string>
+
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
+
+namespace Opm {
+
+    TableContainer::TableContainer(size_t maxTables) :
+        m_maxTables(maxTables)
+    {
+    }
+
+
+    bool TableContainer::empty() const {
+        return m_tables.empty();
+    }
+
+
+    size_t TableContainer::size() const {
+        return m_tables.size();
+    }
+
+
+    size_t TableContainer::hasTable(size_t tableNumber) const {
+        if (m_tables.find( tableNumber ) == m_tables.end())
+            return false;
+        else
+            return true;
+    }
+
+
+    const SimpleTable& TableContainer::getTable(size_t tableNumber) const {
+        if (tableNumber >= m_maxTables)
+            throw std::invalid_argument("TableContainer - invalid tableNumber");
+
+        if (hasTable(tableNumber)) {
+            auto pair = m_tables.find( tableNumber );
+            return *(pair->second.get());
+        } else {
+            if (tableNumber > 0)
+                return getTable( tableNumber - 1);
+            else
+                throw std::invalid_argument("TableContainer does not have any table in the range 0..." + std::to_string( tableNumber ));
+        }
+    }
+
+
+    void TableContainer::addTable(size_t tableNumber , std::shared_ptr<const SimpleTable> table) {
+        if (tableNumber >= m_maxTables)
+            throw std::invalid_argument("TableContainer has max: " + std::to_string( m_maxTables ) + " tables. Table number: " + std::to_string( tableNumber ) + " illegal.");
+
+        m_tables[tableNumber] = table;
+    }
+}
+
+
+

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -47,7 +47,7 @@ namespace Opm {
     }
 
 
-    const SimpleTable& TableContainer::getTable(size_t tableNumber) const {
+    const SimpleTable& TableContainer::operator[](size_t tableNumber) const {
         if (tableNumber >= m_maxTables)
             throw std::invalid_argument("TableContainer - invalid tableNumber");
 
@@ -56,7 +56,7 @@ namespace Opm {
             return *(pair->second.get());
         } else {
             if (tableNumber > 0)
-                return getTable( tableNumber - 1);
+                return (*this)[tableNumber - 1];
             else
                 throw std::invalid_argument("TableContainer does not have any table in the range 0..." + std::to_string( tableNumber ));
         }

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -31,7 +31,6 @@ namespace Opm {
 
 
     bool TableContainer::empty() const {
-        std::cout << "Size: " << m_tables.size() << " empty: " << m_tables.empty() << std::endl;
         return m_tables.empty();
     }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <string>
+#include <iostream>
 
 #include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 
@@ -30,6 +31,7 @@ namespace Opm {
 
 
     bool TableContainer::empty() const {
+        std::cout << "Size: " << m_tables.size() << " empty: " << m_tables.empty() << std::endl;
         return m_tables.empty();
     }
 
@@ -47,7 +49,7 @@ namespace Opm {
     }
 
 
-    const SimpleTable& TableContainer::operator[](size_t tableNumber) const {
+    const SimpleTable& TableContainer::getTable(size_t tableNumber) const {
         if (tableNumber >= m_maxTables)
             throw std::invalid_argument("TableContainer - invalid tableNumber");
 
@@ -56,12 +58,16 @@ namespace Opm {
             return *(pair->second.get());
         } else {
             if (tableNumber > 0)
-                return (*this)[tableNumber - 1];
+                return getTable(tableNumber -1);
             else
                 throw std::invalid_argument("TableContainer does not have any table in the range 0..." + std::to_string( tableNumber ));
         }
     }
 
+
+    const SimpleTable& TableContainer::operator[](size_t tableNumber) const {
+        return getTable(tableNumber);
+    }
 
     void TableContainer::addTable(size_t tableNumber , std::shared_ptr<const SimpleTable> table) {
         if (tableNumber >= m_maxTables)

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -74,7 +74,6 @@ namespace Opm {
           table N is not implemented use table N - 1 behavior.
         */
         size_t hasTable(size_t tableNumber) const;
-
         const SimpleTable& getTable(size_t tableNumber) const;
         const SimpleTable& operator[](size_t tableNumber) const;
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -1,0 +1,96 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_TABLE_CONTAINER_HPP
+#define OPM_TABLE_CONTAINER_HPP
+
+#include <cstddef>
+#include <memory>
+
+#include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>
+
+
+namespace Opm {
+
+    class TableContainer {
+        /*
+          The TableContainer class implements a simple map:
+          {tableNumber , Table}. The main functionality of the
+          TableContainer class is that the getTable method implements
+          the Eclipse behavior:
+
+             If table N is not implemented - use table N - 1.
+
+          The getTable() method will eventually throw an exception if
+          not even table 0 is there.
+
+          Consider the following code:
+
+            TableContainer container(10);
+
+            std::shared_ptr<TableType> table0 = std::make_shared<TableType>(...);
+            container.addTable( table0 , 0 )
+
+         We create a container with maximum 10 tables, and then we add
+         one single table at slot 0; then we have:
+
+            container.size()         == 1
+            container.hasTable( 0 )  == true
+            container.hasTable( 9 )  == false
+            container.hasTable(10 )  == false
+
+            container.getTable( 0 ) == container[9] == table0;
+            container.gteTable(10 ) ==> exception
+        */
+    public:
+        explicit TableContainer( size_t maxTables );
+        bool empty() const;
+
+        /*
+          This is the number of actual tables in the container.
+        */
+        size_t size() const;
+        void addTable(size_t tableNumber , std::shared_ptr<const SimpleTable> table);
+
+
+        /*
+          Observe that the hasTable() method does not invoke the "If
+          table N is not implemented use table N - 1 behavior.
+        */
+        size_t hasTable(size_t tableNumber) const;
+
+        const SimpleTable& getTable(size_t tableNumber) const;
+        const SimpleTable& operator[](size_t tableNumber) const;
+
+        template <class TableType>
+        const TableType& getTable(size_t tableNumber) const {
+            const SimpleTable &simpleTable = getTable( tableNumber );
+            const TableType * table = static_cast<const TableType *>( &simpleTable );
+            return *table;
+        }
+
+    private:
+        size_t m_maxTables;
+        std::map<size_t , std::shared_ptr<const SimpleTable> > m_tables;
+    };
+
+}
+
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -190,13 +190,13 @@ namespace Opm {
             initSimpleTableContainer<ImkrvdTable>( deck , "IMKRVD", numEndScaleTables);
             initSimpleTableContainer<ImptvdTable>( deck , "IMPTVD", numEndScaleTables);
         }
+        initSimpleTableContainer<PvdgTable>(deck, "PVDG", m_tabdims->getNumPVTTables());
+        initSimpleTableContainer<PvdoTable>(deck, "PVDO", m_tabdims->getNumPVTTables());
+        initSimpleTableContainer<PvdsTable>(deck, "PVDS", m_tabdims->getNumPVTTables());
 
         /*****************************************************************/
 
 
-        initSimpleTable(deck, "PVDG", m_pvdgTables);
-        initSimpleTable(deck, "PVDO", m_pvdoTables);
-        initSimpleTable(deck, "PVDS", m_pvdsTables);
         initSimpleTable(deck, "PLYADS", m_plyadsTables);
         initSimpleTable(deck, "PLYVISC", m_plyviscTables);
         initSimpleTable(deck, "PLYDHFLF", m_plydhflfTables);
@@ -483,17 +483,16 @@ namespace Opm {
         return getTables("IMPTVD");
     }
 
-
-    const std::vector<PvdgTable>& TableManager::getPvdgTables() const {
-        return m_pvdgTables;
+    const TableContainer& TableManager::getPvdgTables() const {
+        return getTables("PVDG");
     }
 
-    const std::vector<PvdoTable>& TableManager::getPvdoTables() const {
-        return m_pvdoTables;
+    const TableContainer& TableManager::getPvdoTables() const {
+        return getTables("PVDO");
     }
 
-    const std::vector<PvdsTable>& TableManager::getPvdsTables() const {
-        return m_pvdsTables;
+    const TableContainer& TableManager::getPvdsTables() const {
+        return getTables("PVDS");
     }
 
     const std::vector<OilvisctTable>& TableManager::getOilvisctTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -162,7 +162,6 @@ namespace Opm {
         /*
           initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
           initRocktabTables(deck);
-          initRTempTables(deck);
         */
         initSimpleTableContainer<SwofTable>(deck, "SWOF" , m_tabdims->getNumSatTables());
         initSimpleTableContainer<SgofTable>(deck, "SGOF" , m_tabdims->getNumSatTables());
@@ -195,7 +194,7 @@ namespace Opm {
         initSimpleTableContainer<OilvisctTable>(deck, "OILVISCT", m_tabdims->getNumPVTTables());
         initSimpleTableContainer<WatvisctTable>(deck, "WATVISCT", m_tabdims->getNumPVTTables());
         initGasvisctTables(deck);
-
+        initRTempTables(deck);
         /*****************************************************************/
 
 
@@ -207,7 +206,6 @@ namespace Opm {
         initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
         initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
         initRocktabTables(deck);
-        initRTempTables(deck);
     }
 
 
@@ -219,10 +217,9 @@ namespace Opm {
         if (deck.hasKeyword("TEMPVD") && deck.hasKeyword("RTEMPVD"))
             throw std::invalid_argument("The TEMPVD and RTEMPVD tables are mutually exclusive!");
         else if (deck.hasKeyword("TEMPVD"))
-            initSimpleTable(deck, "TEMPVD", m_rtempvdTables);
+            initSimpleTableContainer<RtempvdTable>(deck, "TEMPVD", "RTEMPVD", m_eqldims->getNumEquilRegions());
         else if (deck.hasKeyword("RTEMPVD"))
-            initSimpleTable(deck, "RTEMPVD", m_rtempvdTables);
-
+            initSimpleTableContainer<RtempvdTable>(deck, "RTEMPVD", "RTEMPVD" , m_eqldims->getNumEquilRegions());
     }
 
 
@@ -504,6 +501,11 @@ namespace Opm {
         return getTables("GASVISCT");
     }
 
+    const TableContainer& TableManager::getRtempvdTables() const {
+        return getTables("RTEMPVD");
+    }
+
+
     const std::vector<PlyadsTable>& TableManager::getPlyadsTables() const {
         return m_plyadsTables;
     }
@@ -531,11 +533,6 @@ namespace Opm {
     const std::vector<RocktabTable>& TableManager::getRocktabTables() const {
         return m_rocktabTables;
     }
-
-    const std::vector<RtempvdTable>& TableManager::getRtempvdTables() const {
-        return m_rtempvdTables;
-    }
-
 
     const std::vector<PvtgTable>& TableManager::getPvtgTables() const {
         return m_pvtgTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -36,30 +36,20 @@ namespace Opm {
 
 
     void TableManager::initTabdims(const Deck& deck) {
-        /*
-          The default values for the various number of tables is
-          embedded in the ParserKeyword("TABDIMS") instance; however
-          the EclipseState object does not have a dependency on the
-          Parser classes, have therefor decided not to add an explicit
-          dependency here, and instead duplicated all the default
-          values.
-        */
-        size_t ntsfun = 1;
-        size_t ntpvt = 1;
-        size_t nssfun = 1;
-        size_t nppvt = 1;
-        size_t ntfip = 1;
-        size_t nrpvt = 1;
-
         if (deck.hasKeyword("TABDIMS")) {
             auto keyword = deck.getKeyword("TABDIMS");
             auto record = keyword->getRecord(0);
-            ntsfun = record->getItem("NTSFUN")->getInt(0);
-            ntpvt  = record->getItem("NTPVT")->getInt(0);
-            nssfun = record->getItem("NSSFUN")->getInt(0);
-            nppvt  = record->getItem("NPPVT")->getInt(0);
-            ntfip  = record->getItem("NTFIP")->getInt(0);
-            nrpvt  = record->getItem("NRPVT")->getInt(0);
+            int ntsfun = record->getItem("NTSFUN")->getInt(0);
+            int ntpvt  = record->getItem("NTPVT")->getInt(0);
+            int nssfun = record->getItem("NSSFUN")->getInt(0);
+            int nppvt  = record->getItem("NPPVT")->getInt(0);
+            int ntfip  = record->getItem("NTFIP")->getInt(0);
+            int nrpvt  = record->getItem("NRPVT")->getInt(0);
+
+            m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
+        } else
+            m_tabdims = std::make_shared<Tabdims>();
+    }
         }
         m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
     }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -25,7 +25,7 @@
 namespace Opm {
 
     TableManager::TableManager( const Deck& deck ) {
-        initTabdims( deck );
+        initDims( deck );
         initSimpleTables( deck );
         initFullTables(deck, "PVTG", m_pvtgTables);
         initFullTables(deck, "PVTO", m_pvtoTables);
@@ -35,20 +35,46 @@ namespace Opm {
     }
 
 
-    void TableManager::initTabdims(const Deck& deck) {
-        if (deck.hasKeyword("TABDIMS")) {
-            auto keyword = deck.getKeyword("TABDIMS");
+    void TableManager::initDims(const Deck& deck) {
+        using namespace Opm::ParserKeywords;
+        if (deck.hasKeyword<TABDIMS>()) {
+            auto keyword = deck.getKeyword<TABDIMS>();
             auto record = keyword->getRecord(0);
-            int ntsfun = record->getItem("NTSFUN")->getInt(0);
-            int ntpvt  = record->getItem("NTPVT")->getInt(0);
-            int nssfun = record->getItem("NSSFUN")->getInt(0);
-            int nppvt  = record->getItem("NPPVT")->getInt(0);
-            int ntfip  = record->getItem("NTFIP")->getInt(0);
-            int nrpvt  = record->getItem("NRPVT")->getInt(0);
+            int ntsfun = record->getItem<TABDIMS::NTSFUN>()->getInt(0);
+            int ntpvt  = record->getItem<TABDIMS::NTPVT>()->getInt(0);
+            int nssfun = record->getItem<TABDIMS::NSSFUN>()->getInt(0);
+            int nppvt  = record->getItem<TABDIMS::NPPVT>()->getInt(0);
+            int ntfip  = record->getItem<TABDIMS::NTFIP>()->getInt(0);
+            int nrpvt  = record->getItem<TABDIMS::NRPVT>()->getInt(0);
 
             m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
         } else
             m_tabdims = std::make_shared<Tabdims>();
+
+        if (deck.hasKeyword<EQLDIMS>()) {
+            auto keyword = deck.getKeyword<EQLDIMS>();
+            auto record = keyword->getRecord(0);
+            int ntsequl   = record->getItem<EQLDIMS::NTEQUL>()->getInt(0);
+            int nodes_p   = record->getItem<EQLDIMS::DEPTH_NODES_P>()->getInt(0);
+            int nodes_tab = record->getItem<EQLDIMS::DEPTH_NODES_TAB>()->getInt(0);
+            int nttrvd    = record->getItem<EQLDIMS::NTTRVD>()->getInt(0);
+            int ntsrvd    = record->getItem<EQLDIMS::NSTRVD>()->getInt(0);
+
+            m_eqldims = std::make_shared<Eqldims>(ntsequl , nodes_p , nodes_tab , nttrvd , ntsrvd );
+        } else
+            m_eqldims = std::make_shared<Eqldims>();
+
+        if (deck.hasKeyword<REGDIMS>()) {
+            auto keyword = deck.getKeyword<REGDIMS>();
+            auto record = keyword->getRecord(0);
+            int ntfip  = record->getItem<REGDIMS::NTFIP>()->getInt(0);
+            int nmfipr = record->getItem<REGDIMS::NMFIPR>()->getInt(0);
+            int nrfreg = record->getItem<REGDIMS::NRFREG>()->getInt(0);
+            int ntfreg = record->getItem<REGDIMS::NTFREG>()->getInt(0);
+            int nplmix = record->getItem<REGDIMS::NPLMIX>()->getInt(0);
+            m_regdims = std::make_shared<Regdims>( ntfip , nmfipr , nrfreg , ntfreg , nplmix );
+        } else
+            m_regdims = std::make_shared<Regdims>();
     }
 
 
@@ -66,6 +92,7 @@ namespace Opm {
             return tables.empty();
         }
     }
+
 
 
     void TableManager::initSimpleTables(const Deck& deck) {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -205,17 +205,13 @@ namespace Opm {
         initSimpleTableContainer<PlyadsTable>(deck, "PLYADS", m_tabdims->getNumSatTables());
         initSimpleTableContainer<PlyviscTable>(deck, "PLYVISC", m_tabdims->getNumPVTTables());
         initSimpleTableContainer<PlydhflfTable>(deck, "PLYDHFLF", m_tabdims->getNumPVTTables());
-
+        initPlyrockTables(deck);
+        initPlymaxTables(deck);
         initGasvisctTables(deck);
         initRTempTables(deck);
         initRocktabTables(deck);
-        /*****************************************************************/
 
-
-
-        initPlyrockTables(deck , "PLYROCK" , m_plyrockTables);
-        initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
-        initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
+        initPlyshlogTables(deck, "PLYSHLOG" , m_plyshlogTables);
     }
 
 
@@ -283,10 +279,9 @@ namespace Opm {
     }
 
 
-    void TableManager::initPlyrockTables(const Deck& deck,
-                                         const std::string& keywordName,
-                                         std::vector<PlyrockTable>& tableVector){
-
+    void TableManager::initPlyrockTables(const Deck& deck) {
+        size_t numTables = m_tabdims->getNumSatTables();
+        const std::string keywordName = "PLYROCK";
         if (!deck.hasKeyword(keywordName)) {
             return;
         }
@@ -296,19 +291,20 @@ namespace Opm {
             return;
         }
 
-        const auto& keyword = deck.getKeyword(keywordName);
-        for( auto iter = keyword->begin(); iter != keyword->end(); ++iter) {
-            auto record = *iter;
-            tableVector.push_back( PlyrockTable() );
-            tableVector.back().init( record );
+        const auto& keyword = deck.getKeyword<ParserKeywords::PLYROCK>();
+        auto& container = forceGetTables(keywordName , numTables);
+        for (size_t tableIdx = 0; tableIdx < keyword->size(); ++tableIdx) {
+            const auto tableRecord = keyword->getRecord( tableIdx );
+            std::shared_ptr<PlyrockTable> table = std::make_shared<PlyrockTable>();
+            table->init( tableRecord );
+            container.addTable( tableIdx , table );
         }
     }
 
 
-    void TableManager::initPlymaxTables(const Deck& deck,
-                                        const std::string& keywordName,
-                                        std::vector<PlymaxTable>& tableVector){
-
+    void TableManager::initPlymaxTables(const Deck& deck) {
+        size_t numTables = m_regdims->getNPLMIX();
+        const std::string keywordName = "PLYMAX";
         if (!deck.hasKeyword(keywordName)) {
             return;
         }
@@ -318,11 +314,13 @@ namespace Opm {
             return;
         }
 
-        const auto& keyword = deck.getKeyword(keywordName);
-        for( auto iter = keyword->begin(); iter != keyword->end(); ++iter) {
-            auto record = *iter;
-            tableVector.push_back( PlymaxTable() );
-            tableVector.back().init( record );
+        const auto& keyword = deck.getKeyword<ParserKeywords::PLYMAX>();
+        auto& container = forceGetTables(keywordName , numTables);
+        for (size_t tableIdx = 0; tableIdx < keyword->size(); ++tableIdx) {
+            const auto tableRecord = keyword->getRecord( tableIdx );
+            std::shared_ptr<PlymaxTable> table = std::make_shared<PlymaxTable>();
+            table->init( tableRecord );
+            container.addTable( tableIdx , table );
         }
     }
 
@@ -530,12 +528,12 @@ namespace Opm {
         return getTables("PLYDHFL");
     }
 
-    const std::vector<PlymaxTable>& TableManager::getPlymaxTables() const {
-        return m_plymaxTables;
+    const TableContainer& TableManager::getPlymaxTables() const {
+        return getTables("PLYMAX");
     }
 
-    const std::vector<PlyrockTable>& TableManager::getPlyrockTables() const {
-        return m_plyrockTables;
+    const TableContainer& TableManager::getPlyrockTables() const {
+        return getTables("PLYROCK");
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -176,6 +176,21 @@ namespace Opm {
 
         initSimpleTableContainer<RsvdTable>(deck, "RSVD" , m_eqldims->getNumEquilRegions());
         initSimpleTableContainer<RvvdTable>(deck, "RVVD" , m_eqldims->getNumEquilRegions());
+        {
+            size_t numEndScaleTables = ParserKeywords::ENDSCALE::NUM_TABLES::defaultValue;
+
+            if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
+                auto keyword = deck.getKeyword<ParserKeywords::ENDSCALE>();
+                auto record = keyword->getRecord(0);
+                numEndScaleTables = static_cast<size_t>(record->getItem<ParserKeywords::ENDSCALE::NUM_TABLES>()->getInt(0));
+            }
+
+            initSimpleTableContainer<EnkrvdTable>( deck , "ENKRVD", numEndScaleTables);
+            initSimpleTableContainer<EnptvdTable>( deck , "ENPTVD", numEndScaleTables);
+            initSimpleTableContainer<ImkrvdTable>( deck , "IMKRVD", numEndScaleTables);
+            initSimpleTableContainer<ImptvdTable>( deck , "IMPTVD", numEndScaleTables);
+        }
+
         /*****************************************************************/
 
 
@@ -187,10 +202,6 @@ namespace Opm {
         initSimpleTable(deck, "PLYDHFLF", m_plydhflfTables);
         initSimpleTable(deck, "OILVISCT", m_oilvisctTables);
         initSimpleTable(deck, "WATVISCT", m_watvisctTables);
-        initSimpleTable(deck, "ENKRVD", m_enkrvdTables);
-        initSimpleTable(deck, "ENPTVD", m_enptvdTables);
-        initSimpleTable(deck, "IMKRVD", m_imkrvdTables);
-        initSimpleTable(deck, "IMPTVD", m_imptvdTables);
 
         initPlyrockTables(deck , "PLYROCK" , m_plyrockTables);
         initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
@@ -455,6 +466,23 @@ namespace Opm {
         return getTables("RVVD");
     }
 
+    const TableContainer& TableManager::getEnkrvdTables() const {
+        return getTables("ENKRVD");
+    }
+
+    const TableContainer& TableManager::getEnptvdTables() const {
+        return getTables("ENPTVD");
+    }
+
+
+    const TableContainer& TableManager::getImkrvdTables() const {
+        return getTables("IMKRVD");
+    }
+
+    const TableContainer& TableManager::getImptvdTables() const {
+        return getTables("IMPTVD");
+    }
+
 
     const std::vector<PvdgTable>& TableManager::getPvdgTables() const {
         return m_pvdgTables;
@@ -510,24 +538,6 @@ namespace Opm {
 
     const std::vector<RtempvdTable>& TableManager::getRtempvdTables() const {
         return m_rtempvdTables;
-    }
-
-
-    const std::vector<EnkrvdTable>& TableManager::getEnkrvdTables() const {
-        return m_enkrvdTables;
-    }
-
-    const std::vector<EnptvdTable>& TableManager::getEnptvdTables() const {
-        return m_enptvdTables;
-    }
-
-
-    const std::vector<ImkrvdTable>& TableManager::getImkrvdTables() const {
-        return m_imkrvdTables;
-    }
-
-    const std::vector<ImptvdTable>& TableManager::getImptvdTables() const {
-        return m_imptvdTables;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -26,35 +26,7 @@ namespace Opm {
 
     TableManager::TableManager( const Deck& deck ) {
         initTabdims( deck );
-        initSimpleTables(deck, "SWOF", m_swofTables);
-        initSimpleTables(deck, "SGOF", m_sgofTables);
-        initSimpleTables(deck, "SLGOF", m_slgofTables);
-        initSimpleTables(deck, "SOF2", m_sof2Tables);
-        initSimpleTables(deck, "SOF3", m_sof3Tables);
-        initSimpleTables(deck, "PVDG", m_pvdgTables);
-        initSimpleTables(deck, "PVDO", m_pvdoTables);
-        initSimpleTables(deck, "SWFN", m_swfnTables);
-        initSimpleTables(deck, "SGFN", m_sgfnTables);
-        initSimpleTables(deck, "SSFN", m_ssfnTables);
-        initSimpleTables(deck, "PVDS", m_pvdsTables);
-        initSimpleTables(deck, "PLYADS", m_plyadsTables);
-        initSimpleTables(deck, "PLYVISC", m_plyviscTables);
-        initSimpleTables(deck, "PLYDHFLF", m_plydhflfTables);
-        initSimpleTables(deck, "OILVISCT", m_oilvisctTables);
-        initSimpleTables(deck, "WATVISCT", m_watvisctTables);
-        initSimpleTables(deck, "ENKRVD", m_enkrvdTables);
-        initSimpleTables(deck, "ENPTVD", m_enptvdTables);
-        initSimpleTables(deck, "IMKRVD", m_imkrvdTables);
-        initSimpleTables(deck, "IMPTVD", m_imptvdTables);
-        initSimpleTables(deck, "RSVD", m_rsvdTables);
-        initSimpleTables(deck, "RVVD", m_rvvdTables);
-
-        initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
-        initPlyrockTables(deck, "PLYROCK", m_plyrockTables);
-        initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
-        initRocktabTables(deck);
-        initRTempTables(deck);
-        initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
+        initSimpleTables( deck );
         initFullTables(deck, "PVTG", m_pvtgTables);
         initFullTables(deck, "PVTO", m_pvtoTables);
 
@@ -93,6 +65,39 @@ namespace Opm {
     }
 
 
+    void TableManager::initSimpleTables(const Deck& deck) {
+        initSimpleTable(deck, "SWOF", m_swofTables);
+        initSimpleTable(deck, "SGOF", m_sgofTables);
+        initSimpleTable(deck, "SLGOF", m_slgofTables);
+        initSimpleTable(deck, "SOF2", m_sof2Tables);
+        initSimpleTable(deck, "SOF3", m_sof3Tables);
+        initSimpleTable(deck, "PVDG", m_pvdgTables);
+        initSimpleTable(deck, "PVDO", m_pvdoTables);
+        initSimpleTable(deck, "SWFN", m_swfnTables);
+        initSimpleTable(deck, "SGFN", m_sgfnTables);
+        initSimpleTable(deck, "SSFN", m_ssfnTables);
+        initSimpleTable(deck, "PVDS", m_pvdsTables);
+        initSimpleTable(deck, "PLYADS", m_plyadsTables);
+        initSimpleTable(deck, "PLYVISC", m_plyviscTables);
+        initSimpleTable(deck, "PLYDHFLF", m_plydhflfTables);
+        initSimpleTable(deck, "OILVISCT", m_oilvisctTables);
+        initSimpleTable(deck, "WATVISCT", m_watvisctTables);
+        initSimpleTable(deck, "ENKRVD", m_enkrvdTables);
+        initSimpleTable(deck, "ENPTVD", m_enptvdTables);
+        initSimpleTable(deck, "IMKRVD", m_imkrvdTables);
+        initSimpleTable(deck, "IMPTVD", m_imptvdTables);
+        initSimpleTable(deck, "RSVD", m_rsvdTables);
+        initSimpleTable(deck, "RVVD", m_rvvdTables);
+
+        initPlyrockTables(deck , "PLYROCK" , m_plyrockTables);
+        initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
+        initPlyshlogTables(deck, "PLYSHLOG", m_plyshlogTables);
+        initRocktabTables(deck);
+        initRTempTables(deck);
+        initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
+    }
+
+
     void TableManager::initRTempTables(const Deck& deck) {
         // the temperature vs depth table. the problem here is that
         // the TEMPVD (E300) and RTEMPVD (E300 + E100) keywords are
@@ -101,9 +106,9 @@ namespace Opm {
         if (deck.hasKeyword("TEMPVD") && deck.hasKeyword("RTEMPVD"))
             throw std::invalid_argument("The TEMPVD and RTEMPVD tables are mutually exclusive!");
         else if (deck.hasKeyword("TEMPVD"))
-            initSimpleTables(deck, "TEMPVD", m_rtempvdTables);
+            initSimpleTable(deck, "TEMPVD", m_rtempvdTables);
         else if (deck.hasKeyword("RTEMPVD"))
-            initSimpleTables(deck, "RTEMPVD", m_rtempvdTables);
+            initSimpleTable(deck, "RTEMPVD", m_rtempvdTables);
 
     }
 
@@ -122,7 +127,7 @@ namespace Opm {
         const auto& tableKeyword = deck.getKeyword(keywordName);
         for (size_t tableIdx = 0; tableIdx < tableKeyword->size(); ++tableIdx) {
             if (tableKeyword->getRecord(tableIdx)->getItem(0)->size() == 0) {
-                // for simple tables, an empty record indicates that the previous table
+                // for simple tables, an empty record indicates that the< previous table
                 // should be copied...
                 if (tableIdx == 0) {
                     std::string msg = "The first table for keyword " + keywordName + " must be explicitly defined! Ignoring keyword";

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -50,12 +50,27 @@ namespace Opm {
         } else
             m_tabdims = std::make_shared<Tabdims>();
     }
+
+
+    void TableManager::addTables( const std::string& tableName , size_t numTables) {
+        m_simpleTables.emplace(std::make_pair(tableName , TableContainer( numTables )));
+    }
+
+
+    bool TableManager::hasTables( const std::string& tableName ) const {
+        auto pair = m_simpleTables.find( tableName );
+        if (pair == m_simpleTables.end())
+            return false;
+        else {
+            const auto& tables = pair->second;
+            return tables.empty();
         }
-        m_tabdims = std::make_shared<Tabdims>(ntsfun , ntpvt , nssfun , nppvt , ntfip , nrpvt);
     }
 
 
     void TableManager::initSimpleTables(const Deck& deck) {
+        addTables( "SWOF" , m_tabdims->getNumSatTables() );
+
         initSimpleTable(deck, "SWOF", m_swofTables);
         initSimpleTable(deck, "SGOF", m_sgofTables);
         initSimpleTable(deck, "SLGOF", m_slgofTables);

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -102,6 +102,16 @@ namespace Opm {
             return pair->second;
     }
 
+    TableContainer& TableManager::forceGetTables( const std::string& tableName , size_t numTables )  {
+        auto pair = m_simpleTables.find( tableName );
+        if (pair == m_simpleTables.end()) {
+            addTables( tableName , numTables );
+            pair = m_simpleTables.find( tableName );
+        }
+        return pair->second;
+    }
+
+
     const TableContainer& TableManager::operator[](const std::string& tableName) const {
         return getTables(tableName);
     }
@@ -156,15 +166,21 @@ namespace Opm {
           initRTempTables(deck);
           initGasvisctTables(deck, "GASVISCT", m_gasvisctTables);
         */
+        initSimpleTableContainer<SwofTable>(deck, "SWOF" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<SgofTable>(deck, "SGOF" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<SlgofTable>(deck, "SLGOF" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<Sof2Table>(deck, "SOF2" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<Sof3Table>(deck, "SOF3" , m_tabdims->getNumSatTables());
 
 
         /*****************************************************************/
 
-        initSimpleTable(deck, "SWOF", m_swofTables);
-        initSimpleTable(deck, "SGOF", m_sgofTables);
-        initSimpleTable(deck, "SLGOF", m_slgofTables);
-        initSimpleTable(deck, "SOF2", m_sof2Tables);
-        initSimpleTable(deck, "SOF3", m_sof3Tables);
+        //initSimpleTable(deck, "SWOF", m_swofTables);
+        //initSimpleTable(deck, "SGOF", m_sgofTables);
+        //initSimpleTable(deck, "SLGOF", m_slgofTables);
+        //initSimpleTable(deck, "SOF2", m_sof2Tables);
+        //initSimpleTable(deck, "SOF3", m_sof3Tables);
+
         initSimpleTable(deck, "PVDG", m_pvdgTables);
         initSimpleTable(deck, "PVDO", m_pvdoTables);
         initSimpleTable(deck, "SWFN", m_swfnTables);
@@ -399,26 +415,31 @@ namespace Opm {
     }
 
 
-    const std::vector<SwofTable>& TableManager::getSwofTables() const {
+    /*
+      const std::vector<SwofTable>& TableManager::getSwofTables() const {
         return m_swofTables;
+        }
+    */
+
+    const TableContainer& TableManager::getSwofTables() const {
+        return getTables("SWOF");
+    }
+
+    const TableContainer& TableManager::getSlgofTables() const {
+        return getTables("SLGOF");
     }
 
 
-    const std::vector<SlgofTable>& TableManager::getSlgofTables() const {
-        return m_slgofTables;
+    const TableContainer& TableManager::getSgofTables() const {
+        return getTables("SGOF");
     }
 
-
-    const std::vector<SgofTable>& TableManager::getSgofTables() const {
-        return m_sgofTables;
+    const TableContainer& TableManager::getSof2Tables() const {
+        return getTables("SOF2");
     }
 
-    const std::vector<Sof2Table>& TableManager::getSof2Tables() const {
-        return m_sof2Tables;
-    }
-
-    const std::vector<Sof3Table>& TableManager::getSof3Tables() const {
-        return m_sof3Tables;
+    const TableContainer& TableManager::getSof3Tables() const {
+        return getTables("SOF3");
     }
 
     const std::vector<PvdgTable>& TableManager::getPvdgTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -118,7 +118,6 @@ namespace Opm {
 
     void TableManager::initSimpleTables(const Deck& deck) {
         addTables( "SWOF" , m_tabdims->getNumSatTables() );
-        addTables( "SWOF",  m_tabdims->getNumSatTables() );
         addTables( "SGOF",  m_tabdims->getNumSatTables() );
         addTables( "SLGOF", m_tabdims->getNumSatTables() );
         addTables( "SOF2",  m_tabdims->getNumSatTables() );
@@ -175,6 +174,8 @@ namespace Opm {
         initSimpleTableContainer<SgfnTable>(deck, "SGFN" , m_tabdims->getNumSatTables());
         initSimpleTableContainer<SsfnTable>(deck, "SSFN" , m_tabdims->getNumSatTables());
 
+        initSimpleTableContainer<RsvdTable>(deck, "RSVD" , m_eqldims->getNumEquilRegions());
+        initSimpleTableContainer<RvvdTable>(deck, "RVVD" , m_eqldims->getNumEquilRegions());
         /*****************************************************************/
 
 
@@ -190,8 +191,6 @@ namespace Opm {
         initSimpleTable(deck, "ENPTVD", m_enptvdTables);
         initSimpleTable(deck, "IMKRVD", m_imkrvdTables);
         initSimpleTable(deck, "IMPTVD", m_imptvdTables);
-        initSimpleTable(deck, "RSVD", m_rsvdTables);
-        initSimpleTable(deck, "RVVD", m_rvvdTables);
 
         initPlyrockTables(deck , "PLYROCK" , m_plyrockTables);
         initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
@@ -448,6 +447,14 @@ namespace Opm {
         return getTables("SSFN");
     }
 
+    const TableContainer& TableManager::getRsvdTables() const {
+        return getTables("RSVD");
+    }
+
+    const TableContainer& TableManager::getRvvdTables() const {
+        return getTables("RVVD");
+    }
+
 
     const std::vector<PvdgTable>& TableManager::getPvdgTables() const {
         return m_pvdgTables;
@@ -523,14 +530,6 @@ namespace Opm {
         return m_imptvdTables;
     }
 
-
-    const std::vector<RsvdTable>& TableManager::getRsvdTables() const {
-        return m_rsvdTables;
-    }
-
-    const std::vector<RvvdTable>& TableManager::getRvvdTables() const {
-        return m_rvvdTables;
-    }
 
     const std::vector<PvtgTable>& TableManager::getPvtgTables() const {
         return m_pvtgTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -171,21 +171,15 @@ namespace Opm {
         initSimpleTableContainer<SlgofTable>(deck, "SLGOF" , m_tabdims->getNumSatTables());
         initSimpleTableContainer<Sof2Table>(deck, "SOF2" , m_tabdims->getNumSatTables());
         initSimpleTableContainer<Sof3Table>(deck, "SOF3" , m_tabdims->getNumSatTables());
-
+        initSimpleTableContainer<SwfnTable>(deck, "SWFN" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<SgfnTable>(deck, "SGFN" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<SsfnTable>(deck, "SSFN" , m_tabdims->getNumSatTables());
 
         /*****************************************************************/
 
-        //initSimpleTable(deck, "SWOF", m_swofTables);
-        //initSimpleTable(deck, "SGOF", m_sgofTables);
-        //initSimpleTable(deck, "SLGOF", m_slgofTables);
-        //initSimpleTable(deck, "SOF2", m_sof2Tables);
-        //initSimpleTable(deck, "SOF3", m_sof3Tables);
 
         initSimpleTable(deck, "PVDG", m_pvdgTables);
         initSimpleTable(deck, "PVDO", m_pvdoTables);
-        initSimpleTable(deck, "SWFN", m_swfnTables);
-        initSimpleTable(deck, "SGFN", m_sgfnTables);
-        initSimpleTable(deck, "SSFN", m_ssfnTables);
         initSimpleTable(deck, "PVDS", m_pvdsTables);
         initSimpleTable(deck, "PLYADS", m_plyadsTables);
         initSimpleTable(deck, "PLYVISC", m_plyviscTables);
@@ -442,24 +436,25 @@ namespace Opm {
         return getTables("SOF3");
     }
 
+    const TableContainer& TableManager::getSwfnTables() const {
+        return getTables("SWFN");
+    }
+
+    const TableContainer& TableManager::getSgfnTables() const {
+        return getTables("SGFN");
+    }
+
+    const TableContainer& TableManager::getSsfnTables() const {
+        return getTables("SSFN");
+    }
+
+
     const std::vector<PvdgTable>& TableManager::getPvdgTables() const {
         return m_pvdgTables;
     }
 
     const std::vector<PvdoTable>& TableManager::getPvdoTables() const {
         return m_pvdoTables;
-    }
-
-    const std::vector<SwfnTable>& TableManager::getSwfnTables() const {
-        return m_swfnTables;
-    }
-
-    const std::vector<SgfnTable>& TableManager::getSgfnTables() const {
-        return m_sgfnTables;
-    }
-
-    const std::vector<SsfnTable>& TableManager::getSsfnTables() const {
-        return m_ssfnTables;
     }
 
     const std::vector<PvdsTable>& TableManager::getPvdsTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -193,6 +193,9 @@ namespace Opm {
         initSimpleTableContainer<PvdgTable>(deck, "PVDG", m_tabdims->getNumPVTTables());
         initSimpleTableContainer<PvdoTable>(deck, "PVDO", m_tabdims->getNumPVTTables());
         initSimpleTableContainer<PvdsTable>(deck, "PVDS", m_tabdims->getNumPVTTables());
+        initSimpleTableContainer<OilvisctTable>(deck, "OILVISCT", m_tabdims->getNumPVTTables());
+        initSimpleTableContainer<WatvisctTable>(deck, "WATVISCT", m_tabdims->getNumPVTTables());
+
 
         /*****************************************************************/
 
@@ -200,8 +203,6 @@ namespace Opm {
         initSimpleTable(deck, "PLYADS", m_plyadsTables);
         initSimpleTable(deck, "PLYVISC", m_plyviscTables);
         initSimpleTable(deck, "PLYDHFLF", m_plydhflfTables);
-        initSimpleTable(deck, "OILVISCT", m_oilvisctTables);
-        initSimpleTable(deck, "WATVISCT", m_watvisctTables);
 
         initPlyrockTables(deck , "PLYROCK" , m_plyrockTables);
         initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
@@ -495,12 +496,12 @@ namespace Opm {
         return getTables("PVDS");
     }
 
-    const std::vector<OilvisctTable>& TableManager::getOilvisctTables() const {
-        return m_oilvisctTables;
+    const TableContainer& TableManager::getOilvisctTables() const {
+        return getTables("OILVISCT");
     }
 
-    const std::vector<WatvisctTable>& TableManager::getWatvisctTables() const {
-        return m_watvisctTables;
+    const TableContainer& TableManager::getWatvisctTables() const {
+        return getTables("WATVISCT");
     }
 
     const std::vector<GasvisctTable>& TableManager::getGasvisctTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -201,15 +201,17 @@ namespace Opm {
         initSimpleTableContainer<PvdsTable>(deck, "PVDS", m_tabdims->getNumPVTTables());
         initSimpleTableContainer<OilvisctTable>(deck, "OILVISCT", m_tabdims->getNumPVTTables());
         initSimpleTableContainer<WatvisctTable>(deck, "WATVISCT", m_tabdims->getNumPVTTables());
+
+        initSimpleTableContainer<PlyadsTable>(deck, "PLYADS", m_tabdims->getNumSatTables());
+        initSimpleTableContainer<PlyviscTable>(deck, "PLYVISC", m_tabdims->getNumPVTTables());
+        initSimpleTableContainer<PlydhflfTable>(deck, "PLYDHFLF", m_tabdims->getNumPVTTables());
+
         initGasvisctTables(deck);
         initRTempTables(deck);
         initRocktabTables(deck);
         /*****************************************************************/
 
 
-        initSimpleTable(deck, "PLYADS", m_plyadsTables);
-        initSimpleTable(deck, "PLYVISC", m_plyviscTables);
-        initSimpleTable(deck, "PLYDHFLF", m_plydhflfTables);
 
         initPlyrockTables(deck , "PLYROCK" , m_plyrockTables);
         initPlymaxTables(deck , "PLYMAX" , m_plymaxTables);
@@ -516,8 +518,16 @@ namespace Opm {
     }
 
 
-    const std::vector<PlyadsTable>& TableManager::getPlyadsTables() const {
-        return m_plyadsTables;
+    const TableContainer& TableManager::getPlyadsTables() const {
+        return getTables("PLYADS");
+    }
+
+    const TableContainer& TableManager::getPlyviscTables() const {
+        return getTables("PLYVISC");
+    }
+
+    const TableContainer& TableManager::getPlydhflfTables() const {
+        return getTables("PLYDHFL");
     }
 
     const std::vector<PlymaxTable>& TableManager::getPlymaxTables() const {
@@ -528,13 +538,6 @@ namespace Opm {
         return m_plyrockTables;
     }
 
-    const std::vector<PlyviscTable>& TableManager::getPlyviscTables() const {
-        return m_plyviscTables;
-    }
-
-    const std::vector<PlydhflfTable>& TableManager::getPlydhflfTables() const {
-        return m_plydhflfTables;
-    }
 
     const std::vector<PlyshlogTable>& TableManager::getPlyshlogTables() const {
         return m_plyshlogTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -92,7 +92,7 @@ namespace Opm {
         const TableContainer& getPvdsTables() const;
         const TableContainer& getWatvisctTables() const;
         const TableContainer& getOilvisctTables() const;
-
+        const TableContainer& getGasvisctTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -108,7 +108,6 @@ namespace Opm {
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<RocktabTable>& getRocktabTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<GasvisctTable>& getGasvisctTables() const;
 
 
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
@@ -123,10 +122,7 @@ namespace Opm {
         void initRTempTables(const Deck& deck);
         void initDims(const Deck& deck);
         void initRocktabTables(const Deck& deck);
-        void initGasvisctTables(const Deck& deck,
-                                const std::string& keywordName,
-                                std::vector<GasvisctTable>& tableVector);
-
+        void initGasvisctTables(const Deck& deck);
 
         void initVFPProdTables(const Deck& deck,
                                std::map<int, VFPProdTable>& tableMap);
@@ -243,7 +239,6 @@ namespace Opm {
         std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<RocktabTable> m_rocktabTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<GasvisctTable> m_gasvisctTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -90,6 +90,9 @@ namespace Opm {
         const TableContainer& getPvdgTables() const;
         const TableContainer& getPvdoTables() const;
         const TableContainer& getPvdsTables() const;
+        const TableContainer& getWatvisctTables() const;
+        const TableContainer& getOilvisctTables() const;
+
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -104,10 +107,9 @@ namespace Opm {
         const std::vector<PlyviscTable>& getPlyviscTables() const;
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<RocktabTable>& getRocktabTables() const;
-        const std::vector<WatvisctTable>& getWatvisctTables() const;
-        const std::vector<OilvisctTable>& getOilvisctTables() const;
-        const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
+        const std::vector<GasvisctTable>& getGasvisctTables() const;
+
 
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
@@ -240,10 +242,8 @@ namespace Opm {
         std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<RocktabTable> m_rocktabTables;
-        std::vector<WatvisctTable> m_watvisctTables;
-        std::vector<OilvisctTable> m_oilvisctTables;
-        std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<RtempvdTable> m_rtempvdTables;
+        std::vector<GasvisctTable> m_gasvisctTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -78,6 +78,9 @@ namespace Opm {
         const TableContainer& getSof3Tables() const;
         const TableContainer& getSgofTables() const;
         const TableContainer& getSlgofTables() const;
+        const TableContainer& getSwfnTables() const;
+        const TableContainer& getSgfnTables() const;
+        const TableContainer& getSsfnTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -87,9 +90,6 @@ namespace Opm {
         const std::vector<PvtoTable>& getPvtoTables() const;
         const std::vector<PvdgTable>& getPvdgTables() const;
         const std::vector<PvdoTable>& getPvdoTables() const;
-        const std::vector<SwfnTable>& getSwfnTables() const;
-        const std::vector<SgfnTable>& getSgfnTables() const;
-        const std::vector<SsfnTable>& getSsfnTables() const;
         const std::vector<PvdsTable>& getPvdsTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PlyadsTable>& getPlyadsTables() const;
@@ -234,9 +234,6 @@ namespace Opm {
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
         std::vector<PvdsTable> m_pvdsTables;
-        std::vector<SwfnTable> m_swfnTables;
-        std::vector<SgfnTable> m_sgfnTables;
-        std::vector<SsfnTable> m_ssfnTables;
         std::vector<PvdgTable> m_pvdgTables;
         std::vector<PvdoTable> m_pvdoTables;
         std::vector<PlyadsTable> m_plyadsTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -55,7 +55,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp>
-
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 
 namespace Opm {
 
@@ -104,6 +104,7 @@ namespace Opm {
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
+        void initSimpleTables(const Deck& deck);
         void initRTempTables(const Deck& deck);
         void initTabdims(const Deck& deck);
         void initRocktabTables(const Deck& deck);
@@ -133,7 +134,7 @@ namespace Opm {
                                 std::vector<PlyshlogTable>& tableVector);
 
         template <class TableType>
-        void initSimpleTables(const Deck& deck,
+        void initSimpleTable(const Deck& deck,
                               const std::string& keywordName,
                               std::vector<TableType>& tableVector) {
             if (!deck.hasKeyword(keywordName))
@@ -187,7 +188,7 @@ namespace Opm {
             }
         }
 
-
+        std::map<std::string , TableContainer> m_simpleTables;
         std::map<int, VFPProdTable> m_vfpprodTables;
         std::map<int, VFPInjTable> m_vfpinjTables;
         std::vector<PvtgTable> m_pvtgTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -83,6 +83,10 @@ namespace Opm {
         const TableContainer& getSsfnTables() const;
         const TableContainer& getRsvdTables() const;
         const TableContainer& getRvvdTables() const;
+        const TableContainer& getEnkrvdTables() const;
+        const TableContainer& getEnptvdTables() const;
+        const TableContainer& getImkrvdTables() const;
+        const TableContainer& getImptvdTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -104,10 +108,6 @@ namespace Opm {
         const std::vector<OilvisctTable>& getOilvisctTables() const;
         const std::vector<GasvisctTable>& getGasvisctTables() const;
         const std::vector<RtempvdTable>& getRtempvdTables() const;
-        const std::vector<EnkrvdTable>& getEnkrvdTables() const;
-        const std::vector<EnptvdTable>& getEnptvdTables() const;
-        const std::vector<ImkrvdTable>& getImkrvdTables() const;
-        const std::vector<ImptvdTable>& getImptvdTables() const;
 
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
@@ -247,10 +247,6 @@ namespace Opm {
         std::vector<OilvisctTable> m_oilvisctTables;
         std::vector<GasvisctTable> m_gasvisctTables;
         std::vector<RtempvdTable> m_rtempvdTables;
-        std::vector<EnkrvdTable> m_enkrvdTables;
-        std::vector<EnptvdTable> m_enptvdTables;
-        std::vector<ImkrvdTable> m_imkrvdTables;
-        std::vector<ImptvdTable> m_imptvdTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -98,13 +98,14 @@ namespace Opm {
         const TableContainer& getPlyadsTables() const;
         const TableContainer& getPlyviscTables() const;
         const TableContainer& getPlydhflfTables() const;
+        const TableContainer& getPlymaxTables() const;
+        const TableContainer& getPlyrockTables() const;
+
 
         // the tables used by the deck. If the tables had some defaulted data in the
         // deck, the objects returned here exhibit the correct values. If the table is
         // not present in the deck, the corresponding vector is of size zero.
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
-        const std::vector<PlymaxTable>& getPlymaxTables() const;
-        const std::vector<PlyrockTable>& getPlyrockTables() const;
 
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
@@ -129,13 +130,8 @@ namespace Opm {
                               std::map<int, VFPInjTable>& tableMap);
 
 
-        void initPlymaxTables(const Deck& deck,
-                              const std::string& keywordName,
-                              std::vector<PlymaxTable>& tableVector);
-
-        void initPlyrockTables(const Deck& deck,
-                               const std::string& keywordName,
-                               std::vector<PlyrockTable>& tableVector);
+        void initPlymaxTables(const Deck& deck);
+        void initPlyrockTables(const Deck& deck);
 
 
         void initPlyshlogTables(const Deck& deck,
@@ -237,8 +233,6 @@ namespace Opm {
         std::map<int, VFPInjTable> m_vfpinjTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::vector<PlymaxTable> m_plymaxTables;
-        std::vector<PlyrockTable> m_plyrockTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
 
         std::shared_ptr<Regdims> m_regdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -87,6 +87,9 @@ namespace Opm {
         const TableContainer& getEnptvdTables() const;
         const TableContainer& getImkrvdTables() const;
         const TableContainer& getImptvdTables() const;
+        const TableContainer& getPvdgTables() const;
+        const TableContainer& getPvdoTables() const;
+        const TableContainer& getPvdsTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -94,9 +97,6 @@ namespace Opm {
         // not present in the deck, the corresponding vector is of size zero.
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
-        const std::vector<PvdgTable>& getPvdgTables() const;
-        const std::vector<PvdoTable>& getPvdoTables() const;
-        const std::vector<PvdsTable>& getPvdsTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PlyadsTable>& getPlyadsTables() const;
         const std::vector<PlymaxTable>& getPlymaxTables() const;
@@ -233,9 +233,6 @@ namespace Opm {
         std::map<int, VFPInjTable> m_vfpinjTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::vector<PvdsTable> m_pvdsTables;
-        std::vector<PvdgTable> m_pvdgTables;
-        std::vector<PvdoTable> m_pvdoTables;
         std::vector<PlyadsTable> m_plyadsTables;
         std::vector<PlymaxTable> m_plymaxTables;
         std::vector<PlyrockTable> m_plyrockTables;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -93,6 +93,7 @@ namespace Opm {
         const TableContainer& getWatvisctTables() const;
         const TableContainer& getOilvisctTables() const;
         const TableContainer& getGasvisctTables() const;
+        const TableContainer& getRtempvdTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -107,7 +108,6 @@ namespace Opm {
         const std::vector<PlyviscTable>& getPlyviscTables() const;
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
         const std::vector<RocktabTable>& getRocktabTables() const;
-        const std::vector<RtempvdTable>& getRtempvdTables() const;
 
 
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
@@ -147,11 +147,12 @@ namespace Opm {
         template <class TableType>
         void initSimpleTableContainer(const Deck& deck,
                                       const std::string& keywordName,
+                                      const std::string& tableName,
                                       size_t numTables) {
             if (!deck.hasKeyword(keywordName))
                 return; // the table is not featured by the deck...
 
-            auto& container = forceGetTables(keywordName , numTables);
+            auto& container = forceGetTables(tableName , numTables);
 
             if (deck.numKeywords(keywordName) > 1) {
                 complainAboutAmbiguousKeyword(deck, keywordName);
@@ -168,6 +169,13 @@ namespace Opm {
                     container.addTable( tableIdx , table );
                 }
             }
+        }
+
+        template <class TableType>
+        void initSimpleTableContainer(const Deck& deck,
+                                      const std::string& keywordName,
+                                      size_t numTables) {
+            initSimpleTableContainer<TableType>(deck , keywordName , keywordName , numTables);
         }
 
 
@@ -238,7 +246,6 @@ namespace Opm {
         std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
         std::vector<RocktabTable> m_rocktabTables;
-        std::vector<RtempvdTable> m_rtempvdTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -63,7 +63,7 @@ namespace Opm {
     public:
         TableManager( const Deck& deck );
 
-
+        bool hasTables( const std::string& tableName ) const;
         std::shared_ptr<const Tabdims> getTabdims() const;
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -104,6 +104,7 @@ namespace Opm {
     private:
         void complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) const;
 
+        void addTables( const std::string& tableName , size_t numTables);
         void initSimpleTables(const Deck& deck);
         void initRTempTables(const Deck& deck);
         void initTabdims(const Deck& deck);

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -23,6 +23,7 @@
 #include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
@@ -107,7 +108,7 @@ namespace Opm {
         void addTables( const std::string& tableName , size_t numTables);
         void initSimpleTables(const Deck& deck);
         void initRTempTables(const Deck& deck);
-        void initTabdims(const Deck& deck);
+        void initDims(const Deck& deck);
         void initRocktabTables(const Deck& deck);
         void initGasvisctTables(const Deck& deck,
                                 const std::string& keywordName,
@@ -222,7 +223,9 @@ namespace Opm {
         std::vector<ImptvdTable> m_imptvdTables;
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
+
         std::shared_ptr<Tabdims> m_tabdims;
+        std::shared_ptr<Eqldims> m_eqldims;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -95,17 +95,16 @@ namespace Opm {
         const TableContainer& getGasvisctTables() const;
         const TableContainer& getRtempvdTables() const;
         const TableContainer& getRocktabTables() const;
-
+        const TableContainer& getPlyadsTables() const;
+        const TableContainer& getPlyviscTables() const;
+        const TableContainer& getPlydhflfTables() const;
 
         // the tables used by the deck. If the tables had some defaulted data in the
         // deck, the objects returned here exhibit the correct values. If the table is
         // not present in the deck, the corresponding vector is of size zero.
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
-        const std::vector<PlyadsTable>& getPlyadsTables() const;
         const std::vector<PlymaxTable>& getPlymaxTables() const;
         const std::vector<PlyrockTable>& getPlyrockTables() const;
-        const std::vector<PlyviscTable>& getPlyviscTables() const;
-        const std::vector<PlydhflfTable>& getPlydhflfTables() const;
 
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
@@ -238,11 +237,8 @@ namespace Opm {
         std::map<int, VFPInjTable> m_vfpinjTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::vector<PlyadsTable> m_plyadsTables;
         std::vector<PlymaxTable> m_plymaxTables;
         std::vector<PlyrockTable> m_plyrockTables;
-        std::vector<PlyviscTable> m_plyviscTables;
-        std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
 
         std::shared_ptr<Regdims> m_regdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -94,22 +94,21 @@ namespace Opm {
         const TableContainer& getOilvisctTables() const;
         const TableContainer& getGasvisctTables() const;
         const TableContainer& getRtempvdTables() const;
+        const TableContainer& getRocktabTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
         // deck, the objects returned here exhibit the correct values. If the table is
         // not present in the deck, the corresponding vector is of size zero.
-        const std::vector<PvtgTable>& getPvtgTables() const;
-        const std::vector<PvtoTable>& getPvtoTables() const;
         const std::vector<PlyshlogTable>& getPlyshlogTables() const;
         const std::vector<PlyadsTable>& getPlyadsTables() const;
         const std::vector<PlymaxTable>& getPlymaxTables() const;
         const std::vector<PlyrockTable>& getPlyrockTables() const;
         const std::vector<PlyviscTable>& getPlyviscTables() const;
         const std::vector<PlydhflfTable>& getPlydhflfTables() const;
-        const std::vector<RocktabTable>& getRocktabTables() const;
 
-
+        const std::vector<PvtgTable>& getPvtgTables() const;
+        const std::vector<PvtoTable>& getPvtoTables() const;
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
     private:
@@ -245,7 +244,6 @@ namespace Opm {
         std::vector<PlyviscTable> m_plyviscTables;
         std::vector<PlydhflfTable> m_plydhflfTables;
         std::vector<PlyshlogTable> m_plyshlogTables;
-        std::vector<RocktabTable> m_rocktabTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -81,6 +81,8 @@ namespace Opm {
         const TableContainer& getSwfnTables() const;
         const TableContainer& getSgfnTables() const;
         const TableContainer& getSsfnTables() const;
+        const TableContainer& getRsvdTables() const;
+        const TableContainer& getRvvdTables() const;
 
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -106,8 +108,6 @@ namespace Opm {
         const std::vector<EnptvdTable>& getEnptvdTables() const;
         const std::vector<ImkrvdTable>& getImkrvdTables() const;
         const std::vector<ImptvdTable>& getImptvdTables() const;
-        const std::vector<RsvdTable>& getRsvdTables() const;
-        const std::vector<RvvdTable>& getRvvdTables() const;
 
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
@@ -251,8 +251,6 @@ namespace Opm {
         std::vector<EnptvdTable> m_enptvdTables;
         std::vector<ImkrvdTable> m_imkrvdTables;
         std::vector<ImptvdTable> m_imptvdTables;
-        std::vector<RsvdTable> m_rsvdTables;
-        std::vector<RvvdTable> m_rvvdTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -100,12 +100,7 @@ namespace Opm {
         const TableContainer& getPlydhflfTables() const;
         const TableContainer& getPlymaxTables() const;
         const TableContainer& getPlyrockTables() const;
-
-
-        // the tables used by the deck. If the tables had some defaulted data in the
-        // deck, the objects returned here exhibit the correct values. If the table is
-        // not present in the deck, the corresponding vector is of size zero.
-        const std::vector<PlyshlogTable>& getPlyshlogTables() const;
+        const TableContainer& getPlyshlogTables() const;
 
         const std::vector<PvtgTable>& getPvtgTables() const;
         const std::vector<PvtoTable>& getPvtoTables() const;
@@ -132,11 +127,7 @@ namespace Opm {
 
         void initPlymaxTables(const Deck& deck);
         void initPlyrockTables(const Deck& deck);
-
-
-        void initPlyshlogTables(const Deck& deck,
-                                const std::string& keywordName,
-                                std::vector<PlyshlogTable>& tableVector);
+        void initPlyshlogTables(const Deck& deck);
 
         template <class TableType>
         void initSimpleTableContainer(const Deck& deck,
@@ -233,7 +224,6 @@ namespace Opm {
         std::map<int, VFPInjTable> m_vfpinjTables;
         std::vector<PvtgTable> m_pvtgTables;
         std::vector<PvtoTable> m_pvtoTables;
-        std::vector<PlyshlogTable> m_plyshlogTables;
 
         std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -24,6 +24,8 @@
 
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Regdims.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp>
@@ -64,7 +66,11 @@ namespace Opm {
     public:
         TableManager( const Deck& deck );
 
+        const TableContainer& getTables( const std::string& tableName ) const;
+        const TableContainer& operator[](const std::string& tableName) const;
         bool hasTables( const std::string& tableName ) const;
+
+
         std::shared_ptr<const Tabdims> getTabdims() const;
 
         // the tables used by the deck. If the tables had some defaulted data in the
@@ -100,6 +106,7 @@ namespace Opm {
         const std::vector<ImptvdTable>& getImptvdTables() const;
         const std::vector<RsvdTable>& getRsvdTables() const;
         const std::vector<RvvdTable>& getRvvdTables() const;
+
         const std::map<int, VFPProdTable>& getVFPProdTables() const;
         const std::map<int, VFPInjTable>& getVFPInjTables() const;
     private:
@@ -224,6 +231,7 @@ namespace Opm {
         std::vector<RsvdTable> m_rsvdTables;
         std::vector<RvvdTable> m_rvvdTables;
 
+        std::shared_ptr<Regdims> m_regdims;
         std::shared_ptr<Tabdims> m_tabdims;
         std::shared_ptr<Eqldims> m_eqldims;
     };

--- a/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp
@@ -25,8 +25,8 @@ namespace Opm {
     // forward declaration
     class TableManager;
 
-    class WatvisctTable : protected SimpleTable {
-
+    class WatvisctTable : public SimpleTable {
+    public:
         friend class TableManager;
         WatvisctTable() = default;
 
@@ -49,7 +49,6 @@ namespace Opm {
             SimpleTable::checkMonotonic("Viscosity", /*isAscending=*/false, /*strictlyMonotonic=*/false);
         }
 
-    public:
         using SimpleTable::numTables;
         using SimpleTable::numRows;
         using SimpleTable::numColumns;

--- a/opm/parser/eclipse/EclipseState/Tables/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/CMakeLists.txt
@@ -1,4 +1,6 @@
-foreach(tapp TableManagerTests TabdimsTests MultiRecordTableTests)
+foreach(tapp TableManagerTests TabdimsTests MultiRecordTableTests TableContainerTests)
+
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})
+
 endforeach()

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TabdimsTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TabdimsTests.cpp
@@ -22,5 +22,9 @@
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
 
 BOOST_AUTO_TEST_CASE(TEST_CREATE) {
-    Opm::Tabdims tabdims(1,2,3,4,5,6);
+    Opm::Tabdims tabdims1(1,2,3,4,5,6);
+    Opm::Tabdims tabdims2;
+
+    BOOST_CHECK_EQUAL( tabdims1.getNumSatNodes() ,  3U );
+    BOOST_CHECK_EQUAL( tabdims2.getNumSatNodes() , 20U );
 }

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -62,10 +62,10 @@ BOOST_AUTO_TEST_CASE( CreateContainer ) {
     container.addTable( 6 , table );
     BOOST_CHECK_EQUAL( 1 , container.size() );
 
-    BOOST_CHECK_EQUAL( table.get() , &(container.getTable(6)));
-    BOOST_CHECK_EQUAL( table.get() , &(container.getTable(9)));
+    BOOST_CHECK_EQUAL( table.get() , &(container[6]));
+    BOOST_CHECK_EQUAL( table.get() , &(container[9]));
 
-    BOOST_CHECK_THROW( container.getTable(5) , std::invalid_argument );
-    BOOST_CHECK_THROW( container.getTable(10) , std::invalid_argument );
+    BOOST_CHECK_THROW( container[5] , std::invalid_argument );
+    BOOST_CHECK_THROW( container[10] , std::invalid_argument );
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -1,0 +1,71 @@
+/*
+  Copyright (C) 2013 by Andreas Lauser
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE TableContainerTests
+
+#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseMode.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
+
+#include <string>
+#include <memory>
+
+std::shared_ptr<const Opm::Deck> createSWOFDeck() {
+    const char *deckData =
+        "TABDIMS\n"
+        " 2 /\n"
+        "\n"
+        "SWOF\n"
+        " 1 2 3 4\n"
+        " 5 6 7 8 /\n"
+        " 9 10 11 12 /\n";
+
+    Opm::Parser parser;
+    Opm::DeckConstPtr deck(parser.parseString(deckData, Opm::ParseMode()));
+    return deck;
+}
+
+BOOST_AUTO_TEST_CASE( CreateContainer ) {
+    std::vector<std::string> columnNames{"A", "B", "C", "D"};
+    Opm::DeckConstPtr deck = createSWOFDeck();
+    Opm::TableContainer container(10);
+    BOOST_CHECK( container.empty() );
+    BOOST_CHECK_EQUAL( 0 , container.size() );
+    BOOST_CHECK_EQUAL( false , container.hasTable( 1 ));
+
+    std::shared_ptr<Opm::SimpleTable> table = std::shared_ptr<Opm::SimpleTable>( new Opm::SimpleTable() );
+    table->initFORUNITTESTONLY(deck->getKeyword("SWOF")->getRecord(0)->getItem(0),
+                              columnNames);
+
+    BOOST_CHECK_THROW( container.addTable( 10 , table ), std::invalid_argument );
+    container.addTable( 6 , table );
+    BOOST_CHECK_EQUAL( 1 , container.size() );
+
+    BOOST_CHECK_EQUAL( table.get() , &(container.getTable(6)));
+    BOOST_CHECK_EQUAL( table.get() , &(container.getTable(9)));
+
+    BOOST_CHECK_THROW( container.getTable(5) , std::invalid_argument );
+    BOOST_CHECK_THROW( container.getTable(10) , std::invalid_argument );
+}
+

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -913,6 +913,9 @@ BOOST_AUTO_TEST_CASE(TableContainer) {
     Opm::TableManager tables( *deck );
     BOOST_CHECK_EQUAL( false , tables.hasTables("SGOF") );
     BOOST_CHECK_EQUAL( false , tables.hasTables("STUPID") );
+
+    BOOST_CHECK_THROW( tables.getTables("STUPID") , std::invalid_argument);
+    BOOST_CHECK_THROW( tables["STUPID"] , std::invalid_argument);
 }
 
 /**

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -908,7 +908,12 @@ VFPINJ \n\
 
 
 
-
+BOOST_AUTO_TEST_CASE(TableContainer) {
+    std::shared_ptr<const Opm::Deck> deck = createSingleRecordDeck();
+    Opm::TableManager tables( *deck );
+    BOOST_CHECK_EQUAL( false , tables.hasTables("SGOF") );
+    BOOST_CHECK_EQUAL( false , tables.hasTables("STUPID") );
+}
 
 /**
  * Spot checks that the VFPPROD table will fail nicely when given invalid data

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -1087,11 +1087,11 @@ BOOST_AUTO_TEST_CASE( TestPLYROCK ) {
     Opm::ParserPtr parser(new Opm::Parser);
     Opm::DeckConstPtr deck(parser->parseString(data, Opm::ParseMode()));
     Opm::TableManager tables( *deck );
-    const std::vector<Opm::PlyrockTable>& plyrock = tables.getPlyrockTables();
+    const Opm::TableContainer& plyrock = tables.getPlyrockTables();
 
     BOOST_CHECK_EQUAL( plyrock.size() , 2 ) ;
-    const Opm::PlyrockTable& table0 = plyrock[0];
-    const Opm::PlyrockTable& table1 = plyrock[1];
+    const Opm::PlyrockTable& table0 = plyrock.getTable<Opm::PlyrockTable>(0);
+    const Opm::PlyrockTable& table1 = plyrock.getTable<Opm::PlyrockTable>(1);
 
     BOOST_CHECK_EQUAL( table0.numColumns() , 5 );
     BOOST_CHECK_EQUAL( table0.getDeadPoreVolumeColumn()[0] , 1.0 );
@@ -1115,11 +1115,11 @@ BOOST_AUTO_TEST_CASE( TestPLYMAX ) {
     Opm::ParserPtr parser(new Opm::Parser);
     Opm::DeckConstPtr deck(parser->parseString(data, Opm::ParseMode()));
     Opm::TableManager tables( *deck );
-    const std::vector<Opm::PlymaxTable>& plymax = tables.getPlymaxTables();
+    const Opm::TableContainer& plymax = tables.getPlymaxTables();
 
     BOOST_CHECK_EQUAL( plymax.size() , 2 ) ;
-    const Opm::PlymaxTable& table0 = plymax[0];
-    const Opm::PlymaxTable& table1 = plymax[1];
+    const Opm::PlymaxTable& table0 = plymax.getTable<Opm::PlymaxTable>(0);
+    const Opm::PlymaxTable& table1 = plymax.getTable<Opm::PlymaxTable>(1);
 
     BOOST_CHECK_EQUAL( table0.numColumns() , 2 );
     BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[0] , 1.0 );

--- a/opm/parser/eclipse/IntegrationTests/Polymer.cpp
+++ b/opm/parser/eclipse/IntegrationTests/Polymer.cpp
@@ -35,8 +35,8 @@ BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     ParserPtr parser(new Parser());
     DeckPtr deck = parser->parseFile("testdata/integration_tests/POLYMER/POLY.inc", ParseMode());
     Opm::TableManager tables( *deck );
-    const std::vector<PlymaxTable>& plymax = tables.getPlymaxTables();
-    const std::vector<PlyrockTable> plyrock = tables.getPlyrockTables();
+    const TableContainer& plymax = tables.getPlymaxTables();
+    const TableContainer& plyrock = tables.getPlyrockTables();
     const TableContainer& plyads = tables.getPlyadsTables();
     const TableContainer& plyvis = tables.getPlyviscTables();
 
@@ -46,28 +46,28 @@ BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     BOOST_CHECK_EQUAL( plyads.size() , 1U );
 
     {
-        const Opm::PlymaxTable& table0 = plymax[0];
+        const Opm::PlymaxTable& table0 = plymax.getTable<Opm::PlymaxTable>(0);
         BOOST_CHECK_EQUAL( table0.numColumns() , 2U );
         BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[0] , 3.0 );
         BOOST_CHECK_EQUAL( table0.getMaxPolymerConcentrationColumn()[0] , 0.0 );
     }
 
     {
-        const Opm::PlyviscTable& table0 = plyvis.getTable<PlyviscTable>(0);
+        const Opm::PlyviscTable& table0 = plyvis.getTable<Opm::PlyviscTable>(0);
         BOOST_CHECK_EQUAL( table0.numColumns() , 2U );
         BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[5] , 3.0 );
         BOOST_CHECK_EQUAL( table0.getViscosityMultiplierColumn()[5] , 48.0 );
     }
 
     {
-        const Opm::PlyrockTable& table0 = plyrock[0];
+        const Opm::PlyrockTable& table0 = plyrock.getTable<Opm::PlyrockTable>(0);
         BOOST_CHECK_EQUAL( table0.numColumns() , 5U );
         BOOST_CHECK_EQUAL( table0.getDeadPoreVolumeColumn()[0] , 0.05 );
         BOOST_CHECK_EQUAL( table0.getMaxAdsorbtionColumn()[0] , 0.000025 );
     }
 
     {
-        const Opm::PlyadsTable& table0 = plyads.getTable<PlyadsTable>(0);
+        const Opm::PlyadsTable& table0 = plyads.getTable<Opm::PlyadsTable>(0);
         BOOST_CHECK_EQUAL( table0.numColumns() , 2U );
         BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[8] , 3.0 );
         BOOST_CHECK_EQUAL( table0.getAdsorbedPolymerColumn()[8] , 0.000025 );

--- a/opm/parser/eclipse/IntegrationTests/Polymer.cpp
+++ b/opm/parser/eclipse/IntegrationTests/Polymer.cpp
@@ -37,8 +37,8 @@ BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     Opm::TableManager tables( *deck );
     const std::vector<PlymaxTable>& plymax = tables.getPlymaxTables();
     const std::vector<PlyrockTable> plyrock = tables.getPlyrockTables();
-    const std::vector<PlyviscTable> plyvis = tables.getPlyviscTables();
-    const std::vector<PlyadsTable> plyads = tables.getPlyadsTables();
+    const TableContainer& plyads = tables.getPlyadsTables();
+    const TableContainer& plyvis = tables.getPlyviscTables();
 
     BOOST_CHECK_EQUAL( plymax.size() , 1U );
     BOOST_CHECK_EQUAL( plyrock.size() , 1U );
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     }
 
     {
-        const Opm::PlyviscTable& table0 = plyvis[0];
+        const Opm::PlyviscTable& table0 = plyvis.getTable<PlyviscTable>(0);
         BOOST_CHECK_EQUAL( table0.numColumns() , 2U );
         BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[5] , 3.0 );
         BOOST_CHECK_EQUAL( table0.getViscosityMultiplierColumn()[5] , 48.0 );
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     }
 
     {
-        const Opm::PlyadsTable& table0 = plyads[0];
+        const Opm::PlyadsTable& table0 = plyads.getTable<PlyadsTable>(0);
         BOOST_CHECK_EQUAL( table0.numColumns() , 2U );
         BOOST_CHECK_EQUAL( table0.getPolymerConcentrationColumn()[8] , 3.0 );
         BOOST_CHECK_EQUAL( table0.getAdsorbedPolymerColumn()[8] , 0.000025 );

--- a/opm/parser/share/keywords/000_Eclipse100/E/EQLDIMS
+++ b/opm/parser/share/keywords/000_Eclipse100/E/EQLDIMS
@@ -3,4 +3,4 @@
   {"name" : "DEPTH_NODES_P"   , "value_type" : "INT", "default" : 100},
   {"name" : "DEPTH_NODES_TAB" , "value_type" : "INT" , "default" : 20},
   {"name" : "NTTRVD"      , "value_type" : "INT" , "default" : 1},
-  {"name" : "TRACER_VD"       , "value_type" : "INT" , "default" : 20}]}
+  {"name" : "NSTRVD"       , "value_type" : "INT" , "default" : 20}]}

--- a/opm/parser/share/keywords/000_Eclipse100/R/ROCKCOMP
+++ b/opm/parser/share/keywords/000_Eclipse100/R/ROCKCOMP
@@ -1,0 +1,7 @@
+{"name" : "ROCKCOMP" , "sections" : ["RUNSPEC"], "size" : 1 , "items" : [
+ {"name" : "HYSTERESIS" , "value_type" : "STRING" , "default" : "REVERS"},
+ {"name" : "NTROCC" , "value_type" : "INT" , "default" : 1},
+ {"name" : "WATER_COMPACTION" , "value_type" : "STRING" , "default" : "NO"}]}
+
+   
+   

--- a/testdata/integration_tests/POLYMER/POLY.inc
+++ b/testdata/integration_tests/POLYMER/POLY.inc
@@ -10,6 +10,9 @@ RUNSPEC
 TABDIMS
  1  1 /
 
+EQLDIMS
+ /
+ 
 
 REGDIMS
  9* 1 /


### PR DESCRIPTION
With this PR a small container `Opm::TableContainer` is created to hold the different tables, instead of `std::vector<TableType>` - work in progress.

1. opm-porsol: https://github.com/OPM/opm-porsol/pull/134
2. opm-material: https://github.com/OPM/opm-material/pull/62
3. opm-core: https://github.com/OPM/opm-core/pull/886  
4. opm-polymer: https://github.com/OPM/opm-polymer/pull/147
5. opm-autodiff: https://github.com/OPM/opm-autodiff/pull/488

The failing test in opm-core should be investigated more - then this should be ready to merge.