### PR TITLE
added/fixed: set soversion for libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,8 @@ if (NOT opm-common_FOUND)
       message( FATAL_ERROR "Could not find OPM Macros")
    endif()
 
+else()
+   include(OpmInit)
 endif()
 
 include(UseMultiArch)

--- a/opm/json/CMakeLists.txt
+++ b/opm/json/CMakeLists.txt
@@ -7,7 +7,8 @@ if (NOT HAVE_CJSON)
 endif()
 add_library(opmjson ${json_source})
 target_link_libraries( opmjson ${CJSON_LIBRARY} ${Boost_LIBRARIES} )
-
+set_target_properties(opmjson PROPERTIES VERSION ${opm-parser_VERSION_MAJOR}.${opm-parser_VERSION_MINOR}
+                                         SOVERSION ${opm-parser_VERSION_MAJOR})
 
 install( TARGETS opmjson DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 foreach ( header ${json_headers} ) 

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -326,6 +326,8 @@ opm_add_test( runInlineKeywordTest SOURCES ${PROJECT_BINARY_DIR}/generated-sourc
 add_library(opmparser ${rawdeck_source} ${parser_source} ${deck_source} ${state_source} ${unit_source} ${log_source} ${generator_source})
 add_dependencies( opmparser generatedCode )
 target_link_libraries(opmparser opmjson ${Boost_LIBRARIES}  ${ERT_LIBRARIES})
+set_target_properties(opmparser PROPERTIES VERSION ${opm-parser_VERSION_MAJOR}.${opm-parser_VERSION_MINOR}
+                                           SOVERSION ${opm-parser_VERSION_MAJOR})
 
 include( ${PROJECT_SOURCE_DIR}/cmake/Modules/install_headers.cmake )   
 install_headers( "${HEADER_FILES}" "${CMAKE_INSTALL_PREFIX}" )


### PR DESCRIPTION
This was quick-fixed for last release. Now uses the information from the dune.module file to set versions.