### PR TITLE
Opm 218 fix

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -91,33 +91,16 @@ namespace Opm {
 
 
     bool IOConfig::getWriteRestartFileFrequency(size_t timestep,
-                                                size_t start_index,
+                                                size_t start_timestep,
                                                 size_t frequency,
-                                                bool   first_timesteps_years,
-                                                bool   first_timesteps_months) const {
+                                                bool   years,
+                                                bool   months) const {
         bool write_restart_file = false;
-        if (!first_timesteps_years && !first_timesteps_months) {
-            write_restart_file = (((timestep-start_index) % frequency) == 0) ? true : false;
+        if ((!years && !months) && (timestep >= start_timestep)) {
+            write_restart_file = ((timestep % frequency) == 0) ? true : false;
         } else {
-            std::vector<size_t> timesteps;
-            if (first_timesteps_years) {
-                m_timemap->initFirstTimestepsYears(timesteps, start_index);
-            } else {
-                m_timemap->initFirstTimestepsMonths(timesteps, start_index);
-            }
-            std::vector<size_t>::const_iterator ci_timestep = std::find(timesteps.begin(), timesteps.end(), timestep);
+              write_restart_file = m_timemap->isTimestepInFirstOfMonthsYearsSequence(timestep, years, start_timestep, frequency);
 
-            if (ci_timestep != timesteps.end()) {
-                if (1 >= frequency) {
-                    write_restart_file = true;
-                } else {
-                    std::vector<size_t>::const_iterator ci_start = timesteps.begin();
-                    int dist = std::distance( ci_start, ci_timestep ) + 1;
-                    if( ( (dist > 0) && ((dist % frequency) == 0) ) ) {
-                        write_restart_file = true;
-                    }
-                 }
-            }
         }
         return write_restart_file;
     }

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -27,6 +27,87 @@
 
 namespace Opm {
 
+    /*The IOConfig class holds data about input / ouput configurations
+
+      Amongst these configuration settings, a IOConfig object knows if
+      a restart file should be written for a specific report step
+
+      The write of restart files is governed by several eclipse keywords.
+      These keywords are all described in the eclipse manual, but some
+      of them are rather porly described there.
+      To have equal sets of restart files written from Eclipse and Flow for various
+      configurations, we have made a qualified guess on the behaviour
+      for some of the keywords (by running eclipse for different configurations,
+      and looked at which restart files that have been written).
+
+
+      ------ RPTSOL RESTART (solution section) ------
+      If RPTSOL RESTART > 1 initial restart file is written.
+
+
+      ------ RPTRST (solution section) ------
+      Eclipse manual states that the initial restart file is to be written
+      if RPTSOL RESTART > 1. But - due to that the initial restart file
+      is written from Eclipse for data where RPTSOL RESTART is not set, - we
+      have made a guess that when RPTRST is set in SOLUTION (no basic though...),
+      it means that the initial restart file should be written.
+      Running of eclipse with different settings have proven this to be a qualified guess.
+
+
+      ------ RPTRST BASIC=0 (solution or schedule section) ------
+      No restart files are written
+
+
+      ------ RPTRST BASIC=1 or RPTRST BASIC=2 (solution or schedule section) ------
+      Restart files are written for every timestep, from timestep 1 to number of timesteps.
+      (Write of inital timestep is governed by a separate setting)
+
+      Notice! Eclipse simulator RPTRST BASIC=1 writes restart files for every
+      report step, but only keeps the last one written. This functionality is
+      not supported in Flow; so to compare Eclipse results with Flow results
+      for every report step, set RPTRST BASIC=2 for the eclipse run
+
+
+      ------ RPTRST BASIC=3 FREQ=n (solution or schedule section) ------
+      Restart files are created every nth report time.  Default frequency is 1 (every report step)
+
+      If a frequency higher than 1 is given:
+      start_rs = report step the setting was given.
+      write report step rstep if (rstep >= start_rs) && ((rstep % frequency) == 0).
+
+
+      ------ RPTRST BASIC=4 FREQ=n or RPTRST BASIC=5 FREQ=n (solution or schedule section) ------
+      For the settings BASIC 4 or BASIC 5, - first report step of every new year(4) or new month(5),
+      the first report step is compared with report step 0 (start), and then every report step is
+      compared with the previous one to see if year/month has changed.
+
+      This leaves us with a set of timesteps.
+      All timesteps in the set that are higher or equal to the timestep the RPTRST keyword was set on is written.
+
+      If in addition FREQUENCY is given (higher than 1), every n'the value of this set are to be written.
+
+      If the setting BASIC=4 or BASIC=5 is set on a timestep that is a member of the set "first timestep of
+      each year" / "First timestep of each month", then the timestep that is freq-1 timesteps (within the set) from
+      this start timestep will be written, and then every n'the timestep (within the set) from this one will be written.
+
+      If the setting BASIC=4 or BASIC=5 is set on a timestep that is not a member of the list "first timestep of
+      each year" / "First timestep of each month", then the list is searched for the closest timestep that are
+      larger than the timestep that introduced the setting, and then; same as above - the timestep that is freq-1
+      timesteps from this one (within the set) will be written, and then every n'the timestep (within the set) from
+      this one will be written.
+
+
+      ------ RPTRST BASIC=6 (solution or schedule section) ------
+      Not supported in Flow
+
+
+      ------ Default ------
+      If no keywords for config of writing restart files have been handled; no restart files are written.
+
+    */
+
+
+
     class IOConfig {
 
     public:
@@ -66,10 +147,10 @@ namespace Opm {
 
         void assertTimeMap(TimeMapConstPtr timemap);
         bool getWriteRestartFileFrequency(size_t timestep,
-                                          size_t start_index,
+                                          size_t start_timestep,
                                           size_t frequency,
-                                          bool first_timesteps_years  = false,
-                                          bool first_timesteps_months = false) const;
+                                          bool years  = false,
+                                          bool months = false) const;
         void handleRPTSOL(DeckKeywordConstPtr keyword);
 
 
@@ -114,6 +195,7 @@ namespace Opm {
 
 
         std::shared_ptr<DynamicState<restartConfig>> m_restart_output_config;
+
 
     };
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -43,39 +43,93 @@ const std::string& deckStr =  "RUNSPEC\n"
                               " 21 MAY 1981 /\n"
                               "\n"
                               "SCHEDULE\n"
-                              "TSTEP\n"
-                              " 1 2 3 4 5 /\n"
                               "DATES\n"
-                              " 1 JAN 1982 /\n"
-                              " 1 JAN 1982 13:55:44 /\n"
-                              " 3 JAN 1982 14:56:45.123 /\n"
-                              "/\n"
-                              "TSTEP\n"
-                              " 9 10 /\n"
-                              "\n";
+                              " 22 MAY 1981 /\n"              // timestep 1
+                              " 23 MAY 1981 /\n"              // timestep 2
+                              " 24 MAY 1981 /\n"              // timestep 3
+                              " 25 MAY 1981 /\n"              // timestep 4
+                              " 26 MAY 1981 /\n"              // timestep 5
+                              " 1 JAN 1982 /\n"               // timestep 6
+                              " 1 JAN 1982 13:55:44 /\n"      // timestep 7
+                              " 3 JAN 1982 14:56:45.123 /\n"  // timestep 8
+                              " 4 JAN 1982 14:56:45.123 /\n"  // timestep 9
+                              " 5 JAN 1982 14:56:45.123 /\n"  // timestep 10
+                              " 6 JAN 1982 14:56:45.123 /\n"  // timestep 11
+                              " 7 JAN 1982 14:56:45.123 /\n"  // timestep 12
+                              " 8 JAN 1982 14:56:45.123 /\n"  // timestep 13
+                              " 9 JAN 1982 14:56:45.123 /\n"  // timestep 14
+                              " 10 JAN 1982 14:56:45.123 /\n" // timestep 15
+                              " 11 JAN 1982 14:56:45.123 /\n" // timestep 16
+                              " 1 JAN 1983 /\n"               // timestep 17
+                              " 2 JAN 1983 /\n"               // timestep 18
+                              " 3 JAN 1983 /\n"               // timestep 19
+                              " 1 JAN 1984 /\n"               // timestep 20
+                              " 2 JAN 1984 /\n"               // timestep 21
+                              " 1 JAN 1985 /\n"               // timestep 22
+                              " 3 JAN 1986 14:56:45.123 /\n"  // timestep 23
+                              " 4 JAN 1986 14:56:45.123 /\n"  // timestep 24
+                              " 5 JAN 1986 14:56:45.123 /\n"  // timestep 25
+                              " 1 JAN 1987 /\n"               // timestep 26
+                              " 1 JAN 1988 /\n"               // timestep 27
+                              " 2 JAN 1988 /\n"               // timestep 28
+                              " 3 JAN 1988 /\n"               // timestep 29
+                              " 1 JAN 1989 /\n"               // timestep 30
+                              " 2 JAN 1989 /\n"               // timestep 31
+                              " 2 JAN 1990 /\n"               // timestep 32
+                              " 2 JAN 1991 /\n"               // timestep 33
+                              " 3 JAN 1991 /\n"               // timestep 34
+                              " 4 JAN 1991 /\n"               // timestep 35
+                              " 1 JAN 1992 /\n"               // timestep 36
+                              " 1 FEB 1992 /\n"               // timestep 37
+                              " 1 MAR 1992 /\n"               // timestep 38
+                              " 2 MAR 1992 /\n"               // timestep 39
+                              " 3 MAR 1992 /\n"               // timestep 40
+                              " 4 MAR 1992 /\n"               // timestep 41
+                              " 1 APR 1992 /\n"               // timestep 42
+                              " 2 APR 1992 /\n"               // timestep 43
+                              " 1 MAY 1992 /\n"               // timestep 44
+                              " 2 MAY 1992 /\n"               // timestep 45
+                              " 3 MAY 1992 /\n"               // timestep 46
+                              " 3 JUN 1992 /\n"               // timestep 47
+                              " 3 JUL 1992 /\n"               // timestep 48
+                              " 3 AUG 1992 /\n"               // timestep 49
+                              " 4 AUG 1992 /\n"               // timestep 50
+                              " 5 AUG 1992 /\n"               // timestep 51
+                              " 6 AUG 1992 /\n"               // timestep 52
+                              " 7 AUG 1992 /\n"               // timestep 53
+                              " 8 AUG 1992 /\n"               // timestep 54
+                              " 9 AUG 1992 /\n"               // timestep 55
+                              " 10 AUG 1992 /\n"              // timestep 56
+                              " 11 AUG 1992 /\n"              // timestep 57
+                              " 12 AUG 1992 /\n"              // timestep 58
+                              " 13 AUG 1992 /\n"              // timestep 59
+                              " 14 AUG 1992 /\n"              // timestep 60
+                              " 15 AUG 1992 /\n"              // timestep 61
+                                                        "/\n"
+                                                        "\n";
 
 
-const std::string& deckStr3 =  "RUNSPEC\n"
-                               "UNIFIN\n"
-                               "UNIFOUT\n"
-                               "FMTIN\n"
-                               "FMTOUT\n"
-                               "\n"
-                               "DIMENS\n"
-                               "10 10 10 /\n"
-                               "GRID\n"
-                               "INIT\n"
-                               "NOGGF\n"
-                               "\n";
+const std::string& deckStr_NOGGF = "RUNSPEC\n"
+                                   "UNIFIN\n"
+                                   "UNIFOUT\n"
+                                   "FMTIN\n"
+                                   "FMTOUT\n"
+                                   "\n"
+                                   "DIMENS\n"
+                                   "10 10 10 /\n"
+                                   "GRID\n"
+                                   "INIT\n"
+                                   "NOGGF\n"
+                                   "\n";
 
-const std::string& deckStr4 =  "RUNSPEC\n"
-                               "\n"
-                               "DIMENS\n"
-                              " 10 10 10 /\n"
-                               "GRID\n"
-                               "GRIDFILE\n"
-                               " 0 0 /\n"
-                               "\n";
+const std::string& deckStr_NO_GRIDFILE = "RUNSPEC\n"
+                                         "\n"
+                                         "DIMENS\n"
+                                        " 10 10 10 /\n"
+                                         "GRID\n"
+                                         "GRIDFILE\n"
+                                         " 0 0 /\n"
+                                         "\n";
 
 
 
@@ -102,8 +156,15 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
 
     Schedule schedule(ParseMode() , grid , deck, ioConfigPtr);
 
+    TimeMapConstPtr timemap   = schedule.getTimeMap();
+    const TimeMap* const_tmap = timemap.get();
+    TimeMap* writableTimemap  = const_cast<TimeMap*>(const_tmap);
+
+    writableTimemap->initFirstTimestepsYears();
+    writableTimemap->initFirstTimestepsMonths();
+
+
     //If no BASIC keyord has been handled, no restart files should be written
-    TimeMapConstPtr timemap = schedule.getTimeMap();
     for (size_t ts = 0; ts < timemap->numTimesteps(); ++ts) {
         BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
     }
@@ -120,24 +181,6 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
         }
     }
 
-    //Add timestep 11, 12, 13, 14, 15, 16
-    const TimeMap* const_tmap = timemap.get();
-    TimeMap* writableTimemap = const_cast<TimeMap*>(const_tmap);
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-
-
-    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(11));
-    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(12));
-    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(13));
-    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(14));
-    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(15));
-    BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(16));
-
 
     /* BASIC=3, restart files are created every nth report time, n=3 */
     timestep      = 11;
@@ -146,24 +189,13 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic, frequency);
 
     for (size_t ts = timestep ; ts < timemap->numTimesteps(); ++ts) {
-        if (((ts-timestep) % frequency) == 0) {
+        if ((ts >= timestep) && ((ts % frequency) == 0)) {
             BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
         } else {
             BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
         }
     }
 
-    //Add timestep 17, 18, 19, 20, 21, 22, 23, 24, 25, 26
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1983
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1984
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1985
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1986
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1987
 
     /* BASIC=4, restart file is written at the first report step of each year.
        Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th year*/
@@ -172,10 +204,11 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     frequency     = 0;
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic, frequency);
 
-    /*Expected results: Write timestep for timestep 20, 22, 23, 26*/
 
-    for (size_t ts = 17; ts <= 26; ++ts) {
-        if ((20 == ts) || (22 == ts) || (23 == ts) || (26 == ts)) {
+    for (size_t ts = timestep; ts < timemap->numTimesteps(); ++ts) {
+        ioConfigPtr->getWriteRestartFile(ts);
+        if ((17 == ts) || (20 == ts) || (22 == ts) || (23 == ts) || (26 == ts) ||
+            (27 == ts) || (30 == ts) || (32 == ts) || (33 == ts) || (36 == ts)) {
             BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
         } else {
             BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
@@ -183,17 +216,23 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     }
 
 
-    //Add timestep 27, 28, 29, 30, 31, 32, 33, 34, 35, 36
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1988
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1989
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1990
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1991
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(8760)); //1992
+    /* BASIC=4, restart file is written at the first report step of each year.
+       Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th year*/
+    timestep      = 18;
+    basic         = 4;
+    frequency     = 0;
+    ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(),timestep, basic, frequency);
+
+    for (size_t ts = timestep; ts < timemap->numTimesteps(); ++ts) {
+        ioConfigPtr->getWriteRestartFile(ts);
+        if ((20 == ts) || (22 == ts) || (23 == ts) || (26 == ts) ||
+            (27 == ts) || (30 == ts) || (32 == ts) || (33 == ts) || (36 == ts)) {
+            BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
+        } else {
+            BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+        }
+    }
+
 
     /* BASIC=4, FREQ = 2 restart file is written at the first report step of each year.
        Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th year*/
@@ -202,10 +241,8 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     frequency     = 2;
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(), timestep, basic, frequency);
 
-    //Expected results: Write timestep for 32 and 36 (30, 32, 33, 36 with frequency 2)
-
-    for (size_t ts = 27; ts <= 36; ++ts) {
-        if ((32 == ts) || (36 == ts)) {
+    for (size_t ts = timestep; ts < timemap->numTimesteps(); ++ts) {
+        if ((30 == ts) || (33 == ts)) {
             BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
         } else {
             BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
@@ -213,18 +250,6 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     }
 
 
-
-    //Add timestep 37, 38, 39, 40, 41, 42, 43, 44, 45, 46
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //february
-    writableTimemap->addTStep(boost::posix_time::hours(650)); //march
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //march
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //march
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //march
-    writableTimemap->addTStep(boost::posix_time::hours(650)); //april
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //april
-    writableTimemap->addTStep(boost::posix_time::hours(650)); //may
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //may
-    writableTimemap->addTStep(boost::posix_time::hours(24));  //may
 
     /* BASIC=5, restart file is written at the first report step of each month.
        Optionally, if the mnemonic FREQ is set >1 the restart is written only every n'th month*/
@@ -233,20 +258,14 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     frequency     = 2;
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(), timestep, basic, frequency);
 
-    //Expected results: Write timestep for timestep  38, 44 (38, 42, 44 with frequency 2)
-
-    for (size_t ts = 37; ts <= 46; ++ts) {
-        if (42 == ts) {
+    for (size_t ts = timestep; ts < timemap->numTimesteps(); ++ts) {
+        if ((38 == ts) || (44 == ts) || (48 == ts)) {
             BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(ts));
         } else {
             BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
         }
     }
 
-    //Add timestep 47, 48, 49
-    writableTimemap->addTStep(boost::posix_time::hours(750)); //june
-    writableTimemap->addTStep(boost::posix_time::hours(750)); //july
-    writableTimemap->addTStep(boost::posix_time::hours(750)); //august
 
     /* BASIC=0, no restart files are written*/
     timestep      = 47;
@@ -254,16 +273,14 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     frequency     = 0;
     ioConfigPtr->handleRPTRSTBasic(schedule.getTimeMap(), timestep, basic, frequency);
 
-    BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(47));
-    BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(48));
-    BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(49));
+    for (size_t ts = timestep; ts < timemap->numTimesteps(); ++ts) {
+        BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(ts));
+    }
+
+
 
 
     /************************* Test RPTSCHED RESTART *************************/
-
-    //Add timestep 50, 51
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
 
     /* RPTSCHED RESTART=1, restart files are written*/
     timestep       = 50;
@@ -273,10 +290,6 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(50));
     BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(51));
 
-    //Add timestep 52, 53
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-
     /* RPTSCHED RESTART=0, no restart files are written*/
     timestep      = 52;
     restart       = 0;
@@ -285,19 +298,12 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(52));
     BOOST_CHECK_EQUAL(false, ioConfigPtr->getWriteRestartFile(53));
 
-    //Add timestep 54, 55
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
     timestep      = 54;
     basic         = 0;
     ioConfigPtr->handleRPTSCHEDRestart(schedule.getTimeMap(), timestep, restart);
 
 
     /* RPTSCHED RESTART IGNORED IF RPTRST BASIC > 2 */
-
-    //Add timestep 56, 57, 58, 59
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
     timestep      = 56;
     basic         = 3;
     frequency     = 1;
@@ -313,11 +319,7 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     ioConfigPtr->handleRPTSCHEDRestart(schedule.getTimeMap(), timestep, restart);
     BOOST_CHECK_EQUAL(true, ioConfigPtr->getWriteRestartFile(timestep));
 
-
     /* RPTSCHED RESTART NOT IGNORED IF RPTRST BASIC <= 2 */
-    //Add timestep 60, 61
-    writableTimemap->addTStep(boost::posix_time::hours(24));
-    writableTimemap->addTStep(boost::posix_time::hours(24));
     timestep      = 60;
     basic         = 1;
     frequency     = 0;
@@ -367,7 +369,7 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     BOOST_CHECK_EQUAL(false, ioConfigPtr->getFMTOUT());
 
     /*If NOGGF keyword is present, no EGRID file is written*/
-    DeckPtr deck3 = createDeck(deckStr3);
+    DeckPtr deck3 = createDeck(deckStr_NOGGF);
     IOConfigPtr ioConfigPtr3;
     BOOST_CHECK_NO_THROW(ioConfigPtr3 = std::make_shared<IOConfig>());
 
@@ -388,7 +390,7 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     BOOST_CHECK_EQUAL(true, ioConfigPtr3->getFMTOUT());
 
     /*If GRIDFILE 0 0 is specified, no EGRID file is written */
-    DeckPtr deck4 = createDeck(deckStr4);
+    DeckPtr deck4 = createDeck(deckStr_NO_GRIDFILE);
     IOConfigPtr ioConfigPtr4;
     BOOST_CHECK_NO_THROW(ioConfigPtr4 = std::make_shared<IOConfig>());
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -187,6 +187,9 @@ namespace Opm {
             }
         }
 
+        m_timeMap->initFirstTimestepsYears();
+        m_timeMap->initFirstTimestepsMonths();
+
         for (auto rftPair = rftProperties.begin(); rftPair != rftProperties.end(); ++rftPair) {
             DeckKeywordConstPtr keyword = rftPair->first;
             size_t timeStep = rftPair->second;

--- a/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -39,6 +39,8 @@ namespace Opm {
         void addTStep(boost::posix_time::time_duration step);
         void addFromDATESKeyword( DeckKeywordConstPtr DATESKeyword );
         void addFromTSTEPKeyword( DeckKeywordConstPtr TSTEPKeyword );
+        void initFirstTimestepsMonths();
+        void initFirstTimestepsYears();
         size_t size() const;
         size_t numTimesteps() const;
         double getTotalTime() const;
@@ -49,10 +51,12 @@ namespace Opm {
         double getTimePassedUntil(size_t tLevelIdx) const;
         /// Return the length of a given time step in seconds.
         double getTimeStepLength(size_t tStepIdx) const;
-        /// Return a list of the first timesteps of each month
-        void initFirstTimestepsMonths(std::vector<size_t>& timesteps, size_t from_timestep=1) const;
-        /// Return a list of the first timesteps of each year
-        void initFirstTimestepsYears(std::vector<size_t>& timesteps, size_t from_timestep=1) const;
+
+        /// Return true if the given timestep is the first one of a new month or year, or if frequency > 1,
+        /// return true for every n'th timestep of every first new month or first new year timesteps,
+        /// starting from start_timestep-1.
+        bool isTimestepInFirstOfMonthsYearsSequence(size_t timestep, bool years = true, size_t start_timestep = 1, size_t frequency = 1) const;
+
         static boost::posix_time::ptime timeFromEclipse(DeckRecordConstPtr dateRecord);
         static boost::posix_time::ptime timeFromEclipse(int day , const std::string& month, int year, const std::string& eclipseTimeString = "00:00:00.000");
         static boost::posix_time::time_duration dayTimeFromEclipse(const std::string& eclipseTimeString);
@@ -60,6 +64,14 @@ namespace Opm {
         static const std::map<std::string , boost::gregorian::greg_month>& eclipseMonthNames();
 
         std::vector<boost::posix_time::ptime> m_timeList;
+
+        const std::vector<size_t>& getFirstTimestepMonths() const;
+        const std::vector<size_t>& getFirstTimestepYears() const;
+        bool isTimestepInFreqSequence (size_t timestep, size_t start_timestep, size_t frequency, bool years) const;
+        size_t closest(const std::vector<size_t> & vec, size_t value) const;
+
+        std::vector<size_t> m_first_timestep_years;   // A list of the first timestep of every year
+        std::vector<size_t> m_first_timestep_months;  // A list of the first timestep of every month
     };
     typedef std::shared_ptr<TimeMap> TimeMapPtr;
     typedef std::shared_ptr<const TimeMap> TimeMapConstPtr;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -1061,8 +1061,8 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHEDandRPTRST) {
 
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(1));
-    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(false, ioConfig->getWriteRestartFile(2));
+    BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
@@ -304,9 +304,13 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
         "TSTEP\n"
         " 6 7 /\n";
 
-    Opm::ParserPtr parser(new Opm::Parser(/*addDefault=*/true));
+    Opm::ParserPtr parser(new Opm::Parser(true));
     Opm::DeckPtr deck = parser->parseString(deckData, Opm::ParseMode());
-    Opm::TimeMap tmap(deck);
+    const Opm::TimeMap tmap(deck);
+
+    Opm::TimeMap* writableTimemap = const_cast<Opm::TimeMap*>(&tmap);
+    writableTimemap->initFirstTimestepsMonths();
+    writableTimemap->initFirstTimestepsYears();
 
     /*deckData timesteps:
     0   21 may  1981 START
@@ -326,29 +330,23 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
     14  1  jan  1982
     15  3  jan  1982
     16  9  jan  1982
-    17  16 jan  1982
-   */
+    17  16 jan  1982*/
 
-    std::vector<size_t> first_timestep_of_each_month;
-    tmap.initFirstTimestepsMonths(first_timestep_of_each_month);
-    BOOST_CHECK_EQUAL(8, first_timestep_of_each_month.size());
-    int expected_results[8] = {5,6,8,9,10,11,12,13};
-    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results, expected_results+8, first_timestep_of_each_month.begin(), first_timestep_of_each_month.end());
+    for (size_t timestep = 0; timestep <= 17; ++timestep) {
+        if ((5 == timestep) || (6 == timestep) || (8 == timestep) || (9 == timestep) ||
+            (10 == timestep) || (11 == timestep) || (12 == timestep) || (13 == timestep)) {
+            BOOST_CHECK_EQUAL(true, tmap.isTimestepInFirstOfMonthsYearsSequence(timestep, false, true));
+        } else {
+            BOOST_CHECK_EQUAL(false, tmap.isTimestepInFirstOfMonthsYearsSequence(timestep, false, true));
+        }
+    }
 
-    first_timestep_of_each_month.clear();
-    tmap.initFirstTimestepsMonths(first_timestep_of_each_month, 6);
-    BOOST_CHECK_EQUAL(6, first_timestep_of_each_month.size());
-    int expected_results3[6] = {8,9,10,11,12,13};
-    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results3, expected_results3+6, first_timestep_of_each_month.begin(), first_timestep_of_each_month.end());
-
-    std::vector<size_t> first_timestep_of_each_year;
-    tmap.initFirstTimestepsYears(first_timestep_of_each_year);
-    BOOST_CHECK_EQUAL(1, first_timestep_of_each_year.size());
-    int expected_results_years[1] = {13};
-    BOOST_CHECK_EQUAL_COLLECTIONS(expected_results_years, expected_results_years+1, first_timestep_of_each_year.begin(), first_timestep_of_each_year.end());
-
-    first_timestep_of_each_year.clear();
-    tmap.initFirstTimestepsYears(first_timestep_of_each_year, 13);
-    BOOST_CHECK_EQUAL(0, first_timestep_of_each_year.size());
+    for (size_t timestep = 0; timestep <= 17; ++timestep) {
+        if (13 == timestep) {
+            BOOST_CHECK_EQUAL(true, tmap.isTimestepInFirstOfMonthsYearsSequence(timestep, true, false));
+        } else {
+            BOOST_CHECK_EQUAL(false, tmap.isTimestepInFirstOfMonthsYearsSequence(timestep, true, false));
+        }
+    }
 }
 

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -492,7 +492,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
     BOOST_CHECK_EQUAL(true  , ioConfig->getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false , ioConfig->getWriteRestartFile(1));
     BOOST_CHECK_EQUAL(false , ioConfig->getWriteRestartFile(2));
-    BOOST_CHECK_EQUAL(true  , ioConfig->getWriteRestartFile(3));
+    BOOST_CHECK_EQUAL(false  , ioConfig->getWriteRestartFile(3));
 }
 
 

--- a/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -34,6 +34,22 @@
 using namespace Opm;
 
 
+void verifyRestartConfig(IOConfigConstPtr ioconfig, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
+
+    for (auto rptrst : rptConfig) {
+        int report_step                    = std::get<0>(rptrst);
+        bool save                          = std::get<1>(rptrst);
+        boost::gregorian::date report_date = std::get<2>(rptrst);
+
+        BOOST_CHECK_EQUAL( save , ioconfig->getWriteRestartFile( report_step ));
+        if (save) {
+            BOOST_CHECK_EQUAL( report_date, ioconfig->getTimestepDate( report_step ));
+        }
+        std::cout << "step: " << report_step << " date: " << report_date << " : " << save << std::endl;
+    }
+}
+
+
 
 BOOST_AUTO_TEST_CASE( NorneResttartConfig ) {
     std::vector<std::tuple<int , bool, boost::gregorian::date> > rptConfig;
@@ -286,18 +302,7 @@ BOOST_AUTO_TEST_CASE( NorneResttartConfig ) {
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/RPTRST_DECK.DATA", parseMode);
     EclipseState state( deck , parseMode );
 
-    std::shared_ptr<const IOConfig> ioconfig = state.getIOConfigConst();
-    for (auto rptrst : rptConfig) {
-        int report_step                    = std::get<0>(rptrst);
-        bool save                          = std::get<1>(rptrst);
-        boost::gregorian::date report_date = std::get<2>(rptrst);
-
-        BOOST_CHECK_EQUAL( save , ioconfig->getWriteRestartFile( report_step ));
-        if (save) {
-          BOOST_CHECK_EQUAL( report_date, ioconfig->getTimestepDate( report_step ));
-        }
-        std::cout << "step: " << report_step << " date: " << report_date << " : " << save << std::endl;
-    }
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
 
 
@@ -342,19 +347,653 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/RPT_TEST2.DATA", parseMode);
     EclipseState state( deck , parseMode );
 
-    std::shared_ptr<const IOConfig> ioconfig = state.getIOConfigConst();
-    for (auto rptrst : rptConfig) {
-        int report_step                    = std::get<0>(rptrst);
-        bool save                          = std::get<1>(rptrst);
-        boost::gregorian::date report_date = std::get<2>(rptrst);
-
-        BOOST_CHECK_EQUAL( save , ioconfig->getWriteRestartFile( report_step ));
-        if (save) {
-          BOOST_CHECK_EQUAL( report_date, ioconfig->getTimestepDate( report_step ));
-        }
-        std::cout << "step: " << report_step << " date: " << report_date << " : " << save << std::endl;
-    }
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+
+
+
+
+//----------------- TESTS on SPE1CASE2 ---------------------------------------------------------------------
+
+void fillRptConfig(std::vector<std::tuple<int, bool, boost::gregorian::date>>& rptConfig) {
+
+    rptConfig.push_back( std::make_tuple(0,  false,  boost::gregorian::date(2015,1,1)));
+
+    rptConfig.push_back( std::make_tuple(1,  true,   boost::gregorian::date(2015,2,1)));
+    rptConfig.push_back( std::make_tuple(2,  true,   boost::gregorian::date(2015,3,1)));
+    rptConfig.push_back( std::make_tuple(3,  true,   boost::gregorian::date(2015,4,1)));
+    rptConfig.push_back( std::make_tuple(4,  true,   boost::gregorian::date(2015,5,1)));
+    rptConfig.push_back( std::make_tuple(5,  true,   boost::gregorian::date(2015,6,1)));
+    rptConfig.push_back( std::make_tuple(6,  true,   boost::gregorian::date(2015,7,1)));
+    rptConfig.push_back( std::make_tuple(7,  true,   boost::gregorian::date(2015,8,1)));
+    rptConfig.push_back( std::make_tuple(8,  true,   boost::gregorian::date(2015,9,1)));
+    rptConfig.push_back( std::make_tuple(9,  true,   boost::gregorian::date(2015,10,1)));
+    rptConfig.push_back( std::make_tuple(10, true,   boost::gregorian::date(2015,11,1)));
+    rptConfig.push_back( std::make_tuple(11, true,   boost::gregorian::date(2015,12,1)));
+    rptConfig.push_back( std::make_tuple(12, true,   boost::gregorian::date(2016,1,1)));
+    rptConfig.push_back( std::make_tuple(13, true,   boost::gregorian::date(2016,2,1)));
+
+    rptConfig.push_back( std::make_tuple(14, false,  boost::gregorian::date(2016,2,29)));
+
+    rptConfig.push_back( std::make_tuple(15, true,   boost::gregorian::date(2016,3,31)));
+    rptConfig.push_back( std::make_tuple(16, true,   boost::gregorian::date(2016,4,30)));
+    rptConfig.push_back( std::make_tuple(17, true,   boost::gregorian::date(2016,5,31)));
+    rptConfig.push_back( std::make_tuple(18, true,   boost::gregorian::date(2016,6,30)));
+    rptConfig.push_back( std::make_tuple(19, true,   boost::gregorian::date(2016,7,31)));
+    rptConfig.push_back( std::make_tuple(20, true,   boost::gregorian::date(2016,8,31)));
+    rptConfig.push_back( std::make_tuple(21, true,   boost::gregorian::date(2016,9,30)));
+    rptConfig.push_back( std::make_tuple(22, true,   boost::gregorian::date(2016,10,31)));
+    rptConfig.push_back( std::make_tuple(23, true,   boost::gregorian::date(2016,11,30)));
+    rptConfig.push_back( std::make_tuple(24, true,   boost::gregorian::date(2016,12,31)));
+
+    rptConfig.push_back( std::make_tuple(25, true,   boost::gregorian::date(2017,1,31)));
+    rptConfig.push_back( std::make_tuple(26, true,   boost::gregorian::date(2017,2,28)));
+    rptConfig.push_back( std::make_tuple(27, true,   boost::gregorian::date(2017,3,31)));
+    rptConfig.push_back( std::make_tuple(28, true,   boost::gregorian::date(2017,4,30)));
+    rptConfig.push_back( std::make_tuple(29, true,   boost::gregorian::date(2017,5,31)));
+    rptConfig.push_back( std::make_tuple(30, true,   boost::gregorian::date(2017,6,30)));
+    rptConfig.push_back( std::make_tuple(31, true,   boost::gregorian::date(2017,7,31)));
+    rptConfig.push_back( std::make_tuple(32, true,   boost::gregorian::date(2017,8,31)));
+    rptConfig.push_back( std::make_tuple(33, true,   boost::gregorian::date(2017,9,30)));
+    rptConfig.push_back( std::make_tuple(34, true,   boost::gregorian::date(2017,10,31)));
+    rptConfig.push_back( std::make_tuple(35, true,   boost::gregorian::date(2017,11,30)));
+    rptConfig.push_back( std::make_tuple(36, true,   boost::gregorian::date(2017,12,31)));
+
+    rptConfig.push_back( std::make_tuple(37, true,   boost::gregorian::date(2018,1,31)));
+    rptConfig.push_back( std::make_tuple(38, true,   boost::gregorian::date(2018,2,28)));
+    rptConfig.push_back( std::make_tuple(39, true,   boost::gregorian::date(2018,3,31)));
+    rptConfig.push_back( std::make_tuple(40, true,   boost::gregorian::date(2018,4,30)));
+    rptConfig.push_back( std::make_tuple(41, true,   boost::gregorian::date(2018,5,31)));
+    rptConfig.push_back( std::make_tuple(42, true,   boost::gregorian::date(2018,6,30)));
+    rptConfig.push_back( std::make_tuple(43, true,   boost::gregorian::date(2018,7,31)));
+    rptConfig.push_back( std::make_tuple(44, true,   boost::gregorian::date(2018,8,31)));
+    rptConfig.push_back( std::make_tuple(45, true,   boost::gregorian::date(2018,9,30)));
+    rptConfig.push_back( std::make_tuple(46, true,   boost::gregorian::date(2018,10,31)));
+    rptConfig.push_back( std::make_tuple(47, true,   boost::gregorian::date(2018,11,30)));
+    rptConfig.push_back( std::make_tuple(48, true,   boost::gregorian::date(2018,12,31)));
+
+    rptConfig.push_back( std::make_tuple(49, true,   boost::gregorian::date(2019,1,31)));
+    rptConfig.push_back( std::make_tuple(50, true,   boost::gregorian::date(2019,2,28)));
+    rptConfig.push_back( std::make_tuple(51, true,   boost::gregorian::date(2019,3,31)));
+    rptConfig.push_back( std::make_tuple(52, true,   boost::gregorian::date(2019,4,30)));
+    rptConfig.push_back( std::make_tuple(53, true,   boost::gregorian::date(2019,5,31)));
+    rptConfig.push_back( std::make_tuple(54, true,   boost::gregorian::date(2019,6,30)));
+    rptConfig.push_back( std::make_tuple(55, true,   boost::gregorian::date(2019,7,31)));
+    rptConfig.push_back( std::make_tuple(56, true,   boost::gregorian::date(2019,8,31)));
+    rptConfig.push_back( std::make_tuple(57, true,   boost::gregorian::date(2019,9,30)));
+    rptConfig.push_back( std::make_tuple(58, true,   boost::gregorian::date(2019,10,31)));
+    rptConfig.push_back( std::make_tuple(59, true,   boost::gregorian::date(2019,11,30)));
+    rptConfig.push_back( std::make_tuple(60, true,   boost::gregorian::date(2019,12,31)));
+
+    rptConfig.push_back( std::make_tuple(61, true,   boost::gregorian::date(2020,1,31)));
+    rptConfig.push_back( std::make_tuple(62, true,   boost::gregorian::date(2020,2,28)));
+    rptConfig.push_back( std::make_tuple(63, true,   boost::gregorian::date(2020,3,30)));
+    rptConfig.push_back( std::make_tuple(64, true,   boost::gregorian::date(2020,4,29)));
+    rptConfig.push_back( std::make_tuple(65, true,   boost::gregorian::date(2020,5,30)));
+    rptConfig.push_back( std::make_tuple(66, true,   boost::gregorian::date(2020,6,29)));
+    rptConfig.push_back( std::make_tuple(67, true,   boost::gregorian::date(2020,7,30)));
+    rptConfig.push_back( std::make_tuple(68, true,   boost::gregorian::date(2020,8,30)));
+    rptConfig.push_back( std::make_tuple(69, true,   boost::gregorian::date(2020,9,29)));
+    rptConfig.push_back( std::make_tuple(70, true,   boost::gregorian::date(2020,10,30)));
+    rptConfig.push_back( std::make_tuple(71, true,   boost::gregorian::date(2020,11,29)));
+    rptConfig.push_back( std::make_tuple(72, true,   boost::gregorian::date(2020,12,30)));
+
+    rptConfig.push_back( std::make_tuple(73, true,   boost::gregorian::date(2021,1,30)));
+    rptConfig.push_back( std::make_tuple(74, true,   boost::gregorian::date(2021,2,27)));
+    rptConfig.push_back( std::make_tuple(75, true,   boost::gregorian::date(2021,3,30)));
+    rptConfig.push_back( std::make_tuple(76, true,   boost::gregorian::date(2021,4,29)));
+    rptConfig.push_back( std::make_tuple(77, true,   boost::gregorian::date(2021,5,30)));
+    rptConfig.push_back( std::make_tuple(78, true,   boost::gregorian::date(2021,6,29)));
+    rptConfig.push_back( std::make_tuple(79, true,   boost::gregorian::date(2021,7,30)));
+    rptConfig.push_back( std::make_tuple(80, true,   boost::gregorian::date(2021,8,30)));
+    rptConfig.push_back( std::make_tuple(81, true,   boost::gregorian::date(2021,9,29)));
+    rptConfig.push_back( std::make_tuple(82, true,   boost::gregorian::date(2021,10,30)));
+    rptConfig.push_back( std::make_tuple(83, true,   boost::gregorian::date(2021,11,29)));
+    rptConfig.push_back( std::make_tuple(84, true,   boost::gregorian::date(2021,12,30)));
+
+    rptConfig.push_back( std::make_tuple(85, true,   boost::gregorian::date(2022,1,30)));
+    rptConfig.push_back( std::make_tuple(86, true,   boost::gregorian::date(2022,2,27)));
+    rptConfig.push_back( std::make_tuple(87, true,   boost::gregorian::date(2022,3,30)));
+    rptConfig.push_back( std::make_tuple(88, true,   boost::gregorian::date(2022,4,29)));
+    rptConfig.push_back( std::make_tuple(89, true,   boost::gregorian::date(2022,5,30)));
+    rptConfig.push_back( std::make_tuple(90, true,   boost::gregorian::date(2022,6,29)));
+    rptConfig.push_back( std::make_tuple(91, true,   boost::gregorian::date(2022,7,30)));
+    rptConfig.push_back( std::make_tuple(92, true,   boost::gregorian::date(2022,8,30)));
+    rptConfig.push_back( std::make_tuple(93, true,   boost::gregorian::date(2022,9,29)));
+    rptConfig.push_back( std::make_tuple(94, true,   boost::gregorian::date(2022,10,30)));
+    rptConfig.push_back( std::make_tuple(95, true,   boost::gregorian::date(2022,11,29)));
+    rptConfig.push_back( std::make_tuple(96, true,   boost::gregorian::date(2022,12,30)));
+
+    rptConfig.push_back( std::make_tuple(97,  true,   boost::gregorian::date(2023,1,30)));
+    rptConfig.push_back( std::make_tuple(98,  true,   boost::gregorian::date(2023,2,27)));
+    rptConfig.push_back( std::make_tuple(99,  true,   boost::gregorian::date(2023,3,30)));
+    rptConfig.push_back( std::make_tuple(100, true,   boost::gregorian::date(2023,4,29)));
+    rptConfig.push_back( std::make_tuple(101, true,   boost::gregorian::date(2023,5,30)));
+    rptConfig.push_back( std::make_tuple(102, true,   boost::gregorian::date(2023,6,29)));
+    rptConfig.push_back( std::make_tuple(103, true,   boost::gregorian::date(2023,7,30)));
+    rptConfig.push_back( std::make_tuple(104, true,   boost::gregorian::date(2023,8,30)));
+    rptConfig.push_back( std::make_tuple(105, true,   boost::gregorian::date(2023,9,29)));
+    rptConfig.push_back( std::make_tuple(106, true,   boost::gregorian::date(2023,10,30)));
+    rptConfig.push_back( std::make_tuple(107, true,   boost::gregorian::date(2023,11,29)));
+    rptConfig.push_back( std::make_tuple(108, true,   boost::gregorian::date(2023,12,30)));
+
+    rptConfig.push_back( std::make_tuple(109, true,   boost::gregorian::date(2024,1,30)));
+    rptConfig.push_back( std::make_tuple(110, true,   boost::gregorian::date(2024,2,27)));
+    rptConfig.push_back( std::make_tuple(111, true,   boost::gregorian::date(2024,3,29)));
+    rptConfig.push_back( std::make_tuple(112, true,   boost::gregorian::date(2024,4,28)));
+    rptConfig.push_back( std::make_tuple(113, true,   boost::gregorian::date(2024,5,29)));
+    rptConfig.push_back( std::make_tuple(114, true,   boost::gregorian::date(2024,6,28)));
+    rptConfig.push_back( std::make_tuple(115, true,   boost::gregorian::date(2024,7,29)));
+    rptConfig.push_back( std::make_tuple(116, true,   boost::gregorian::date(2024,8,29)));
+    rptConfig.push_back( std::make_tuple(117, true,   boost::gregorian::date(2024,9,28)));
+    rptConfig.push_back( std::make_tuple(118, true,   boost::gregorian::date(2024,10,29)));
+    rptConfig.push_back( std::make_tuple(119, true,   boost::gregorian::date(2024,11,28)));
+    rptConfig.push_back( std::make_tuple(120, true,   boost::gregorian::date(2024,12,29)));
+}
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_SET_ON_TIMESTEP_1 ) {
+
+    //Write reportfile every first day of a month
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+    EclipseState state( deck , parseMode );
+
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    TimeMapConstPtr timemap = state.getSchedule()->getTimeMap();
+    ioconfig->handleRPTRSTBasic(timemap,
+                                1,
+                                basic);
+
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+    fillRptConfig(rptConfig);
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_SET_ON_TIMESTEP_13 ) {
+
+    //Write reportfile every first day of a month
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    TimeMapConstPtr timemap = state.getSchedule()->getTimeMap();
+    ioconfig->handleRPTRSTBasic(timemap,
+                                13,
+                                basic);
+
+    // Expecting same results as Eclipse:
+    // Report steps 13 (1 Feb 2016) - 120 (29 Dec 2024) should be written,
+    // except for step 14!
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+    fillRptConfig(rptConfig);
+    for (size_t reportstep = 1; reportstep <= 12; ++reportstep) {
+        std::get<1>(rptConfig[reportstep]) = false;
+    }
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_SET_ON_TIMESTEP_14 ) {
+
+    //Write reportfile every first day of a month
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    TimeMapConstPtr timemap = state.getSchedule()->getTimeMap();
+    ioconfig->handleRPTRSTBasic(timemap,
+                                14,
+                                basic);
+
+    // Expecting same results as Eclipse:
+    // Report steps 15 (31 Mars 2016) - 120 (29 Dec 2024) should be written
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+    fillRptConfig(rptConfig);
+    for (size_t reportstep = 1; reportstep <= 14; ++reportstep) {
+        std::get<1>(rptConfig[reportstep]) = false;
+    }
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_SET_ON_TIMESTEP_37 ) {
+
+    //Write reportfile every first day of a month
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    TimeMapConstPtr timemap = state.getSchedule()->getTimeMap();
+    ioconfig->handleRPTRSTBasic(timemap,
+                                37,
+                                basic);
+
+    // Expecting same results as Eclipse:
+    // Report steps 37 (31 Jan 2018) - 120 (29 Dec 2024) should be written
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+    fillRptConfig(rptConfig);
+    for (size_t reportstep = 1; reportstep <= 36; ++reportstep) {
+        std::get<1>(rptConfig[reportstep]) = false;
+    }
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ10_SET_ON_TIMESTEP_10 ) {
+    //Write reportfile every first day of each month, with frequency 10
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (20 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2016,8,31)));
+        } else if (30 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,6,30)));
+        } else if (40 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,4,30)));
+        } else if (50 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,2,28)));
+        } else if (60 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,12,31)));
+        } else if (70 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2020,10,30)));
+        } else if (80 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,8,30)));
+        } else if (90 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,6,29)));
+        } else if (100 == reportstep) {
+          rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2023,4,29)));
+        } else if (110 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,2,27)));
+        } else if (120 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,12,29)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    int freq  = 10;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                10,
+                                basic,
+                                freq);
+
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ40_SET_ON_TIMESTEP_1 ) {
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (0 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        } else if (41 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,5,31)));
+        } else if (81 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,9,29)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    int freq  = 40;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                1,
+                                basic,
+                                freq);
+
+
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ40_SET_ON_TIMESTEP_14 ) {
+
+    //Write reportfile every first day of a month, with frequency 40
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 5;
+    int freq  = 40;
+    TimeMapConstPtr timemap = state.getSchedule()->getTimeMap();
+    ioconfig->handleRPTRSTBasic(timemap,
+                                14,
+                                basic,
+                                freq);
+
+    // Expecting same results as Eclipse:
+    // Report steps 54 and 94 should be written
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (54 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,6,30)));
+        } else if (94 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,10,30)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_1 ) {
+    //Write reportfile every first day of each year
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (12 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2016,1,1)));
+        } else if (25 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,1,31)));
+        } else if (37 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,1,31)));
+        } else if (49 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,1,31)));
+        } else if (61 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2020,1,31)));
+        } else if (73 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,1,30)));
+        } else if (85 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,1,30)));
+        } else if (97 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2023,1,30)));
+        } else if (109 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,1,30)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+    int basic = 4;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                1,
+                                basic);
+
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_12 ) {
+
+    //Write reportfile every first day of each year
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (12 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2016,1,1)));
+        } else if (25 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,1,31)));
+        } else if (37 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,1,31)));
+        } else if (49 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,1,31)));
+        } else if (61 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2020,1,31)));
+        } else if (73 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,1,30)));
+        } else if (85 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,1,30)));
+        } else if (97 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2023,1,30)));
+        } else if (109 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,1,30)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+
+    int basic = 4;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                12,
+                                basic);
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_13 ) {
+
+    //Write reportfile every first day of each year
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (25 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,1,31)));
+        } else if (37 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,1,31)));
+        } else if (49 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,1,31)));
+        } else if (61 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2020,1,31)));
+        } else if (73 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,1,30)));
+        } else if (85 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,1,30)));
+        } else if (97 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2023,1,30)));
+        } else if (109 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,1,30)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+
+    int basic = 4;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                13,
+                                basic);
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_FREQ3_SET_ON_TIMESTEP_13 ) {
+
+    //Write reportfile every first day of each year
+
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (49 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,1,31)));
+        } else if (85 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,1,30)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+
+    int basic = 4;
+    int freq  = 3;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                13,
+                                basic,
+                                freq);
+
+
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC3_FREQ5_SET_ON_TIMESTEP_11 ) {
+
+    //Write reportfile every first day of each year
+    std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
+
+    for (size_t reportstep = 0; reportstep <= 120; ++reportstep) {
+        if (15 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2016,3,31)));
+        } else if (20 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2016,8,31)));
+        } else if (25 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,1,31)));
+        } else if (30 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,6,30)));
+        } else if (35 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2017,11,30)));
+        } else if (40 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,4,30)));
+        } else if (45 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2018,9,30)));
+        } else if (50 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,2,28)));
+        } else if (55 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,7,31)));
+        } else if (60 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2019,12,31)));
+        } else if (65 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2020,5,30)));
+        } else if (70 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2020,10,30)));
+        } else if (75 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,3,30)));
+        } else if (80 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2021,8,30)));
+        } else if (85 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,1,30)));
+        } else if (90 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,6,29)));
+        } else if (95 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2022,11,29)));
+        } else if (100 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2023,4,29)));
+        } else if (105 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2023,9,29)));
+        } else if (110 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,2,27)));
+        } else if (115 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,7,29)));
+        } else if (120 == reportstep) {
+            rptConfig.push_back( std::make_tuple(reportstep, true, boost::gregorian::date(2024,12,29)));
+        } else {
+            rptConfig.push_back( std::make_tuple(reportstep, false, boost::gregorian::date(2015,1,1)));
+        }
+    }
+
+
+    ParseMode parseMode;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseMode);
+
+    EclipseState state( deck , parseMode );
+    std::shared_ptr<IOConfig> ioconfig = state.getIOConfig();
+
+
+    int basic = 3;
+    int freq  = 5;
+    ioconfig->handleRPTRSTBasic(state.getSchedule()->getTimeMap(),
+                                11,
+                                basic,
+                                freq);
+
+    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+}
+
+
+
+
+
+
+
 
 
 

--- a/testdata/integration_tests/IOConfig/SPE1CASE2.DATA
+++ b/testdata/integration_tests/IOConfig/SPE1CASE2.DATA
@@ -1,0 +1,156 @@
+-- This reservoir simulation deck is a simplified version of SPE1CASE2.DATA 
+-- found in opm-data: https://github.com/OPM/opm-data/blob/master/spe1/SPE1CASE2.DATA
+
+
+-- This reservoir simulation deck is made available under the Open Database
+-- License: http://opendatacommons.org/licenses/odbl/1.0/. Any rights in
+-- individual contents of the database are licensed under the Database Contents
+-- License: http://opendatacommons.org/licenses/dbcl/1.0/
+
+-- Copyright (C) 2015 Statoil
+
+-- This simulation is based on the data given in 
+-- 'Comparison of Solutions to a Three-Dimensional
+-- Black-Oil Reservoir Simulation Problem' by Aziz S. Odeh,
+-- Journal of Petroleum Technology, January 1981
+
+---------------------------------------------------------------------------
+------------------------ SPE1 - CASE 2 ------------------------------------
+---------------------------------------------------------------------------
+
+RUNSPEC
+-- -------------------------------------------------------------------------
+
+TITLE
+   SPE1 - CASE 2
+
+DIMENS
+   10 10 3 /
+
+-- The number of equilibration regions is inferred from the EQLDIMS
+-- keyword.
+EQLDIMS
+/
+
+-- The number of PVTW tables is inferred from the TABDIMS keyword;
+-- when no data is included in the keyword the default values are used.
+TABDIMS
+/
+
+
+OIL
+GAS
+WATER
+DISGAS
+-- As seen from figure 4 in Odeh, GOR is increasing with time,
+-- which means that dissolved gas is present
+
+
+FIELD
+
+START
+   1 'JAN' 2015 /
+
+GRID
+-- -------------------------------------------------------------------------
+
+
+DX 
+-- There are in total 300 cells with length 1000ft in x-direction	
+   	300*1000 /
+DY
+-- There are in total 300 cells with length 1000ft in y-direction	
+	300*1000 /
+DZ
+-- The layers are 20, 30 and 50 ft thick, in each layer there are 100 cells
+	100*20 100*30 100*50 /
+
+TOPS
+-- The depth of the top of each grid block
+	100*8325 /
+
+PORO
+-- Constant porosity of 0.3 throughout all 300 grid cells
+   	300*0.3 /
+
+PERMX
+-- The layers have perm. 500mD, 50mD and 200mD, respectively.
+	100*500 100*50 100*200 /
+
+PERMY
+-- Equal to PERMX
+	100*500 100*50 100*200 /
+
+PERMZ
+-- Cannot find perm. in z-direction in Odeh's paper
+-- For the time being, we will assume PERMZ equal to PERMX and PERMY:
+	100*500 100*50 100*200 /
+
+
+
+SCHEDULE
+-- -------------------------------------------------------------------------
+RPTSCHED
+	'PRES' 'SGAS' 'RS' 'WELLS' /
+
+
+-- If no resolution (i.e. case 1), the two following lines must be added:
+--DRSDT
+-- 0 /
+-- Since this is Case 2, the two lines above have been commented out.
+-- if DRSDT is set to 0, GOR cannot rise and free gas does not 
+-- dissolve in undersaturated oil -> constant bubble point pressure
+
+WELSPECS
+-- Item #: 1	 2	3	4	5	 6
+	'PROD'	'G1'	10	10	8400	'OIL' /
+	'INJ'	'G1'	1	1	8335	'GAS' /
+/
+-- Coordinates in item 3-4 are retrieved from Odeh's figure 1 and 2
+-- Note that the depth at the midpoint of the well grid blocks
+-- has been used as reference depth for bottom hole pressure in item 5
+
+COMPDAT
+-- Item #: 1	2	3	4	5	6	7	8	9
+	'PROD'	10	10	3	3	'OPEN'	1*	1*	0.5 /
+	'INJ'	1	1	1	1	'OPEN'	1*	1*	0.5 /
+/
+-- Coordinates in item 2-5 are retreived from Odeh's figure 1 and 2 
+-- Item 9 is the well bore internal diameter, 
+-- the radius is given to be 0.25ft in Odeh's paper
+
+
+WCONPROD
+-- Item #:1	2      3     4	   5  9
+	'PROD' 'OPEN' 'ORAT' 20000 4* 1000 /
+/
+-- It is stated in Odeh's paper that the maximum oil prod. rate
+-- is 20 000stb per day which explains the choice of value in item 4.
+-- The items > 4 are defaulted with the exception of item  9,
+-- the BHP lower limit, which is given to be 1000psia in Odeh's paper
+
+WCONINJE
+-- Item #:1	 2	 3	 4	5      6  7
+	'INJ'	'GAS'	'OPEN'	'RATE'	100000 1* 9014 /
+/
+-- Stated in Odeh that gas inj. rate (item 5) is 100MMscf per day
+-- BHP upper limit (item 7) should not be exceeding the highest
+-- pressure in the PVT table=9014.7psia (default is 100 000psia) 
+
+TSTEP
+--Advance the simulater once a month for TEN years:
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 
+31 28 31 30 31 30 31 31 30 31 30 31 /
+
+--Advance the simulator once a year for TEN years:
+--10*365 /
+
+END


### PR DESCRIPTION
Testing have revealed difference in behaviour for when restart files are written for Eclipse and Flow
for RPTRST basic = 3/4/5 settings. 

This have now been fixed, and more testing that compares IOConfig settings with results as written from eclipse for the same settings (Integration tests) have been added. 
