### PR TITLE
Add flag allowCrossFlow()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1272,7 +1272,12 @@ namespace Opm {
         if (refDepthItem->hasValue(0))
             refDepth.setValue( refDepthItem->getSIDouble(0));
 
-        well = std::make_shared<Well>(wellName, m_grid , headI, headJ, refDepth, preferredPhase, m_timeMap , timeStep, wellCompletionOrder);
+        bool allowCrossFlow = true;
+        const std::string& allowCrossFlowStr = record->getItem("CROSSFLOW")->getTrimmedString(0);
+        if (allowCrossFlowStr == "NO")
+            allowCrossFlow = false;
+
+        well = std::make_shared<Well>(wellName, m_grid , headI, headJ, refDepth, preferredPhase, m_timeMap , timeStep, wellCompletionOrder, allowCrossFlow);
         m_wells.insert( wellName  , well);
         m_events.addEvent( ScheduleEvents::NEW_WELL , timeStep );
     }

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1273,7 +1273,7 @@ namespace Opm {
             refDepth.setValue( refDepthItem->getSIDouble(0));
 
         bool allowCrossFlow = true;
-        const std::string& allowCrossFlowStr = record->getItem("CROSSFLOW")->getTrimmedString(0);
+        const std::string& allowCrossFlowStr = record->getItem<ParserKeywords::WELSPECS::CROSSFLOW>()->getTrimmedString(0);
         if (allowCrossFlowStr == "NO")
             allowCrossFlow = false;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -31,7 +31,7 @@
 namespace Opm {
 
     Well::Well(const std::string& name_, std::shared_ptr<const EclipseGrid> grid , int headI, int headJ, Value<double> refDepth , Phase::PhaseEnum preferredPhase,
-               TimeMapConstPtr timeMap, size_t creationTimeStep, WellCompletion::CompletionOrderEnum completionOrdering)
+               TimeMapConstPtr timeMap, size_t creationTimeStep, WellCompletion::CompletionOrderEnum completionOrdering, bool allowCrossFlow)
         : m_status(new DynamicState<WellCommon::StatusEnum>(timeMap, WellCommon::SHUT)),
           m_isAvailableForGroupControl(new DynamicState<bool>(timeMap, true)),
           m_guideRate(new DynamicState<double>(timeMap, -1.0)),
@@ -52,7 +52,8 @@ namespace Opm {
           m_refDepth(refDepth),
           m_preferredPhase(preferredPhase),
           m_grid( grid ),
-          m_comporder(completionOrdering)
+          m_comporder(completionOrdering),
+          m_allowCrossFlow(allowCrossFlow)
     {
         m_name = name_;
         m_creationTimeStep = creationTimeStep;
@@ -301,6 +302,10 @@ namespace Opm {
             wellNameInPattern = true;
         }
         return wellNameInPattern;
+    }
+
+    bool Well::getAllowCrossFlow() const {
+        return m_allowCrossFlow;
     }
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -47,7 +47,7 @@ namespace Opm {
     class Well {
     public:
         Well(const std::string& name, std::shared_ptr<const EclipseGrid> grid , int headI, int headJ, Value<double> refDepth , Phase::PhaseEnum preferredPhase,
-             TimeMapConstPtr timeMap, size_t creationTimeStep, WellCompletion::CompletionOrderEnum completionOrdering = WellCompletion::TRACK);
+             TimeMapConstPtr timeMap, size_t creationTimeStep, WellCompletion::CompletionOrderEnum completionOrdering = WellCompletion::TRACK, bool allowCrossFlow = true);
         const std::string& name() const;
 
         bool hasBeenDefined(size_t timeStep) const;
@@ -104,6 +104,9 @@ namespace Opm {
 
         WellCompletion::CompletionOrderEnum getWellCompletionOrdering() const;
 
+        bool getAllowCrossFlow() const;
+
+
 
 
 
@@ -129,7 +132,6 @@ namespace Opm {
         std::shared_ptr<DynamicState<bool> > m_rft;
         std::shared_ptr<DynamicState<bool> > m_plt;
 
-
         // WELSPECS data - assumes this is not dynamic
 
         TimeMapConstPtr m_timeMap;
@@ -140,6 +142,8 @@ namespace Opm {
         std::shared_ptr<const EclipseGrid> m_grid;
 
         WellCompletion::CompletionOrderEnum m_comporder;
+        bool m_allowCrossFlow;
+
     };
     typedef std::shared_ptr<Well> WellPtr;
     typedef std::shared_ptr<const Well> WellConstPtr;


### PR DESCRIPTION
This PR adds support for item 10 in welspecs where a flag is used to
determine whether the well should allow cross flow or not.

A test is added to check default behavior.