### PR TITLE
Change return type from tuple to array for getCellCenter().

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -619,22 +619,22 @@ namespace Opm {
         return ecl_grid_get_cell_thickness1( c_ptr() , static_cast<int>(globalIndex));
     }
 
-    std::tuple<double,double,double> EclipseGrid::getCellCenter(size_t globalIndex) const {
+    std::array<double, 3> EclipseGrid::getCellCenter(size_t globalIndex) const {
         assertGlobalIndex( globalIndex );
         {
             double x,y,z;
             ecl_grid_get_xyz1( c_ptr() , static_cast<int>(globalIndex) , &x , &y , &z);
-            return std::tuple<double,double,double> {x,y,z};
+            return std::array<double, 3>{{x,y,z}};
         }
     }
 
 
-    std::tuple<double,double,double> EclipseGrid::getCellCenter(size_t i,size_t j, size_t k) const {
+    std::array<double, 3> EclipseGrid::getCellCenter(size_t i,size_t j, size_t k) const {
         assertIJK(i,j,k);
         {
             double x,y,z;
             ecl_grid_get_xyz3( c_ptr() , static_cast<int>(i),static_cast<int>(j),static_cast<int>(k), &x , &y , &z);
-            return std::tuple<double,double,double> {x,y,z};
+            return std::array<double, 3>{{x,y,z}};
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -91,8 +91,8 @@ namespace Opm {
         size_t getGlobalIndex(size_t i, size_t j, size_t k) const;
         void assertGlobalIndex(size_t globalIndex) const;
         void assertIJK(size_t i , size_t j , size_t k) const;
-        std::tuple<double,double,double> getCellCenter(size_t i,size_t j, size_t k) const;
-        std::tuple<double,double,double> getCellCenter(size_t globalIndex) const;
+        std::array<double, 3> getCellCenter(size_t i,size_t j, size_t k) const;
+        std::array<double, 3> getCellCenter(size_t globalIndex) const;
         double getCellVolume(size_t globalIndex) const;
         double getCellVolume(size_t i , size_t j , size_t k) const;
         double getCellThicknes(size_t globalIndex) const;


### PR DESCRIPTION
This makes it easier to write code using this function (see OPM/opm-autodiff#543).

The tests needed no changes since they used `auto` for the return type and an std::array supports the std::tuple interface.