### PR TITLE
Use warning suppression headers to avoid warnings from boost.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
@@ -24,7 +24,9 @@
 
 #include <stdexcept>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/date_time.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 


### PR DESCRIPTION
Just a minor annoyance fix.