### PR TITLE
Do not use const for value return.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
@@ -23,7 +23,7 @@ namespace Opm {
         }
     }
 
-    const bool OilVaporizationProperties::getOption() const{
+    bool OilVaporizationProperties::getOption() const{
         if (m_type == Opm::OilVaporizationEnum::DRSDT){
             return m_maxDRSDT_allCells;
         }else{

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -26,7 +26,7 @@ namespace Opm
         double getVap2() const;
         double getMaxDRSDT() const;
         double getMaxDRVDT() const;
-        const bool getOption() const;
+        bool getOption() const;
 
     private:
         OilVaporizationProperties();


### PR DESCRIPTION
What matters is the type (const or not) used at the call site. It does not matter if the method returns a const. Note that this applies to value types, not references.

Update: the reason I fix this is that it generates a warning for me.