### PR TITLE
Shut wells with zero rates and crossflow not allowed

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -362,6 +362,16 @@ namespace Opm {
                 updateWellStatus( well , currentStep , status );
                 if (well->setProductionProperties(currentStep, properties))
                     m_events.addEvent( ScheduleEvents::PRODUCTION_UPDATE , currentStep);
+
+                if ( !well->getAllowCrossFlow() && !isPredictionMode && (properties.OilRate + properties.WaterRate + properties.GasRate) == 0 ) {
+
+                    std::string msg =
+                            "Well " + well->name() + " is a history matched well with zero rate where crossflow is banned. " +
+                            "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
+                    OpmLog::addMessage(Log::MessageType::Info , Log::prefixMessage(Log::MessageType::Info, msg));
+                    updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
+                }
+
             }
         }
     }
@@ -525,8 +535,17 @@ namespace Opm {
                         throw std::invalid_argument("Tried to set invalid control: " + cmodeString + " for well: " + wellNamePattern);
                     }
                 }
+
                 if (well->setInjectionProperties(currentStep, properties))
                     m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );
+
+                if ( ! well->getAllowCrossFlow() && properties.surfaceInjectionRate == 0 ) {
+                    std::string msg =
+                            "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
+                            "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
+                    OpmLog::addMessage(Log::MessageType::Info , Log::prefixMessage(Log::MessageType::Info, msg));
+                    updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
+                }
             }
         }
     }
@@ -610,6 +629,15 @@ namespace Opm {
 
             if (well->setInjectionProperties(currentStep, properties))
                 m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );
+
+            if ( ! well->getAllowCrossFlow() && injectionRate == 0 ) {
+                std::string msg =
+                        "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
+                        "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
+                OpmLog::addMessage(Log::MessageType::Info , Log::prefixMessage(Log::MessageType::Info, msg));
+                updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
+            }
+
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -539,7 +539,7 @@ namespace Opm {
                 if (well->setInjectionProperties(currentStep, properties))
                     m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );
 
-                if ( ! well->getAllowCrossFlow() && properties.surfaceInjectionRate == 0 ) {
+                if ( ! well->getAllowCrossFlow() && (properties.surfaceInjectionRate == 0) ) {
                     std::string msg =
                             "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
                             "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
@@ -630,7 +630,7 @@ namespace Opm {
             if (well->setInjectionProperties(currentStep, properties))
                 m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );
 
-            if ( ! well->getAllowCrossFlow() && injectionRate == 0 ) {
+            if ( ! well->getAllowCrossFlow() && (injectionRate == 0) ) {
                 std::string msg =
                         "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
                         "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -83,7 +83,49 @@ static DeckPtr createDeckForTestingCrossFlow() {
             "     \'DEFAULT\'    \'OP\'   30   37  3.33       \'OIL\'  7*/   \n"
             "     \'ALLOW\'      \'OP\'   30   37  3.33       \'OIL\'  3*  YES / \n"
             "     \'BAN\'        \'OP\'   20   51  3.92       \'OIL\'  3*  NO /  \n"
+            "/\n"
+
+            "COMPDAT\n"
+            " \'BAN\'  1  1   1   1 \'OPEN\' 1*    1.168   0.311   107.872 1*  1*  \'Z\'  21.925 / \n"
+            "/\n"
+
+            "WCONHIST\n"
+            "     'BAN'      'OPEN'      'RESV'      0.000      0.000      0.000  5* / \n"
+            "/\n"
+
+            "DATES             -- 1\n"
+            " 10  JUN 2007 / \n"
+            "/\n"
+
+            "WCONHIST\n"
+            "     'BAN'      'OPEN'      'RESV'      1.000      0.000      0.000  5* / \n"
+            "/\n"
+
+            "DATES             -- 2\n"
+            " 10  JUL 2007 / \n"
+            "/\n"
+
+            "WCONPROD\n"
+            "     'BAN'      'OPEN'      'ORAT'      0.000      0.000      0.000  5* / \n"
+            "/\n"
+
+
+            "DATES             -- 3\n"
+            " 10  AUG 2007 / \n"
+            "/\n"
+
+            "WCONINJH\n"
+            "     'BAN'      'WATER'      1*      0 / \n"
+            "/\n"
+
+            "DATES             -- 4\n"
+            " 10  SEP 2007 / \n"
+            "/\n"
+
+            "WCONINJH\n"
+            "     'BAN'      'WATER'      1*      1.0 / \n"
             "/\n";
+
 
     return parser.parseString(input, ParseMode());
 }
@@ -312,6 +354,18 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     BOOST_CHECK_EQUAL(well_allow[0]->getAllowCrossFlow(), true);
     std::vector<WellPtr> well_ban = schedule.getWells("BAN");
     BOOST_CHECK_EQUAL(well_ban[0]->getAllowCrossFlow(), false);
+
+    size_t currentStep = 0;
+    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban[0]->getStatus(currentStep));
+    currentStep = 1;
+    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban[0]->getStatus(currentStep));
+    currentStep = 2;
+    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban[0]->getStatus(currentStep));
+    currentStep = 3;
+    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well_ban[0]->getStatus(currentStep));
+    currentStep = 4;
+    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well_ban[0]->getStatus(currentStep));
+
 
 }
 


### PR DESCRIPTION
Note: Producing wells in prediction mode is kept open even if the
control rate is set to zero.