### PR TITLE
Add warning suppression includes.

### DIFF
--- a/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
@@ -18,8 +18,11 @@
 
 #define BOOST_TEST_MODULE ParseMiscible
 #include <math.h>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>


### PR DESCRIPTION
I still do not really know why this is not always triggered, probably not all tests instantiate every template. Content to fix as they turn up though...