### PR TITLE
Rename from HO to H0

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -653,8 +653,8 @@ namespace Opm {
 
         const std::string MultiPhaseModelEnumToString(MultiPhaseModelEnum enumValue) {
             switch (enumValue) {
-                case HO:
-                    return "HO";
+                case H0:
+                    return "H0";
                 case DF:
                     return "DF";
                 default:
@@ -667,8 +667,8 @@ namespace Opm {
             std::string trimmedString(stringValue);
             boost::algorithm::trim(trimmedString);
 
-            if (trimmedString == "HO") {
-                return HO;
+            if (trimmedString == "H0") {
+                return H0;
             } else if (trimmedString == "DF") {
                 return DF;
             } else {

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -264,7 +264,7 @@ namespace Opm {
         CompPressureDropEnum CompPressureDropEnumFromString(const std::string& stringValue);
 
         enum MultiPhaseModelEnum {
-            HO = 0,
+            H0 = 0,
             DF = 1
         };
         const std::string MultiPhaseModelEnumToString(MultiPhaseModelEnum enumValue);


### PR DESCRIPTION
It is hard to judge from the manual, but H0 and not HO is used in the new model. 