### PR TITLE
Bump version and unify format of dune.module.

### DIFF
--- a/dune.module
+++ b/dune.module
@@ -1,7 +1,13 @@
+####################################################################
+# Dune module information file: This file gets parsed by dunecontrol
+# and by the CMake build scripts.
+####################################################################
+
 Module: opm-parser
 Description: Open Porous Media Initiative File Parser Library
-# if you change this, make sure to also change opm/parser/version.h
-Version: 2.0
-Label: 2015.04
+Version: 2016.04-pre
+Label: 2016.04-pre
 Maintainer: joaho@statoil.com
+MaintainerName: Joakim Hove
+Url: http://opm-project.org
 Depends: opm-common


### PR DESCRIPTION
After this, all code modules have the same formatting in dune.module, and the correct version name (for the master branch): "2016.04-pre".