### PR TITLE
OPM-250: Minor changes to support restart

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -22,6 +22,9 @@
 
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
+#include <ert/ecl/ecl_util.h>
+
+
 
 
 namespace Opm {
@@ -295,9 +298,11 @@ namespace Opm {
         return m_FMTOUT;
     }
 
+
     const std::string& IOConfig::getEclipseInputPath() const {
         return m_eclipse_input_path;
     }
+
 
     void IOConfig::setWriteInitialRestartFile(bool writeInitialRestartFile) {
         m_write_initial_RST_file = writeInitialRestartFile;
@@ -369,5 +374,17 @@ namespace Opm {
         }
     }
 
+
+    std::string IOConfig::getRestartFileName(const std::string& restart_base, int report_step, bool output) const {
+        bool unified  = output ? getUNIFOUT() : getUNIFIN();
+        bool fmt_file = output ? getFMTOUT()  : getFMTIN();
+
+        ecl_file_enum file_type = (unified) ? ECL_UNIFIED_RESTART_FILE : ECL_RESTART_FILE;
+        char * c_str = ecl_util_alloc_filename( NULL , restart_base.c_str() , file_type, fmt_file , report_step);
+        std::string restart_filename = c_str;
+        free( c_str );
+
+        return restart_filename;
+    }
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -140,7 +140,7 @@ namespace Opm {
         boost::gregorian::date getTimestepDate(size_t timestep) const;
         void dumpRestartConfig() const;
 
-
+        std::string getRestartFileName(const std::string& restart_base, int report_step, bool output) const;
 
 
     private:


### PR DESCRIPTION
Added a new method getRestartFileName(const std::string& restart_base, int report_step) to IOConfig. 
The parameters are the restart_base and report_step given in the RESTART keyword in the DATA file, located in the initConfig object. 
I will be using this method from the restart functionality code in autodiff. (not yet a PR for this).

 There are some things I wonder about here though , - what about support for higher restart numbers than 9999? As you can see from the code this is not supported here, and I can't see that Eclipse supports it either, but I am sure that I am wrong. So please enlighten me on this subject. 

Or maybe the ert code has functionality for getting the name of a restart file?



