### PR TITLE
handling both HO and H0 for mutliphase model input

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -653,8 +653,8 @@ namespace Opm {
 
         const std::string MultiPhaseModelEnumToString(MultiPhaseModelEnum enumValue) {
             switch (enumValue) {
-                case H0:
-                    return "H0";
+                case HO:
+                    return "HO";
                 case DF:
                     return "DF";
                 default:
@@ -667,8 +667,8 @@ namespace Opm {
             std::string trimmedString(stringValue);
             boost::algorithm::trim(trimmedString);
 
-            if (trimmedString == "H0") {
-                return H0;
+            if ((trimmedString == "HO") || (trimmedString == "H0")) {
+                return HO;
             } else if (trimmedString == "DF") {
                 return DF;
             } else {

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -264,7 +264,7 @@ namespace Opm {
         CompPressureDropEnum CompPressureDropEnumFromString(const std::string& stringValue);
 
         enum MultiPhaseModelEnum {
-            H0 = 0,
+            HO = 0,
             DF = 1
         };
         const std::string MultiPhaseModelEnumToString(MultiPhaseModelEnum enumValue);


### PR DESCRIPTION
To fix a failed test.

Internally and output we still use `HO`. 