### PR TITLE
OPM-252: Added VAPOIL, DISGAS to SimulationConfig

### DIFF
--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -41,7 +41,9 @@
 namespace Opm {
 
     SimulationConfig::SimulationConfig(const ParseMode& parseMode , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) :
-        m_useCPR( false )
+        m_useCPR(false),
+        m_DISGAS(false),
+        m_VAPOIL(false)
     {
         if (Section::hasRUNSPEC(deck)) {
             const RUNSPECSection runspec(deck);
@@ -51,6 +53,12 @@ namespace Opm {
                     throw std::invalid_argument("ERROR: In the RUNSPEC section the CPR keyword should EXACTLY one empty record.");
 
                 m_useCPR = true;
+            }
+            if (runspec.hasKeyword<ParserKeywords::DISGAS>()) {
+                m_DISGAS = true;
+            }
+            if (runspec.hasKeyword<ParserKeywords::VAPOIL>()) {
+                m_VAPOIL = true;
             }
         }
 
@@ -74,6 +82,14 @@ namespace Opm {
 
     bool SimulationConfig::useCPR() const {
         return m_useCPR;
+    }
+
+    bool SimulationConfig::hasDISGAS() const {
+        return m_DISGAS;
+    }
+
+    bool SimulationConfig::hasVAPOIL() const {
+        return m_VAPOIL;
     }
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -35,6 +35,8 @@ namespace Opm {
         std::shared_ptr<const ThresholdPressure> getThresholdPressure() const;
         bool hasThresholdPressure() const;
         bool useCPR() const;
+        bool hasDISGAS() const;
+        bool hasVAPOIL() const;
 
     private:
 
@@ -42,6 +44,8 @@ namespace Opm {
 
         ThresholdPressureConstPtr m_ThresholdPressure;
         bool m_useCPR;
+        bool m_DISGAS;
+        bool m_VAPOIL;
     };
 
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -37,7 +37,7 @@ using namespace Opm;
 
 const std::string& inputStr = "RUNSPEC\n"
                               "EQLOPTS\n"
-                              "THPRES /\n "
+                              "THPRES /\n"
                               "DIMENS\n"
                               "10 3 4 /\n"
                               "\n"
@@ -93,6 +93,16 @@ const std::string& inputStr_cpr_BOTH = "RUNSPEC\n"
     "CPR\n"
     "well1 10 20 30/\n/\n";
 
+const std::string& inputStr_vap_dis = "RUNSPEC\n"
+                                      "VAPOIL\n"
+                                      "DISGAS\n"
+                                      "DIMENS\n"
+                                      "10 3 4 /\n"
+                                      "\n"
+                                      "GRID\n"
+                                      "REGIONS\n"
+                                      "\n";
+
 static DeckPtr createDeck(const ParseMode& parseMode , const std::string& input) {
     Opm::Parser parser;
     return parser.parseString(input, parseMode);
@@ -115,7 +125,6 @@ BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
     DeckPtr deck = createDeck(parseMode , inputStr);
     SimulationConfigConstPtr simulationConfigPtr;
     BOOST_CHECK_NO_THROW(simulationConfigPtr = std::make_shared<const SimulationConfig>(parseMode , deck, getGridProperties()));
-    BOOST_CHECK_EQUAL( true , simulationConfigPtr->hasThresholdPressure());
 }
 
 
@@ -171,9 +180,21 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
 }
 
 
-
-
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRRUnspecWithData) {
     ParseMode parseMode;
     BOOST_CHECK_THROW( createDeck(parseMode , inputStr_INVALID) , std::invalid_argument );
+}
+
+
+BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
+    ParseMode parseMode;
+    DeckPtr deck = createDeck(parseMode , inputStr);
+    SimulationConfig simulationConfig(parseMode , deck, getGridProperties());
+    BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
+    BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
+
+    DeckPtr deck_vd = createDeck(parseMode, inputStr_vap_dis);
+    SimulationConfig simulationConfig_vd(parseMode , deck_vd, getGridProperties());
+    BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
+    BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());
 }


### PR DESCRIPTION
Added VAPOIL, DISGAS to SimulationConfig. To be used from EclipseReader (opm-core) for restart functionality