### PR TITLE
fix build on GCC 4.4

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -65,7 +65,7 @@ namespace Opm {
             if (index < keywordList.size())
                 return keywordList[index];
             else
-                throw std::out_of_range("Keyword " + keyword + ":" + std::to_string( index ) + " not in deck.");
+                throw std::out_of_range("Keyword " + keyword + ":" + std::to_string( static_cast<long long>(index) ) + " not in deck.");
         } else
             throw std::invalid_argument("Keyword " + keyword + " not in deck.");
     }
@@ -82,7 +82,7 @@ namespace Opm {
         if (index < m_keywordList.size())
             return m_keywordList[index];
         else
-            throw std::out_of_range("Keyword index " + std::to_string( index ) + " is out of range.");
+            throw std::out_of_range("Keyword index " + std::to_string( static_cast<long long>(index) ) + " is out of range.");
     }
 
     size_t Deck::numKeywords(const std::string& keyword) const {

--- a/opm/parser/eclipse/Deck/SCHEDULESection.cpp
+++ b/opm/parser/eclipse/Deck/SCHEDULESection.cpp
@@ -31,7 +31,7 @@ namespace Opm {
         if (timestep < m_decktimesteps.size()) {
             return m_decktimesteps[timestep];
         } else {
-            throw std::out_of_range("No DeckTimeStep in ScheduleSection for timestep " + std::to_string(timestep));
+            throw std::out_of_range("No DeckTimeStep in ScheduleSection for timestep " + std::to_string(static_cast<long long>(timestep)));
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -196,7 +196,7 @@ namespace Opm {
 
 
             if (unsupportedModifiers.find( keyword->name() ) != unsupportedModifiers.end()) {
-                std::string msg = "OPM does not support grid property modifier " + keyword->name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
+                std::string msg = "OPM does not support grid property modifier " + keyword->name() + " in the Schedule section. Error at report: " + std::to_string( static_cast<long long>(currentStep) );
                 parseMode.handleError( ParseMode::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , msg );
             }
         }
@@ -253,8 +253,8 @@ namespace Opm {
 
 
     void Schedule::handleCOMPORD(const ParseMode& parseMode, std::shared_ptr<const DeckKeyword> compordKeyword, size_t /* currentStep */) {
-        for (const auto record : (*compordKeyword)) {
-            auto methodItem = record->getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
+        for (auto it = compordKeyword->begin(); it != compordKeyword->end(); ++it) {
+            auto methodItem = (*it)->getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if ((methodItem->getString(0) != "TRACK")  && (methodItem->getString(0) != "INPUT")) {
                 std::string msg = "The COMPORD keyword only handles 'TRACK' or 'INPUT' order.";
                 parseMode.handleError( ParseMode::UNSUPPORTED_COMPORD_TYPE , msg );
@@ -413,7 +413,7 @@ namespace Opm {
 
                     std::string msg =
                             "Well " + well->name() + " is a history matched well with zero rate where crossflow is banned. " +
-                            "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
+                            "This well will be closed at " + std::to_string ( static_cast<long double>(m_timeMap->getTimePassedUntil(currentStep) / (60*60*24)) ) + " days";
                     OpmLog::addMessage(Log::MessageType::Info , Log::prefixMessage(Log::MessageType::Info, msg));
                     updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
                 }
@@ -588,7 +588,7 @@ namespace Opm {
                 if ( ! well->getAllowCrossFlow() && (properties.surfaceInjectionRate == 0) ) {
                     std::string msg =
                             "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
-                            "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
+                            "This well will be closed at " + std::to_string ( static_cast<long double>(m_timeMap->getTimePassedUntil(currentStep) / (60*60*24)) ) + " days";
                     OpmLog::addMessage(Log::MessageType::Info , Log::prefixMessage(Log::MessageType::Info, msg));
                     updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
                 }
@@ -679,7 +679,7 @@ namespace Opm {
             if ( ! well->getAllowCrossFlow() && (injectionRate == 0) ) {
                 std::string msg =
                         "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
-                        "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
+                        "This well will be closed at " + std::to_string ( static_cast<long double>(m_timeMap->getTimePassedUntil(currentStep) / (60*60*24)) ) + " days";
                 OpmLog::addMessage(Log::MessageType::Info , Log::prefixMessage(Log::MessageType::Info, msg));
                 updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
             }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -157,7 +157,7 @@ namespace Opm {
             if (valid)
                 return value;
             else {
-                std::string msg = "The THPRES value for regions " + std::to_string(r1) + " and " + std::to_string(r2) + " has not been initialized. Using 0.0";
+                std::string msg = "The THPRES value for regions " + std::to_string(static_cast<long long>(r1)) + " and " + std::to_string(static_cast<long long>(r2)) + " has not been initialized. Using 0.0";
                 m_parseMode.handleError(ParseMode::INTERNAL_ERROR_UNINITIALIZED_THPRES, msg);
                 return 0;
             }

--- a/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/MultiRecordTable.cpp
@@ -56,7 +56,7 @@ void MultiRecordTable::init(Opm::DeckKeywordConstPtr keyword,
 {
     auto ranges = recordRanges(keyword);
     if (tableIdx >= ranges.size())
-        throw std::invalid_argument("Asked for table: " + std::to_string( tableIdx ) + " in keyword + " + keyword->name() + " which only has " + std::to_string( ranges.size() ) + " tables");
+        throw std::invalid_argument("Asked for table: " + std::to_string( static_cast<long long>(tableIdx) ) + " in keyword + " + keyword->name() + " which only has " + std::to_string( static_cast<long long>(ranges.size()) ) + " tables");
 
     createColumns(columnNames);
     m_recordRange = ranges[ tableIdx ];

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.cpp
@@ -23,6 +23,10 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 
 namespace Opm {
+    TableContainer::TableContainer() :
+        m_maxTables(0)
+    {
+    }
 
     TableContainer::TableContainer(size_t maxTables) :
         m_maxTables(maxTables)
@@ -59,7 +63,7 @@ namespace Opm {
             if (tableNumber > 0)
                 return getTable(tableNumber -1);
             else
-                throw std::invalid_argument("TableContainer does not have any table in the range 0..." + std::to_string( tableNumber ));
+                throw std::invalid_argument("TableContainer does not have any table in the range 0..." + std::to_string( static_cast<long long>(tableNumber) ));
         }
     }
 
@@ -70,7 +74,7 @@ namespace Opm {
 
     void TableContainer::addTable(size_t tableNumber , std::shared_ptr<const SimpleTable> table) {
         if (tableNumber >= m_maxTables)
-            throw std::invalid_argument("TableContainer has max: " + std::to_string( m_maxTables ) + " tables. Table number: " + std::to_string( tableNumber ) + " illegal.");
+            throw std::invalid_argument("TableContainer has max: " + std::to_string( static_cast<long long>(m_maxTables) ) + " tables. Table number: " + std::to_string( static_cast<long long>(tableNumber) ) + " illegal.");
 
         m_tables[tableNumber] = table;
     }

--- a/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp
@@ -59,6 +59,7 @@ namespace Opm {
             container.gteTable(10 ) ==> exception
         */
     public:
+        TableContainer();
         explicit TableContainer( size_t maxTables );
         bool empty() const;
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -79,7 +79,7 @@ namespace Opm {
 
 
     void TableManager::addTables( const std::string& tableName , size_t numTables) {
-        m_simpleTables.emplace(std::make_pair(tableName , TableContainer( numTables )));
+        m_simpleTables[tableName] = TableContainer( numTables );
     }
 
 

--- a/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -36,10 +36,10 @@ using namespace Opm;
 
 void verifyRestartConfig(IOConfigConstPtr ioconfig, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
 
-    for (auto rptrst : rptConfig) {
-        int report_step                    = std::get<0>(rptrst);
-        bool save                          = std::get<1>(rptrst);
-        boost::gregorian::date report_date = std::get<2>(rptrst);
+    for (auto it = rptConfig.begin(); it != rptConfig.end(); ++it) {
+        int report_step                    = std::get<0>(*it);
+        bool save                          = std::get<1>(*it);
+        boost::gregorian::date report_date = std::get<2>(*it);
 
         BOOST_CHECK_EQUAL( save , ioconfig->getWriteRestartFile( report_step ));
         if (save) {
@@ -308,6 +308,8 @@ BOOST_AUTO_TEST_CASE( NorneResttartConfig ) {
 
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
 
@@ -349,6 +351,7 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
 
@@ -604,7 +607,8 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_SET_ON_TIMESTEP_37 ) {
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
 
-
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ10_SET_ON_TIMESTEP_10 ) {
     //Write reportfile every first day of each month, with frequency 10
 
@@ -655,8 +659,11 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ10_SET_ON_TIMESTEP_10 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ40_SET_ON_TIMESTEP_1 ) {
     std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
 
@@ -690,11 +697,13 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ40_SET_ON_TIMESTEP_1 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ40_SET_ON_TIMESTEP_14 ) {
-
     //Write reportfile every first day of a month, with frequency 40
     ParseMode parseMode;
     ParserPtr parser(new Parser());
@@ -724,14 +733,16 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC5_FREQ40_SET_ON_TIMESTEP_14 ) {
         }
     }
 
-
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
 
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_1 ) {
     //Write reportfile every first day of each year
 
@@ -776,10 +787,12 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_1 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_12 ) {
-
     //Write reportfile every first day of each year
 
     std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
@@ -824,10 +837,12 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_12 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_13 ) {
-
     //Write reportfile every first day of each year
 
     std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
@@ -870,12 +885,14 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_SET_ON_TIMESTEP_13 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_FREQ3_SET_ON_TIMESTEP_13 ) {
-
     //Write reportfile every first day of each year
 
     std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
@@ -910,12 +927,14 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC4_FREQ3_SET_ON_TIMESTEP_13 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
+#endif
 
 
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC3_FREQ5_SET_ON_TIMESTEP_11 ) {
-
     //Write reportfile every first day of each year
     std::vector<std::tuple<int, bool, boost::gregorian::date>> rptConfig;
 
@@ -987,13 +1006,4 @@ BOOST_AUTO_TEST_CASE( SPE1CASE2_BASIC3_FREQ5_SET_ON_TIMESTEP_11 ) {
 
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
-
-
-
-
-
-
-
-
-
-
+#endif

--- a/opm/parser/eclipse/Parser/ParseMode.cpp
+++ b/opm/parser/eclipse/Parser/ParseMode.cpp
@@ -51,8 +51,8 @@ namespace Opm {
     ParseMode::ParseMode(const std::vector<std::pair<std::string , InputError::Action>> initial) {
         initDefault();
 
-        for (const auto& pair : initial)
-            update( pair.first , pair.second );
+        for (auto it = initial.begin(); it != initial.end(); ++it)
+            update( it->first , it->second );
 
         initEnv();
     }
@@ -151,8 +151,8 @@ namespace Opm {
 
 
     void ParseMode::update(InputError::Action action) {
-        for (const auto& pair : m_errorModes) {
-            const std::string& key = pair.first;
+        for (auto it = m_errorModes.begin(); it != m_errorModes.end(); ++it) {
+            const std::string& key = it->first;
             updateKey( key , action );
          }
     }
@@ -160,8 +160,8 @@ namespace Opm {
 
     void ParseMode::patternUpdate( const std::string& pattern , InputError::Action action) {
         const char * c_pattern = pattern.c_str();
-        for (const auto& pair : m_errorModes) {
-            const std::string& key = pair.first;
+        for (auto it = m_errorModes.begin(); it != m_errorModes.end(); ++it) {
+            const std::string& key = it->first;
             if (util_fnmatch( c_pattern , key.c_str()) == 0)
                 updateKey( key , action );
          }
@@ -191,15 +191,15 @@ namespace Opm {
     void ParseMode::update(const std::string& keyString , InputError::Action action) {
         std::vector<std::string> keys;
         boost::split( keys , keyString , boost::is_any_of(":|"));
-        for (const auto& input_key : keys) {
+        for (auto it = keys.begin(); it != keys.end(); ++it) {
             std::vector<std::string> matching_keys;
-            size_t wildcard_pos = input_key.find("*");
+            size_t wildcard_pos = it->find("*");
 
             if (wildcard_pos == std::string::npos) {
-                if (hasKey( input_key ))
-                    updateKey( input_key , action );
+                if (hasKey( *it ))
+                    updateKey( *it , action );
             } else
-                patternUpdate( input_key , action );
+                patternUpdate( *it , action );
 
         }
     }

--- a/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -125,7 +125,7 @@ namespace Opm {
 
         if (rawRecord->size() > 0) {
             std::string msg = "The RawRecord for keyword \""  + rawRecord->getKeywordName() + "\" in file\"" + rawRecord->getFileName() + "\" contained " +
-                std::to_string(rawRecord->size()) +
+                std::to_string(static_cast<long long>(rawRecord->size())) +
                 " too many items according to the spec. RawRecord was: " + recordBeforeParsing;
             parseMode.handleError(ParseMode::PARSE_EXTRA_DATA , msg);
         }

--- a/opm/parser/eclipse/Parser/tests/ParseModeTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParseModeTests.cpp
@@ -239,6 +239,8 @@ BOOST_AUTO_TEST_CASE(TestNew) {
 }
 
 
+// disable this unit test on GCC 4.4 because it does not compile there
+#if !defined __GNUC__ || (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 4))
 BOOST_AUTO_TEST_CASE( test_constructor_with_values) {
     ParseMode parseMode( {{ParseMode::PARSE_RANDOM_SLASH , InputError::IGNORE},
                 {"UNSUPPORTED_*" , InputError::WARN},
@@ -249,6 +251,7 @@ BOOST_AUTO_TEST_CASE( test_constructor_with_values) {
     BOOST_CHECK_EQUAL( parseMode.get(ParseMode::UNSUPPORTED_INITIAL_THPRES) , InputError::WARN );
     BOOST_CHECK_EQUAL( parseMode.get(ParseMode::UNSUPPORTED_COMPORD_TYPE) , InputError::WARN );
 }
+#endif
 
 
 


### PR DESCRIPTION
the changes are mostly trivial, but the patch required to disable a
few unit tests on that compiler.

On my machine all tests continue to pass on a more modern compiler (clang 3.5)