### PR TITLE
fix build when using newish Boost libraries

### DIFF
--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -142,7 +142,7 @@ BOOST_AUTO_TEST_CASE(getKeyword_outOfRange_throws) {
     Deck deck;
     DeckKeywordPtr keyword = DeckKeywordPtr(new DeckKeyword("TRULS"));
     deck.addKeyword(keyword);
-    BOOST_CHECK_THROW( deck.getKeyword("TRULS" , 3) , std::out_of_range)
+    BOOST_CHECK_THROW( deck.getKeyword("TRULS" , 3) , std::out_of_range);
 }
 
 


### PR DESCRIPTION
it seems that recent Boost versions (I used 1.59) enforce a semicolon
behind the BOOST_CHECK macros, while older ones did not.