### PR TITLE
Fixes warning about ignored qualifiers on function return types.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp
@@ -435,7 +435,7 @@ protected:
     // If SWOF and SGOF are specified in the deck it return FamilyI
     // If SWFN, SGFN and SOF3 are specified in the deck it return FamilyII
     // If keywords are missing or mixed, an error is given.
-    const SaturationFunctionFamily getSaturationFunctionFamily() const{
+    SaturationFunctionFamily getSaturationFunctionFamily() const{
         auto tables = m_eclipseState.getTableManager( );
         const TableContainer& swofTables = tables->getSwofTables();
         const TableContainer& sgofTables = tables->getSgofTables();


### PR DESCRIPTION
In particular this warning is removed:
```
In file included from /home/mblatt/src/dune/opm/opm-parser/opm/parser/eclipse/EclipseState/EclipseState.cpp:34:0:
/home/mblatt/src/dune/opm/opm-parser/opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp:438:66: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
     const SaturationFunctionFamily getSaturationFunctionFamily() const{
                                                              ^
```
Probably this should go to the release, too.
