### PR TITLE
Move warning headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ include( cmake/Modules/CheckCaseSensitiveFileSystem.cmake )
 add_definitions("-DHAVE_CASE_SENSITIVE_FILESYSTEM=${HAVE_CASE_SENSITIVE_FILESYSTEM}")
 
 find_package(opm-common)
+include_directories( ${opm-common_INCLUDE_DIR} )   
 include( Findopm-data )
 
 find_package(ERT)

--- a/opm/core/utility/platform_dependent/disable_warnings.h
+++ b/opm/core/utility/platform_dependent/disable_warnings.h
@@ -53,6 +53,8 @@
 // Note that both clang and (newer) gcc accept the
 // "#pragma GCC diagnostic" syntax.
 #if COMPATIBLE_COMPILER
+#warning "The disable/enable warnings header files have moved to opm-common"
+
 #pragma GCC diagnostic push
 // Suppress warnings: "unknown option after ‘#pragma GCC diagnostic’ kind [-Wpragmas]".
 // This is necessary because not all the compilers have the same warning options.

--- a/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
@@ -20,9 +20,9 @@
 
 #define BOOST_TEST_MODULE DeckItemTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <stdexcept>
 #include <opm/parser/eclipse/Deck/DeckIntItem.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckFloatItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckFloatItemTests.cpp
@@ -20,9 +20,9 @@
 
 #define BOOST_TEST_MODULE DeckItemTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <stdexcept>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
@@ -19,9 +19,9 @@
 
 #define BOOST_TEST_MODULE DeckItemTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <stdexcept>
 #include <opm/parser/eclipse/Deck/DeckIntItem.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
@@ -22,9 +22,9 @@
 
 #define BOOST_TEST_MODULE DeckKeywordTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckStringItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckStringItemTests.cpp
@@ -21,9 +21,9 @@
 
 #define BOOST_TEST_MODULE DeckStringItemTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/DeckStringItem.hpp>
 

--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -22,9 +22,9 @@
 
 #define BOOST_TEST_MODULE DeckTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/OpmLog/CounterLog.hpp>
 #include <opm/parser/eclipse/OpmLog/OpmLog.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/BoxTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/BoxTests.cpp
@@ -23,11 +23,11 @@
 
 #define BOOST_TEST_MODULE BoxManagereTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -24,10 +24,10 @@
 
 #define BOOST_TEST_MODULE EclipseGridTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
@@ -22,11 +22,11 @@
 
 #define BOOST_TEST_MODULE FaultTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
@@ -22,11 +22,11 @@
 
 #define BOOST_TEST_MODULE EclipseGridTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -23,11 +23,11 @@
 
 #define BOOST_TEST_MODULE EclipseGridTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <ert/ecl/EclKW.hpp>

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -30,11 +30,11 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <boost/optional.hpp>
 
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <memory>
 #include <string>

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -23,10 +23,10 @@
 
 #define BOOST_TEST_MODULE ScheduleTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Deck/DeckIntItem.hpp>

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
@@ -23,10 +23,10 @@
 
 #define BOOST_TEST_MODULE TimeMapTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
@@ -19,10 +19,10 @@
 
 #define BOOST_TEST_MODULE WellSolventTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/Deck/DeckIntItem.hpp>

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -21,10 +21,10 @@
 
 #define BOOST_TEST_MODULE SimulationConfigTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -23,10 +23,10 @@
 
 #define BOOST_TEST_MODULE ThresholdPressureTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp
@@ -23,11 +23,11 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <boost/multi_array.hpp>
 
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
@@ -22,11 +22,11 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <boost/multi_array.hpp>
 
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/Tables/tests/MultiRecordTableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/MultiRecordTableTests.cpp
@@ -19,9 +19,9 @@
 
 #define BOOST_TEST_MODULE MultiRecordTableTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/ParserKeywords.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -19,9 +19,9 @@
 
 #define BOOST_TEST_MODULE TableContainerTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -19,9 +19,9 @@
 
 #define BOOST_TEST_MODULE SimpleTableTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -23,10 +23,10 @@
 
 #define BOOST_TEST_MODULE EclipseStateTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/OpmLog/CounterLog.hpp>

--- a/opm/parser/eclipse/Generator/tests/KeywordLoaderTests.cpp
+++ b/opm/parser/eclipse/Generator/tests/KeywordLoaderTests.cpp
@@ -23,11 +23,11 @@
 
 #define BOOST_TEST_MODULE InputKeywordTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/Generator/KeywordLoader.hpp>

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -19,10 +19,10 @@
 
 #define BOOST_TEST_MODULE BoxTest
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
@@ -32,9 +32,9 @@
 
 #define BOOST_TEST_MODULE NNCTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 using namespace Opm;
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
@@ -20,10 +20,10 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 

--- a/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
@@ -20,10 +20,10 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
@@ -20,10 +20,10 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/OpmLog/tests/OpmLogTests.cpp
+++ b/opm/parser/eclipse/OpmLog/tests/OpmLogTests.cpp
@@ -20,9 +20,9 @@
 
 #define BOOST_TEST_MODULE LogTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <stdexcept>
 #include <iostream>

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -20,9 +20,9 @@
 
 #define BOOST_TEST_MODULE ParserTests
 
-#include <opm/core/utility/platform_dependent/disable_warnings.h>
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/core/utility/platform_dependent/reenable_warnings.h>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/json/JsonObject.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>


### PR DESCRIPTION
1. Added a warning in the disable_warnings header that the include path should be updated to use opm-common.

2. Updated all occurences to use the headers in opm-common

Downstream PRs:

1. https://github.com/OPM/opm-core/pull/896
2. https://github.com/OPM/opm-autodiff/pull/493
3. https://github.com/OPM/dune-cornerpoint/pull/179

In addition there is a PR to opm-common: which makes opm-common a **REQUIRED** dependency for `opm-core, dune-cornerpoint` and `opm-autodiff`: https://github.com/OPM/opm-common/pull/52

You will only affected by this if you build with `-DSILENCE_EXTERNAL_WARNINGS` - and *if* I have missed something the worst consequence is that you will get a preprocessor warning during the build. 