### PR TITLE
Temporarily remove parser support for CPR keyword

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -24,15 +24,31 @@
 
 
 
+/*
+  The internalization of the CPR keyword has been temporarily
+  disabled, suddenly decks with 'CPR' in the summary section turned
+  up. Keywords with section aware keyword semantics is currently not
+  handled by the parser.
+
+  When the CPR is added again the following keyword configuration must
+  be added:
+
+    {"name" : "CPR" , "sections" : ["RUNSPEC"], "size": 1 }
+
+*/
+
+
 namespace Opm {
 
     SimulationConfig::SimulationConfig(const ParseMode& parseMode , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
         initThresholdPressure(parseMode , deck, gridProperties);
 
         m_useCPR = false;
-        if(deck->hasKeyword<ParserKeywords::CPR>()){
-            m_useCPR = true;
-        }
+        /*
+          if(deck->hasKeyword<ParserKeywords::CPR>()){
+          m_useCPR = true;
+          }
+        */
     }
 
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -43,7 +43,7 @@ namespace Opm {
     SimulationConfig::SimulationConfig(const ParseMode& parseMode , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
         initThresholdPressure(parseMode , deck, gridProperties);
 
-        m_useCPR = false;
+        m_useCPR = true;
         /*
           if(deck->hasKeyword<ParserKeywords::CPR>()){
           m_useCPR = true;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -112,7 +112,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
         ParseMode parseMode;
         DeckPtr deck = createDeck(parseMode , inputStr_noTHPRES);
         SimulationConfig simulationConfig(parseMode , deck, getGridProperties());
-        BOOST_CHECK_EQUAL( false , simulationConfig.useCPR());
+        BOOST_CHECK_EQUAL( true , simulationConfig.useCPR());
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {

--- a/opm/parser/share/keywords/000_Eclipse100/C/CPR
+++ b/opm/parser/share/keywords/000_Eclipse100/C/CPR
@@ -1,2 +1,0 @@
-{"name" : "CPR" , "sections" : ["RUNSPEC"], "size": 1 }
-


### PR DESCRIPTION
The following has happened:

1. In https://github.com/OPM/opm-parser/pull/581 we added support for internalizing the CPR keyword.
2. In https://github.com/OPM/opm-autodiff/issues/489 @dr-robertk reported that flow/parser could no langer handle an old version of the SPE9 data.

It turns out that the old SPE9 input deck has a `CPR` keyword in the summary section: https://github.com/OPM/opm-data/blob/9af155c26bc0946d9af846ac6e503115c0267050/spe9/SPE9.DATA - this keyword has completely different schema than the keyword added in #581, and the parsing goes completely belly up. The current 'fix' is just to revert the functionality of #581 - but the longer term fix must determine one two:

1. I have found no references to `CPR` in the `SUMMARY` section in the documentation, maybe it is a "bug" in the old SPE9 deck which can be ignored (i.e. just comment out the `CPR`keyword from the summary section).
2. If it is indeed legitimate with `CPR` in the `SUMMARY` section - this suddenly implies that the parser must support section aware keyword schema - now that is a significant change. 