### PR TITLE
Basic Python wrappers for opm-parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,17 @@ if(NOT OPM_COMMON_ROOT)
   find_package(opm-common QUIET)
 endif()
 
+#-----------------------------------------------------------------
+option (ENABLE_PYTHON "Enable simple python wappers" OFF)
+if (ENABLE_PYTHON)
+   if (NOT BUILD_SHARED_LIBS)
+      set( BUILD_SHARED_LIBS ON)
+      message( WARNING "When ENABLE_PYTHON is ON we must use shared libraries - forcing BUILD_SHARED_LIBS to ON")
+   endif()
+endif()
+#-----------------------------------------------------------------
+
+
 if (NOT opm-common_FOUND)
    unset(opm-common_FOUND)
 

--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -350,3 +350,7 @@ include( ${PROJECT_SOURCE_DIR}/cmake/Modules/install_headers.cmake )
 install_headers( "${HEADER_FILES}" "${CMAKE_INSTALL_PREFIX}" )
 install( TARGETS opmparser DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 install( FILES ${PROJECT_BINARY_DIR}/generated-source/include/opm/parser/eclipse/Parser/ParserKeywords.hpp DESTINATION "include/opm/parser/eclipse/Parser")
+
+if (ENABLE_PYTHON)
+   add_subdirectory( python )
+endif()

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -53,6 +53,12 @@ namespace Opm {
         DeckPtr parseString(const std::string &data, const ParseMode& parseMode) const;
         DeckPtr parseStream(std::shared_ptr<std::istream> inputStream , const ParseMode& parseMode) const;
 
+        Deck * newDeckFromFile(const std::string &dataFileName, const ParseMode& parseMode) const;
+        Deck * newDeckFromString(const std::string &dataFileName, const ParseMode& parseMode) const;
+
+        DeckPtr parseFile(const std::string &dataFile, bool strict = true) const;
+        DeckPtr parseString(const std::string &data, bool strict = true) const;
+        DeckPtr parseStream(std::shared_ptr<std::istream> inputStream , bool strict = true) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(ParserKeywordConstPtr parserKeyword);
@@ -67,7 +73,7 @@ namespace Opm {
         bool loadKeywordFromFile(const boost::filesystem::path& configFile);
 
         void loadKeywordsFromDirectory(const boost::filesystem::path& directory , bool recursive = true);
-        void applyUnitsToDeck(DeckPtr deck) const;
+        void applyUnitsToDeck(Deck& deck) const;
 
         /*!
          * \brief Returns the approximate number of recognized keywords in decks

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -790,7 +790,7 @@ namespace Opm {
     }
 
 
-    void ParserKeyword::applyUnitsToDeck(std::shared_ptr<const Deck> deck , std::shared_ptr<const DeckKeyword> deckKeyword) const {
+    void ParserKeyword::applyUnitsToDeck(const Deck& deck, std::shared_ptr<const DeckKeyword> deckKeyword) const {
         for (size_t index = 0; index < deckKeyword->size(); index++) {
             std::shared_ptr<const ParserRecord> parserRecord = getRecord(index);
             std::shared_ptr<const DeckRecord> deckRecord = deckKeyword->getRecord(index);

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -109,7 +109,7 @@ namespace Opm {
         std::string createDeclaration(const std::string& indent) const;
         std::string createDecl() const;
         std::string createCode() const;
-        void applyUnitsToDeck(std::shared_ptr<const Deck> deck , std::shared_ptr<const DeckKeyword> deckKeyword) const;
+        void applyUnitsToDeck(const Deck& deck , std::shared_ptr<const DeckKeyword> deckKeyword) const;
     private:
         std::pair<std::string,std::string> m_sizeDefinitionPair;
         std::string m_name;

--- a/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -75,15 +75,15 @@ namespace Opm {
 
 
 
-    void ParserRecord::applyUnitsToDeck(std::shared_ptr<const Deck> deck , std::shared_ptr<const DeckRecord> deckRecord) const {
+    void ParserRecord::applyUnitsToDeck(const Deck& deck , std::shared_ptr<const DeckRecord> deckRecord) const {
         for (auto iter=begin(); iter != end(); ++iter) {
             if ((*iter)->hasDimension()) {
                 std::shared_ptr<DeckItem> deckItem = deckRecord->getItem( (*iter)->name() );
                 std::shared_ptr<const ParserItem> parserItem = get( (*iter)->name() );
 
                 for (size_t idim=0; idim < (*iter)->numDimensions(); idim++) {
-                    std::shared_ptr<const Dimension> activeDimension  = deck->getActiveUnitSystem()->getNewDimension( parserItem->getDimension(idim) );
-                    std::shared_ptr<const Dimension> defaultDimension = deck->getDefaultUnitSystem()->getNewDimension( parserItem->getDimension(idim) );
+                    std::shared_ptr<const Dimension> activeDimension  = deck.getActiveUnitSystem()->getNewDimension( parserItem->getDimension(idim) );
+                    std::shared_ptr<const Dimension> defaultDimension = deck.getDefaultUnitSystem()->getNewDimension( parserItem->getDimension(idim) );
                     deckItem->push_backDimension( activeDimension , defaultDimension );
                 }
             }

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -45,7 +45,7 @@ namespace Opm {
         bool equal(const ParserRecord& other) const;
         bool hasDimension() const;
         bool hasItem(const std::string& itemName) const;
-        void applyUnitsToDeck(std::shared_ptr<const Deck> deck , std::shared_ptr<const DeckRecord> deckRecord) const;
+        void applyUnitsToDeck(const Deck& deck , std::shared_ptr<const DeckRecord> deckRecord) const;
         std::vector<ParserItemConstPtr>::const_iterator begin() const;
         std::vector<ParserItemConstPtr>::const_iterator end() const;
     private:

--- a/opm/parser/eclipse/python/CMakeLists.txt
+++ b/opm/parser/eclipse/python/CMakeLists.txt
@@ -1,0 +1,16 @@
+find_package (PythonInterp REQUIRED)
+find_package (ERTPython REQUIRED)
+
+add_subdirectory( c_inter )
+
+if (EXISTS "/etc/debian_version")
+   set( PYTHON_PACKAGE_PATH "dist-packages")
+else()
+   set( PYTHON_PACKAGE_PATH "site-packages")
+endif()
+set(PYTHON_INSTALL_PREFIX  "lib/python${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}/${PYTHON_PACKAGE_PATH}"  CACHE STRING "Subdirectory to install Python modules in")
+
+
+include(cmake/python.cmake)
+add_subdirectory( python )
+add_subdirectory( tests )

--- a/opm/parser/eclipse/python/c_inter/CMakeLists.txt
+++ b/opm/parser/eclipse/python/c_inter/CMakeLists.txt
@@ -1,0 +1,12 @@
+add_library(copmparser SHARED
+cparser.cc
+cdeck.cc cdeck_keyword.cc cdeck_record.cc cdeck_item.cc
+cparse_mode.cc
+ctable_manager.cc
+copm_log.cc
+)
+
+target_link_libraries(copmparser opmparser)
+set_target_properties(copmparser PROPERTIES VERSION ${opm-parser_VERSION_MAJOR}.${opm-parser_VERSION_MINOR}
+                                            SOVERSION ${opm-parser_VERSION_MAJOR})
+install( TARGETS copmparser DESTINATION ${CMAKE_INSTALL_LIBDIR} )

--- a/opm/parser/eclipse/python/c_inter/cdeck.cc
+++ b/opm/parser/eclipse/python/c_inter/cdeck.cc
@@ -1,0 +1,44 @@
+#include <iostream>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+extern "C" {
+
+    int deck_size( const Opm::Deck * deck ) {
+        return static_cast<int>( deck->size() );
+    }
+
+
+    Opm::Deck * deck_alloc() {
+        return new Opm::Deck();
+    }
+
+
+    void deck_free( Opm::Deck * deck ) {
+        delete deck;
+    }
+
+
+    const Opm::DeckKeyword * deck_iget_keyword( const Opm::Deck * deck , int index) {
+        auto shared = deck->getKeyword( index );
+        return shared.get();
+    }
+
+
+    const Opm::DeckKeyword * deck_iget_named_keyword( const Opm::Deck * deck , const char * keyword , int index) {
+        auto shared = deck->getKeyword( keyword , index );
+        return shared.get();
+    }
+
+
+    bool deck_has_keyword( const Opm::Deck * deck , const char * keyword) {
+        return deck->hasKeyword( keyword );
+    }
+
+    int deck_num_keywords( const Opm::Deck * deck , const char * keyword) {
+        return static_cast<int>( deck->numKeywords(keyword) );
+    }
+
+
+}
+
+

--- a/opm/parser/eclipse/python/c_inter/cdeck_item.cc
+++ b/opm/parser/eclipse/python/c_inter/cdeck_item.cc
@@ -1,0 +1,44 @@
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckIntItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckDoubleItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckStringItem.hpp>
+
+extern "C" {
+
+    int deck_item_get_size( const Opm::DeckItem * item ) {
+        return static_cast<int>(item->size());
+    }
+
+    /*
+      These types must be *manually* syncronized with the values in
+      the Python module: opm/deck/item_type_enum.py
+    */
+
+    int deck_item_get_type( const Opm::DeckItem * item ) {
+        if (dynamic_cast<const Opm::DeckIntItem* >(item))
+            return 1;
+
+        if (dynamic_cast<const Opm::DeckStringItem *>(item))
+            return 2;
+
+        if (dynamic_cast<const Opm::DeckDoubleItem *>(item))
+            return 3;
+
+        return 0;
+    }
+
+    int deck_item_iget_int( const Opm::DeckItem * item , int index) {
+        return item->getInt(static_cast<size_t>(index));
+    }
+
+    double deck_item_iget_double( const Opm::DeckItem * item , int index) {
+        return item->getRawDouble(static_cast<size_t>(index));
+    }
+
+    const char * deck_item_iget_string( const Opm::DeckItem * item , int index) {
+        const std::string& string = item->getString(static_cast<size_t>(index));
+        return string.c_str();
+    }
+}
+
+

--- a/opm/parser/eclipse/python/c_inter/cdeck_keyword.cc
+++ b/opm/parser/eclipse/python/c_inter/cdeck_keyword.cc
@@ -1,0 +1,35 @@
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+
+extern "C" {
+
+
+    Opm::DeckKeyword * deck_keyword_alloc( const char * name ) {
+        auto keyword = new Opm::DeckKeyword( name );
+        return keyword;
+    }
+
+
+    void deck_keyword_free( Opm::DeckKeyword * keyword ) {
+        delete keyword;
+    }
+
+
+    const char * deck_keyword_get_name( const Opm::DeckKeyword * keyword ) {
+        const std::string& std_string = keyword->name();
+        return std_string.c_str();
+    }
+
+
+    int deck_keyword_get_size( const Opm::DeckKeyword * keyword ) {
+        return static_cast<int>(keyword->size());
+    }
+
+
+    const Opm::DeckRecord* deck_keyword_iget_record( const Opm::DeckKeyword * keyword , int index) {
+        auto shared = keyword->getRecord( static_cast<int>(index) );
+        return shared.get();
+    }
+
+}
+
+

--- a/opm/parser/eclipse/python/c_inter/cdeck_record.cc
+++ b/opm/parser/eclipse/python/c_inter/cdeck_record.cc
@@ -1,0 +1,25 @@
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
+extern "C" {
+
+    int deck_record_get_size( const Opm::DeckRecord * record ) {
+        return static_cast<int>(record->size());
+    }
+
+    bool deck_record_has_item(const Opm::DeckRecord * record , const char * item) {
+        return record->hasItem( item );
+    }
+
+    Opm::DeckItem * deck_record_iget_item( const Opm::DeckRecord * record , int index) {
+        auto shared = record->getItem( static_cast<size_t>(index));
+        return shared.get();
+    }
+
+    Opm::DeckItem * deck_record_get_item( const Opm::DeckRecord * record , const char * name) {
+        auto shared = record->getItem( name );
+        return shared.get();
+    }
+
+}
+
+

--- a/opm/parser/eclipse/python/c_inter/copm_log.cc
+++ b/opm/parser/eclipse/python/c_inter/copm_log.cc
@@ -1,0 +1,25 @@
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
+#include <opm/parser/eclipse/OpmLog/StreamLog.hpp>
+
+extern "C" {
+
+    void add_stdout_log(int64_t messageMask) {
+        std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cout , messageMask);
+        Opm::OpmLog::addBackend( "STDOUT" , streamLog );
+    }
+
+    void add_stderr_log(int64_t messageMask) {
+        std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(std::cerr , messageMask);
+        Opm::OpmLog::addBackend( "STDERR" , streamLog );
+    }
+
+    void add_file_log( const char * filename , int64_t messageMask) {
+        std::shared_ptr<Opm::StreamLog> streamLog = std::make_shared<Opm::StreamLog>(filename , messageMask);
+        Opm::OpmLog::addBackend( filename , streamLog );
+    }
+
+    void log_add_message( int64_t messageType , const char * message) {
+        Opm::OpmLog::addMessage(messageType , message );
+    }
+
+}

--- a/opm/parser/eclipse/python/c_inter/cparse_mode.cc
+++ b/opm/parser/eclipse/python/c_inter/cparse_mode.cc
@@ -1,0 +1,22 @@
+#include <opm/parser/eclipse/Parser/ParseMode.hpp>
+#include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
+
+extern "C" {
+
+
+    Opm::ParseMode * parse_mode_alloc() {
+        Opm::ParseMode * parse_mode = new Opm::ParseMode( );
+        return parse_mode;
+    }
+
+
+    void parse_mode_free( Opm::ParseMode * parse_mode ) {
+        delete parse_mode;
+    }
+
+
+    void parse_mode_update( Opm::ParseMode * parse_mode , const char * var , Opm::InputError::Action action) {
+        parse_mode->update( var , action );
+    }
+
+}

--- a/opm/parser/eclipse/python/c_inter/cparser.cc
+++ b/opm/parser/eclipse/python/c_inter/cparser.cc
@@ -1,0 +1,27 @@
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseMode.hpp>
+
+
+extern "C" {
+
+    Opm::Deck * parser_parse_file(const Opm::Parser * parser , const char * file , const Opm::ParseMode * parse_mode) {
+        return parser->newDeckFromFile( file , *parse_mode );
+    }
+
+
+    void * parser_alloc() {
+        Opm::Parser * parser = new Opm::Parser( true );
+        return parser;
+    }
+
+    bool parser_has_keyword(const Opm::Parser * parser , const char * keyword) {
+        return parser->hasInternalKeyword( keyword );
+    }
+
+
+    void parser_free(Opm::Parser * parser) {
+        delete parser;
+    }
+
+}

--- a/opm/parser/eclipse/python/c_inter/ctable_manager.cc
+++ b/opm/parser/eclipse/python/c_inter/ctable_manager.cc
@@ -1,0 +1,14 @@
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
+
+extern "C" {
+
+    Opm::TableManager * table_manager_alloc( const Opm::Deck * deck ) {
+        return new Opm::TableManager( *deck );
+    }
+
+
+    void table_manager_free( Opm::TableManager * table_manager ) {
+        delete table_manager;
+    }
+}

--- a/opm/parser/eclipse/python/c_inter/parser-c.cc
+++ b/opm/parser/eclipse/python/c_inter/parser-c.cc
@@ -1,0 +1,22 @@
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+
+extern "C" {
+
+Opm::Deck * parser_parse_file(const Opm::Parser * parser , const char * file) {
+    return parser->newDeckFromFile( file , true );
+}
+
+
+void * parser_alloc() {
+    Opm::Parser * parser = new Opm::Parser( true );
+    return parser;
+}
+
+
+void parser_free(Opm::Parser * parser) {
+    delete parser;
+}
+
+}

--- a/opm/parser/eclipse/python/c_inter/parser.cc
+++ b/opm/parser/eclipse/python/c_inter/parser.cc
@@ -1,0 +1,35 @@
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+/*
+#include <c_inter.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void * parser_parse_file(const void * parser , const char * file);
+void * parser_alloc();
+
+#ifdef __cplusplus
+}
+#endif
+*/
+
+extern "C" {
+
+Opm::Deck * parser_parse_file(const Opm::Parser * parser , const char * file) {
+    return parser->newDeckFromFile( file , true );
+}
+
+
+void * parser_alloc() {
+    Opm::Parser * parser = new Opm::Parser( true );
+    return parser;
+}
+
+void parser_free(Opm::Parser * parser) {
+    delete parser;
+}
+
+}

--- a/opm/parser/eclipse/python/c_inter/parser_c.cc
+++ b/opm/parser/eclipse/python/c_inter/parser_c.cc
@@ -1,0 +1,22 @@
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+
+extern "C" {
+
+Opm::Deck * parser_parse_file(const Opm::Parser * parser , const char * file) {
+    return parser->newDeckFromFile( file , true );
+}
+
+
+void * parser_alloc() {
+    Opm::Parser * parser = new Opm::Parser( true );
+    return parser;
+}
+
+
+void parser_free(Opm::Parser * parser) {
+    delete parser;
+}
+
+}

--- a/opm/parser/eclipse/python/cmake/cmake_pyc
+++ b/opm/parser/eclipse/python/cmake/cmake_pyc
@@ -1,0 +1,27 @@
+import py_compile
+import os
+import os.path
+import sys
+import shutil
+
+
+src_file = sys.argv[1]
+target_file = sys.argv[2]
+
+(target_path , tail) = os.path.split( target_file )
+if not os.path.exists( target_path ):
+   try:
+      os.makedirs( target_path )
+   except:
+      # When running with make -j 4 there might be a race to create this directory.
+      pass
+
+shutil.copyfile( src_file , target_file )
+shutil.copystat( src_file , target_file )
+try:
+    py_compile.compile( target_file , doraise = True)
+except Exception,error:
+    sys.exit("py_compile(%s) failed:%s" % (target_file , error))
+
+
+sys.exit(0)

--- a/opm/parser/eclipse/python/cmake/ctest_run
+++ b/opm/parser/eclipse/python/cmake/ctest_run
@@ -1,0 +1,45 @@
+import sys
+
+try:
+    from unittest2 import TextTestRunner
+except ImportError:
+    from unittest import TextTestRunner
+
+
+def runTestCase(tests):
+    test_result = TextTestRunner(verbosity=0).run(tests)
+    if test_result.errors or test_result.failures:
+        for (test, trace_back) in test_result.errors:
+            sys.stderr.write("=================================================================\n")
+            sys.stderr.write("Test:%s error \n" % test.id())
+            sys.stderr.write("%s\n" % trace_back)
+
+        for (test, trace_back) in test_result.failures:
+            sys.stderr.write("=================================================================\n")
+            sys.stderr.write("Test:%s failure \n" % test.id())
+            sys.stderr.write("%s\n" % trace_back)
+
+        return False
+    else:
+        return True
+
+
+if __name__ == '__main__':
+    PYTHONPATH = sys.argv[1]
+    sys.path.insert(0, PYTHONPATH)
+
+    test_class_path = sys.argv[2]
+    argv = []
+
+    try:
+        argv = sys.argv[3:]
+    except IndexError:
+        pass
+
+    from ert.test import ErtTestRunner
+    tests = ErtTestRunner.getTestsFromTestClass(test_class_path, argv)
+
+    if runTestCase(tests):
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/opm/parser/eclipse/python/cmake/ctest_run_python
+++ b/opm/parser/eclipse/python/cmake/ctest_run_python
@@ -1,0 +1,41 @@
+import sys
+from unittest import TextTestRunner
+
+
+def runTestCase(tests):
+    test_result = TextTestRunner(verbosity=0).run(tests)
+    if test_result.errors or test_result.failures:
+        for (test, trace_back) in test_result.errors:
+            sys.stderr.write("=================================================================\n")
+            sys.stderr.write("Test:%s error \n" % test.id())
+            sys.stderr.write("%s\n" % trace_back)
+
+        for (test, trace_back) in test_result.failures:
+            sys.stderr.write("=================================================================\n")
+            sys.stderr.write("Test:%s failure \n" % test.id())
+            sys.stderr.write("%s\n" % trace_back)
+
+        return False
+    else:
+        return True
+
+
+if __name__ == '__main__':
+    PYTHONPATH = sys.argv[1]
+    sys.path.insert(0, PYTHONPATH)
+
+    test_class_path = sys.argv[2]
+    argv = []
+
+    try:
+        argv = sys.argv[3:]
+    except IndexError:
+        pass
+
+    from ert.test import ErtTestRunner
+    tests = ErtTestRunner.getTestsFromTestClass(test_class_path, argv)
+
+    if runTestCase(tests):
+        sys.exit(0)
+    else:
+        sys.exit(1)

--- a/opm/parser/eclipse/python/cmake/python.cmake
+++ b/opm/parser/eclipse/python/cmake/python.cmake
@@ -1,0 +1,57 @@
+if (NOT PYTHONINTERP_FOUND)
+  find_package (PythonInterp REQUIRED)
+endif ()
+
+
+function(add_python_package target package_path source_files install_package)
+
+  set(build_files "")                       
+
+  foreach (file ${source_files} )
+     set( source_file ${CMAKE_CURRENT_SOURCE_DIR}/${file} )
+     set( build_file ${PROJECT_BINARY_DIR}/${package_path}/${file} )
+     set( install_file ${CMAKE_INSTALL_PREFIX}/${package_path}/${file} )
+
+     add_custom_command(
+        OUTPUT  ${build_file}
+        COMMAND ${PYTHON_EXECUTABLE}
+        ARGS    ${PROJECT_SOURCE_DIR}/opm/parser/eclipse/python/cmake/cmake_pyc ${source_file} ${build_file}
+        DEPENDS ${source_file} )
+    
+     list(APPEND build_files ${build_file} )
+
+     if (install_package)
+        install(FILES ${build_file} DESTINATION ${CMAKE_INSTALL_PREFIX}/${package_path})
+        install(CODE "execute_process(COMMAND ${PROJECT_SOURCE_DIR}/cmake/cmake_pyc_file ${install_file})")
+     endif()
+     
+  endforeach()
+  add_custom_target( ${target} ALL DEPENDS ${build_files})
+
+endfunction()
+
+
+#-----------------------------------------------------------------
+
+
+function (addPythonTest TEST_NAME TEST_CLASS)
+    set(oneValueArgs LABELS)
+    set(multiValueArgs ARGUMENTS ENVIRONMENT)
+    cmake_parse_arguments(TEST_OPTIONS "" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    add_test(NAME python.tests.${TEST_NAME}
+             WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}
+             COMMAND ${PYTHON_EXECUTABLE} ${PROJECT_SOURCE_DIR}/opm/parser/eclipse/python/cmake/ctest_run_python ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX} ${TEST_CLASS} ${TEST_OPTIONS_ARGUMENTS})
+
+    if(TEST_OPTIONS_LABELS)
+        set_property(TEST python.tests.${TEST_NAME} PROPERTY LABELS "Python:${TEST_OPTIONS_LABELS}")
+    else()
+        set_property(TEST python.tests.${TEST_NAME} PROPERTY LABELS "Python")
+    endif()
+
+    if(TEST_OPTIONS_ENVIRONMENT)
+        set_property(TEST python.tests.${TEST_NAME} PROPERTY ENVIRONMENT ${TEST_OPTIONS_ENVIRONMENT})
+    endif()
+    set_property(TEST python.tests.${TEST_NAME} PROPERTY ENVIRONMENT "PYTHONPATH=${ERT_PYTHON_PATH}:${PYTHONPATH}")
+endfunction(addPythonTest)
+

--- a/opm/parser/eclipse/python/python/CMakeLists.txt
+++ b/opm/parser/eclipse/python/python/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory( opm )

--- a/opm/parser/eclipse/python/python/opm/CMakeLists.txt
+++ b/opm/parser/eclipse/python/python/opm/CMakeLists.txt
@@ -1,0 +1,15 @@
+set(PYTHON_SOURCES
+    __init__.py
+)
+
+add_python_package("opm"  ${PYTHON_INSTALL_PREFIX}/opm "${PYTHON_SOURCES}" True)
+
+add_subdirectory( parser )
+add_subdirectory( deck )
+add_subdirectory( ecl_state )
+add_subdirectory( log )
+
+
+configure_file(opm_lib_info_build.py.in   ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/opm/__opm_lib_info.py )
+configure_file(opm_lib_info_install.py.in ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/opm_lib_info_install.py )
+install(FILES ${PROJECT_BINARY_DIR}/${PYTHON_INSTALL_PREFIX}/opm_lib_info_install.py DESTINATION ${PYTHON_INSTALL_PREFIX}/opm RENAME __opm_lib_info.py)

--- a/opm/parser/eclipse/python/python/opm/__init__.py
+++ b/opm/parser/eclipse/python/python/opm/__init__.py
@@ -1,0 +1,23 @@
+import ctypes
+from ert.cwrap.clib import lib_name
+from ert.cwrap.metacwrap import Prototype
+
+        
+lib_path = None
+so_version = ""
+
+try:
+    import __opm_lib_info
+    lib_path = __opm_lib_info.lib_path
+    so_version = __opm_lib_info.so_version
+except ImportError:
+    pass
+
+
+class OPMPrototype(Prototype):
+    lib_file = lib_name( "libcopmparser" , path = lib_path , so_version = so_version)
+    lib = ctypes.CDLL( lib_file , ctypes.RTLD_GLOBAL )
+    
+    def __init__(self , prototype , bind = False):
+        super(OPMPrototype , self).__init__( OPMPrototype.lib , prototype , bind = bind)
+

--- a/opm/parser/eclipse/python/python/opm/deck/CMakeLists.txt
+++ b/opm/parser/eclipse/python/python/opm/deck/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(PYTHON_SOURCES
+    __init__.py
+    deck.py
+    deck_keyword.py
+    deck_record.py
+    deck_item.py
+    item_type_enum.py
+)
+
+add_python_package("opm.deck"  ${PYTHON_INSTALL_PREFIX}/opm/deck "${PYTHON_SOURCES}" True)

--- a/opm/parser/eclipse/python/python/opm/deck/__init__.py
+++ b/opm/parser/eclipse/python/python/opm/deck/__init__.py
@@ -1,0 +1,5 @@
+from .item_type_enum import ItemType
+from .deck_item import DeckItem
+from .deck_record import DeckRecord
+from .deck_keyword import DeckKeyword
+from .deck import Deck

--- a/opm/parser/eclipse/python/python/opm/deck/deck.py
+++ b/opm/parser/eclipse/python/python/opm/deck/deck.py
@@ -1,0 +1,122 @@
+from ert.cwrap import BaseCClass
+from opm import OPMPrototype
+
+class Deck(BaseCClass):
+    TYPE_NAME = "deck"
+    _alloc              = OPMPrototype("void* deck_alloc()")
+    _free               = OPMPrototype("void  deck_free(deck)")
+    _size               = OPMPrototype("int   deck_size(deck)")
+    _iget_keyword       = OPMPrototype("deck_keyword_ref  deck_iget_keyword(deck , int)")
+    _iget_named_keyword = OPMPrototype("deck_keyword_ref  deck_iget_named_keyword(deck , char* , int)")
+    _has_keyword        = OPMPrototype("bool  deck_has_keyword(deck , char*)")
+    _num_keywords       = OPMPrototype("int   deck_num_keywords(deck , char*)")
+    
+    
+    def __init__(self):
+        c_ptr = self._alloc( )
+        super(Deck , self).__init__( c_ptr )
+
+        
+    def __len__(self):
+        """
+        Will return the number of keywords in the deck.
+        """
+        return self._size(self)
+
+
+    def __contains__(self , keyword):
+        """
+        Will return True if the deck has at least one occurence of @keword.
+        """
+        return self._has_keyword(self , keyword)
+
+
+    def numKeywords(self , keyword):
+        """
+        Will count the number of occurences of @keyword.
+        """
+        return self._num_keywords(self , keyword)
+
+
+    def __igetKeyword(self , index):
+        keyword = self._iget_keyword( self , index )
+        keyword.setParent( self )
+        return keyword
+
+    
+    def __igetNamedKeyword(self , name , index):
+        keyword = self._iget_named_keyword( self , name , index )
+        keyword.setParent( self )
+        return keyword
+        
+
+    def __getitem__(self, index):
+        """Implements the [] operator for the deck.
+
+        The @index variable can be either an integegr, i.e. deck[2]
+        will return the third keyword in the deck. The integer based
+        indexing supports slicing; in that case a normal Python list
+        of keywords will be returned.
+
+        Alternatively the @index can be a string: deck["PORO"] will
+        return a Python list of all the PORO keywords in the
+        deck. Finally the @index can be a tuple of ("STRING",int) to
+        get directly get a named keyword instance:
+
+           deck["PORO,0]
+ 
+        will return the first PORO keyword. The tuple syntax supports
+        negative indexing.
+        """
+        if isinstance(index , int):
+            if index < 0:
+                index += len(self)
+
+            if 0 <= index < len(self):
+                return self.__igetKeyword( index )
+            else:
+                raise IndexError
+        elif isinstance(index , slice):
+            (start , step, stop) = index.indices( len(self) )
+            keyword_list = []
+            print start,stop,step
+            for i in range(start,stop,step):
+                keyword_list.append( self.__igetKeyword( i ))
+            return keyword_list
+        elif isinstance(index , str):
+            if index in self:
+                keyword_list = []
+                for i in range(self.numKeywords( index )):
+                    keyword_list.append( self.__igetNamedKeyword(index , i))
+                return keyword_list
+            else:
+                raise KeyError("No %s keyword in deck" % index)
+        elif isinstance(index,tuple):
+            if len(index) == 2:
+                kw = index[0]
+                int_index = index[1]
+                if isinstance(kw , str) and isinstance(int_index , int):
+                    if kw in self:
+                        num_kw = self.numKeywords( kw )
+                        if int_index < num_kw:
+                            if int_index < 0:
+                                int_index += num_kw
+                            return self.__igetNamedKeyword(kw , int_index)
+                        else:
+                            raise IndexError("Not so many %s keywords" % kw)
+                    else:
+                        raise KeyError("No %s keyword in deck" % kw)
+                else:
+                    raise TypeError("Tuple must be two elements : (string,int)")
+            else:
+                raise TypeError("Tuple must be two elements : (string,int)")
+        else:
+            raise TypeError("Index must integer or string")
+        
+
+        
+    def free(self):
+        self._free( self )
+
+
+        

--- a/opm/parser/eclipse/python/python/opm/deck/deck_item.py
+++ b/opm/parser/eclipse/python/python/opm/deck/deck_item.py
@@ -1,0 +1,58 @@
+from ert.cwrap import BaseCClass
+from opm import OPMPrototype
+from opm.deck import ItemType
+
+
+class DeckItem(BaseCClass):
+    TYPE_NAME = "deck_item"
+
+    _size        = OPMPrototype("int            deck_item_get_size( deck_item )")
+    _get_type    = OPMPrototype("item_type_enum deck_item_get_type( deck_item )")
+    _iget_int    = OPMPrototype("int            deck_item_iget_int( deck_item , int )")
+    _iget_double = OPMPrototype("double         deck_item_iget_double( deck_item , int )")
+    _iget_string = OPMPrototype("char*          deck_item_iget_string( deck_item , int )")
+
+    
+    def __init__(self):
+        raise NotImplementedError("Can not create instantiate record directly")
+
+    
+    def __len__(self):
+        """
+        Returns the number of values in the item.
+        """
+        return self._size( self )
+    
+
+    def assertType(self):
+        if not hasattr(self,"value_type"):
+            self.value_type = self._get_type( self )
+
+            if self.value_type == ItemType.INTEGER:
+                self.iget = self._iget_int
+            elif self.value_type == ItemType.DOUBLE:
+                self.iget = self._iget_double
+            elif self.value_type == ItemType.STRING:
+                self.iget = self._iget_string
+            else:
+                raise Exception("What the ??")
+                
+
+            
+    def __getitem__(self , index):
+        """
+        Will return value corresponding to @index.
+        """
+        self.assertType()
+        if isinstance(index , int):
+            if index < 0:
+                index += len(self)
+            if 0 <= index < len(self):
+                return self.iget( self , index )
+            else:
+                raise IndexError("Invalid index:%d  -valid range [0,%d)" % (index , len(self)))
+        else:
+            raise TypeError("Expected integer index")
+
+        
+

--- a/opm/parser/eclipse/python/python/opm/deck/deck_keyword.py
+++ b/opm/parser/eclipse/python/python/opm/deck/deck_keyword.py
@@ -1,0 +1,47 @@
+from ert.cwrap import BaseCClass
+from opm import OPMPrototype
+
+class DeckKeyword(BaseCClass):
+    TYPE_NAME = "deck_keyword"
+
+    _alloc       = OPMPrototype("void* deck_keyword_alloc( char* )")
+    _get_name    = OPMPrototype("char* deck_keyword_get_name( deck_keyword )")
+    _size        = OPMPrototype("int deck_keyword_get_size( deck_keyword )")
+    _free        = OPMPrototype("void deck_keyword_free( deck_keyword )")
+    _iget_record = OPMPrototype("deck_record_ref deck_keyword_iget_record( deck_keyword , int)")
+    
+    def __init__(self , kw):
+        c_ptr = self._alloc( kw )
+        super(DeckKeyword, self).__init__(c_ptr)
+
+    def __len__(self):
+        """
+        Returns the number of records in the keyword.
+        """
+        return self._size( self )
+
+    def __getitem__(self , index):
+        """
+        Will return DeckRecord corresponding to @index.
+        """
+        if index < 0:
+            index += len(self)
+            
+        if 0 <= index < len(self):
+            record = self._iget_record( self , index )
+            record.setParent( self )
+            return record
+        else:
+            raise IndexError("Invalid index:%d  -valid range [0,%d)" % (index , len(self)))
+
+    def __str__(self):
+        return self.name()
+
+    def name(self):
+        return self._get_name( self )
+
+    
+    def free(self):
+        self._free( self )
+    
+

--- a/opm/parser/eclipse/python/python/opm/deck/deck_record.py
+++ b/opm/parser/eclipse/python/python/opm/deck/deck_record.py
@@ -1,0 +1,62 @@
+from ert.cwrap import BaseCClass
+from opm import OPMPrototype
+
+class DeckRecord(BaseCClass):
+    TYPE_NAME = "deck_record"
+
+    _size      = OPMPrototype("int           deck_record_get_size( deck_record )")
+    _has_item  = OPMPrototype("bool          deck_record_has_item( deck_record , char*)")
+    _get_item  = OPMPrototype("deck_item_ref deck_record_get_item( deck_record , char*)")
+    _iget_item = OPMPrototype("deck_item_ref deck_record_iget_item( deck_record , int)")
+
+    
+    def __init__(self):
+        raise NotImplementedError("Can not create instantiate record directly")
+
+    
+    def __len__(self):
+        """Returns the number of items in the record; observe that an item
+        can consist of several input values. Observe that the count
+        will include items with a default, which are not specified in
+        the deck, i.e. for a input item like:
+
+          DATES
+             10 'MAY' 2012 /
+          /
+        
+          dates_kw = deck["DATES"][0]
+          record = dates_kw[0]
+          length = len(record)
+
+        The length variable will have the value 4 - because the DATES
+        item has an optional fourth item 'TIME' with a default value.
+        """
+        return self._size( self )
+
+
+    def __contains__(self , item):
+        return self._has_item( self , item )
+    
+    
+    def __getitem__(self , index):
+        """
+        Will return DeckItem corresponding to @index.
+        """
+        if isinstance(index , int):
+            if index < 0:
+                index += len(self)
+
+            if 0 <= index < len(self):
+                item = self._iget_item( self , index )
+                item.setParent( self )
+                return item
+            else:
+                raise IndexError("Invalid index:%d  -valid range [0,%d)" % (index , len(self)))
+        elif isinstance(index,str):
+            if index in self:
+                item = self._get_item( self , index )
+                item.setParent( self )
+                return item
+            else:
+                raise KeyError("Not recognized item key:%s" % index)
+

--- a/opm/parser/eclipse/python/python/opm/deck/item_type_enum.py
+++ b/opm/parser/eclipse/python/python/opm/deck/item_type_enum.py
@@ -1,0 +1,14 @@
+from ert.cwrap import BaseCEnum
+
+
+class ItemType(BaseCEnum):
+    TYPE_NAME="item_type_enum"
+    INTEGER = None
+    STRING = None
+    DOUBLE = None
+
+
+ItemType.addEnum("INTEGER", 1)
+ItemType.addEnum("STRING", 2)
+ItemType.addEnum("DOUBLE", 3)
+

--- a/opm/parser/eclipse/python/python/opm/ecl_state/CMakeLists.txt
+++ b/opm/parser/eclipse/python/python/opm/ecl_state/CMakeLists.txt
@@ -1,0 +1,6 @@
+set(PYTHON_SOURCES
+    __init__.py
+    table_manager.py
+)
+
+add_python_package("opm.ecl_state"  ${PYTHON_INSTALL_PREFIX}/opm/ecl_state "${PYTHON_SOURCES}" True)

--- a/opm/parser/eclipse/python/python/opm/ecl_state/__init__.py
+++ b/opm/parser/eclipse/python/python/opm/ecl_state/__init__.py
@@ -1,0 +1,2 @@
+from .table_manager import TableManager
+

--- a/opm/parser/eclipse/python/python/opm/ecl_state/table_manager.py
+++ b/opm/parser/eclipse/python/python/opm/ecl_state/table_manager.py
@@ -1,0 +1,20 @@
+import os.path
+
+from ert.cwrap import BaseCClass
+from opm import OPMPrototype
+
+
+class TableManager(BaseCClass):
+    TYPE_NAME = "table_manager"
+    _alloc    = OPMPrototype("void* table_manager_alloc(deck)")
+    _free     = OPMPrototype("void* table_manager_free(table_manager)")
+    
+    def __init__(self , deck):
+        c_ptr = self._alloc(deck)
+        super(TableManager, self).__init__(c_ptr)
+
+
+    def free(self):
+        self._free( self )
+
+        

--- a/opm/parser/eclipse/python/python/opm/log/CMakeLists.txt
+++ b/opm/parser/eclipse/python/python/opm/log/CMakeLists.txt
@@ -1,0 +1,7 @@
+set(PYTHON_SOURCES
+    __init__.py
+    message_type.py
+    opm_log.py
+)
+
+add_python_package("opm.log"  ${PYTHON_INSTALL_PREFIX}/opm/log "${PYTHON_SOURCES}" True)

--- a/opm/parser/eclipse/python/python/opm/log/__init__.py
+++ b/opm/parser/eclipse/python/python/opm/log/__init__.py
@@ -1,0 +1,3 @@
+from .message_type import MessageType
+from .opm_log import OpmLog
+

--- a/opm/parser/eclipse/python/python/opm/log/log_message.py
+++ b/opm/parser/eclipse/python/python/opm/log/log_message.py
@@ -1,0 +1,3 @@
+class MessageType(object):
+    # These are hand-copied from LogUtil.hpp
+    

--- a/opm/parser/eclipse/python/python/opm/log/message_type.py
+++ b/opm/parser/eclipse/python/python/opm/log/message_type.py
@@ -1,0 +1,11 @@
+class MessageType(object):
+    # These are hand-copied from LogUtil.hpp
+    DEBUG = 1
+    INFO = 2
+    WARNING = 4
+    ERROR = 8
+    PROBLEM = 16
+    BUG = 16
+
+    
+    DEFAULT = DEBUG + INFO + WARNING + ERROR + PROBLEM + BUG

--- a/opm/parser/eclipse/python/python/opm/log/opm_log.py
+++ b/opm/parser/eclipse/python/python/opm/log/opm_log.py
@@ -1,0 +1,34 @@
+from ert.cwrap import BaseCClass, CWrapper
+from opm import OPMPrototype
+
+from opm.log import MessageType
+
+class OpmLog(BaseCClass):
+    _add_file_log   = OPMPrototype("void add_file_log( char* , int64 )")
+    _add_stderr_log = OPMPrototype("void add_stderr_log( int64 )")
+    _add_stdout_log = OPMPrototype("void add_stdout_log( int64 )")
+    _add_message    = OPMPrototype("void log_add_message( int64 , char* )")
+
+    def __init__(self):
+        raise Exception("Can not instantiate - just use class methods")
+
+    @classmethod
+    def addStdoutLog(cls , message_mask = MessageType.DEFAULT):
+        cls._add_stdout_log(message_mask)
+
+
+    @classmethod
+    def addStderrLog(cls , message_mask = MessageType.DEFAULT):
+        cls._add_stderr_log(message_mask)
+
+
+    @classmethod
+    def addFileLog(cls , filename , message_mask = MessageType.DEFAULT):
+        cls._add_file_log(filename , message_mask)
+
+        
+    @classmethod
+    def addMessage(cls , message_type , message):
+        cls._add_message(message_type , message)
+    
+

--- a/opm/parser/eclipse/python/python/opm/opm_lib_info_build.py.in
+++ b/opm/parser/eclipse/python/python/opm/opm_lib_info_build.py.in
@@ -1,0 +1,3 @@
+lib_path = "${LIBRARY_OUTPUT_PATH}"
+so_version = ""
+

--- a/opm/parser/eclipse/python/python/opm/opm_lib_info_install.py.in
+++ b/opm/parser/eclipse/python/python/opm/opm_lib_info_install.py.in
@@ -1,0 +1,2 @@
+lib_path = "${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}"
+so_version = ""

--- a/opm/parser/eclipse/python/python/opm/parser/CMakeLists.txt
+++ b/opm/parser/eclipse/python/python/opm/parser/CMakeLists.txt
@@ -1,0 +1,8 @@
+set(PYTHON_SOURCES
+    __init__.py
+    parser.py
+    parse_mode.py
+    error_action.py
+)
+
+add_python_package("opm.parser"  ${PYTHON_INSTALL_PREFIX}/opm/parser "${PYTHON_SOURCES}" True)

--- a/opm/parser/eclipse/python/python/opm/parser/__init__.py
+++ b/opm/parser/eclipse/python/python/opm/parser/__init__.py
@@ -1,0 +1,4 @@
+from .error_action import ErrorAction
+from .parse_mode import ParseMode
+from .parser import Parser
+

--- a/opm/parser/eclipse/python/python/opm/parser/error_action.py
+++ b/opm/parser/eclipse/python/python/opm/parser/error_action.py
@@ -1,0 +1,13 @@
+from ert.cwrap import BaseCEnum
+
+
+class ErrorAction(BaseCEnum):
+    TYPE_NAME = "error_action_enum"
+    THROW_EXCEPTION = None
+    WARN = None
+    IGNORE = None
+
+
+ErrorAction.addEnum("THROW_EXCEPTION", 0)
+ErrorAction.addEnum("WARN", 1)
+ErrorAction.addEnum("IGNORE", 2)

--- a/opm/parser/eclipse/python/python/opm/parser/parse_mode.py
+++ b/opm/parser/eclipse/python/python/opm/parser/parse_mode.py
@@ -1,0 +1,21 @@
+from ert.cwrap import BaseCClass, CWrapper
+from opm import OPMPrototype
+
+class ParseMode(BaseCClass):
+    TYPE_NAME = "parse_mode"
+    _alloc    = OPMPrototype("void* parse_mode_alloc()")
+    _free     = OPMPrototype("void  parse_mode_free(parse_mode)")
+    _update   = OPMPrototype("void  parse_mode_update(parse_mode, char* , error_action_enum)")
+    
+    def __init__(self):
+        c_ptr = self._alloc()
+        super(ParseMode, self).__init__(c_ptr)
+
+        
+    def free(self):
+        self._free( self )
+
+
+    def update(self , var , action):
+        self._update( self , var , action )
+

--- a/opm/parser/eclipse/python/python/opm/parser/parser.py
+++ b/opm/parser/eclipse/python/python/opm/parser/parser.py
@@ -1,0 +1,36 @@
+import os.path
+
+from ert.cwrap import BaseCClass
+from opm import OPMPrototype
+from opm.deck import Deck
+from opm.parser import ParseMode
+
+
+class Parser(BaseCClass):
+    TYPE_NAME = "parser"
+    _alloc       = OPMPrototype("void* parser_alloc()")
+    _free        = OPMPrototype("void  parser_free(parser)")
+    _has_keyword = OPMPrototype("bool  parser_has_keyword(parser, char*)")
+    _parse_file  = OPMPrototype("deck_obj  parser_parse_file(parser, char*, parse_mode)")
+    
+    def __init__(self):
+        c_ptr = self._alloc()
+        super(Parser, self).__init__(c_ptr)
+
+        
+    def __contains__(self , kw):
+        return self._has_keyword(kw)
+        
+        
+    def free(self):
+        self._free( self )
+
+        
+    def parseFile(self , filename , parse_mode = None):
+        if os.path.isfile( filename ):
+            if parse_mode is None:
+                parse_mode = ParseMode( )
+            return self._parse_file(self , filename, parse_mode)
+        else:
+            raise IOError("No such file:%s" % filename)
+

--- a/opm/parser/eclipse/python/test.py
+++ b/opm/parser/eclipse/python/test.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+sys.path += ["/private/joaho/work/OPM/opm-parser/opm/parser/eclipse/python/python"]
+from opm.parser.parser import Parser
+
+p = Parser()
+
+deck = p.parseFile( sys.argv[1] )    
+print "Number of keywords in deck: %s" % len(deck)
+
+for kw in deck:
+    print "%s:%d" % (kw.name() , len(kw))

--- a/opm/parser/eclipse/python/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/python/tests/CMakeLists.txt
@@ -1,0 +1,10 @@
+set(TEST_SOURCES
+    __init__.py
+)
+
+add_python_package("python.tests" "${PYTHON_INSTALL_PREFIX}/tests" "${TEST_SOURCES}" False)
+add_subdirectory( parser )
+add_subdirectory( deck )
+add_subdirectory( parse_mode )
+add_subdirectory( ecl_state )
+add_subdirectory( opm_log )

--- a/opm/parser/eclipse/python/tests/deck/CMakeLists.txt
+++ b/opm/parser/eclipse/python/tests/deck/CMakeLists.txt
@@ -1,0 +1,13 @@
+set (TEST_SOURCES
+    __init__.py
+    test_deck.py
+    test_deck_keyword.py
+    test_deck_record.py
+    test_deck_item.py )
+
+add_python_package("python.tests.deck" "${PYTHON_INSTALL_PREFIX}/tests/deck" "${TEST_SOURCES}" False)
+
+addPythontest( python.test_deck tests.deck.test_deck.DeckTest )
+addPythontest( python.test_deck_keyword tests.deck.test_deck_keyword.DeckKeywordTest )
+addPythontest( python.test_deck_record tests.deck.test_deck_record.DeckRecordTest )
+addPythontest( python.test_deck_item tests.deck.test_deck_item.DeckItemTest )

--- a/opm/parser/eclipse/python/tests/deck/test_deck.py
+++ b/opm/parser/eclipse/python/tests/deck/test_deck.py
@@ -1,0 +1,67 @@
+from unittest import TestCase
+
+from ert.test import TestAreaContext
+
+from opm.parser import Parser
+from opm.deck import Deck
+
+
+
+class DeckTest(TestCase):
+    def test_empty_deck(self):
+        deck = Deck()
+        self.assertEqual( len(deck) , 0 )
+
+        with self.assertRaises(IndexError):
+            deck[9]
+
+        with self.assertRaises(KeyError):
+            l = deck["EQUIL"]
+
+        self.assertEqual( 0 , deck.numKeywords("EQUIL"))
+
+        
+    def test_deck(self):
+        with TestAreaContext("parse-test"):
+            with open("test.DATA", "w") as fileH:
+                fileH.write("RUNSPEC\n")
+                fileH.write("DIMENS\n")
+                fileH.write(" 10 10 10 /\n")
+                fileH.write("SCHEDULE\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  10 10 /\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  20 20 /\n")
+                fileH.write("DATES\n")
+                fileH.write("  10 'MAY' 2017 /\n")
+                fileH.write("/\n")
+                
+            p = Parser( )
+            deck = p.parseFile("test.DATA")
+        self.assertEqual( len(deck) , 6 )
+        self.assertEqual( 2 , deck.numKeywords("TSTEP"))
+        tstep = deck["TSTEP"]
+        self.assertEqual( len(tstep) , 2)
+
+        slice_list = deck[0:2:6]
+        self.assertEqual( len(slice_list) , 3)
+        self.assertEqual( slice_list[0].name() , "RUNSPEC")
+        self.assertEqual( slice_list[1].name() , "SCHEDULE")
+        self.assertEqual( slice_list[2].name() , "TSTEP")
+
+        dates_kw = deck[-1]
+        self.assertEqual( dates_kw.name() , "DATES")
+        
+        with self.assertRaises(IndexError):
+            deck["TSTEP" , 2]
+
+        with self.assertRaises(TypeError):
+            deck["TSTEP" , "X"]
+        
+        t0 = deck["TSTEP",0]
+        t1 = deck["TSTEP",1]
+        t1 = deck["TSTEP",-1]
+        
+            
+
+        

--- a/opm/parser/eclipse/python/tests/deck/test_deck_item.py
+++ b/opm/parser/eclipse/python/tests/deck/test_deck_item.py
@@ -1,0 +1,43 @@
+from unittest import TestCase
+
+from ert.test import TestAreaContext
+
+from opm.parser import Parser
+from opm.deck import Deck, DeckKeyword, DeckRecord , DeckItem
+
+
+
+class DeckItemTest(TestCase):
+        
+    def test_from_deck(self):
+        with TestAreaContext("parse-test"):
+            with open("test.DATA", "w") as fileH:
+                fileH.write("RUNSPEC\n")
+                fileH.write("DIMENS\n")
+                fileH.write(" 10 10 10 /\n")
+                fileH.write("SCHEDULE\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  10 10 /\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  20 20 /\n")
+                fileH.write("DATES\n")
+                fileH.write("  10 'MAY' 2017 /\n")
+                fileH.write("  15 'MAY' 2017 /\n")
+                fileH.write("/\n")
+                
+            p = Parser( )
+            deck = p.parseFile("test.DATA")
+
+        dates_kw = deck[-1]
+        record = dates_kw[0]
+        day_item = record[0]
+        year_item = record["YEAR"]
+        month_item = record[1]
+        
+        self.assertTrue( isinstance( day_item , DeckItem ))
+        self.assertTrue( isinstance( year_item , DeckItem ))
+
+        self.assertEqual( day_item[0] , 10 )
+        self.assertEqual( month_item[0] , "MAY")
+        self.assertEqual( year_item[0] , 2017)
+

--- a/opm/parser/eclipse/python/tests/deck/test_deck_keyword.py
+++ b/opm/parser/eclipse/python/tests/deck/test_deck_keyword.py
@@ -1,0 +1,55 @@
+from unittest import TestCase
+
+from ert.test import TestAreaContext
+
+from opm.parser import Parser
+from opm.deck import Deck, DeckKeyword, DeckRecord
+
+
+
+class DeckKeywordTest(TestCase):
+    def test_empty_keyword(self):
+        kw = DeckKeyword("MYKW")
+        self.assertEqual( len(kw) , 0 )
+
+        with self.assertRaises(IndexError):
+            kw[9]
+
+        self.assertEqual( kw.name() , "MYKW")
+        
+        
+    def test_from_deck(self):
+        with TestAreaContext("parse-test"):
+            with open("test.DATA", "w") as fileH:
+                fileH.write("RUNSPEC\n")
+                fileH.write("DIMENS\n")
+                fileH.write(" 10 10 10 /\n")
+                fileH.write("SCHEDULE\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  10 10 /\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  20 20 /\n")
+                fileH.write("DATES\n")
+                fileH.write("  10 'MAY' 2017 /\n")
+                fileH.write("  15 'MAY' 2017 /\n")
+                fileH.write("/\n")
+                
+            p = Parser( )
+            deck = p.parseFile("test.DATA")
+
+        self.assertEqual( len(deck) , 6 )
+        dates_kw = deck[-1]
+        self.assertEqual( dates_kw.name() , "DATES")
+        self.assertEqual( len(dates_kw) , 2 )
+        runspec_kw = deck["RUNSPEC"][0]
+        self.assertEqual( len(runspec_kw) , 0 )
+
+        with self.assertRaises( IndexError ):
+            runspec_kw[0]
+
+        with self.assertRaises( IndexError ):
+            dates_kw[2]
+
+        record = dates_kw[0]
+        self.assertTrue( isinstance( record , DeckRecord ))
+        

--- a/opm/parser/eclipse/python/tests/deck/test_deck_record.py
+++ b/opm/parser/eclipse/python/tests/deck/test_deck_record.py
@@ -1,0 +1,44 @@
+from unittest import TestCase
+
+from ert.test import TestAreaContext
+
+from opm.parser import Parser
+from opm.deck import Deck, DeckKeyword, DeckRecord
+
+
+
+class DeckRecordTest(TestCase):
+        
+    def test_from_deck(self):
+        with TestAreaContext("parse-test"):
+            with open("test.DATA", "w") as fileH:
+                fileH.write("RUNSPEC\n")
+                fileH.write("DIMENS\n")
+                fileH.write(" 10 10 10 /\n")
+                fileH.write("SCHEDULE\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  10 10 /\n")
+                fileH.write("TSTEP\n")
+                fileH.write("  20 20 /\n")
+                fileH.write("DATES\n")
+                fileH.write("  10 'MAY' 2017 /\n")
+                fileH.write("  15 'MAY' 2017 /\n")
+                fileH.write("/\n")
+                
+            p = Parser( )
+            deck = p.parseFile("test.DATA")
+
+        dates_kw = deck[-1]
+        record = dates_kw[0]
+        self.assertTrue( isinstance( record , DeckRecord ))
+        self.assertEqual( len(record) , 4 )
+
+        with self.assertRaises(IndexError):
+            record[100]
+
+        with self.assertRaises(KeyError):
+            record["NO-NOT-THAT-ITEM"]
+
+        self.assertTrue( "DAY" in record )
+        self.assertFalse( "XXX" in record )
+        

--- a/opm/parser/eclipse/python/tests/ecl_state/CMakeLists.txt
+++ b/opm/parser/eclipse/python/tests/ecl_state/CMakeLists.txt
@@ -1,0 +1,7 @@
+set (TEST_SOURCES
+    __init__.py
+    test_table_manager.py)
+
+add_python_package("python.tests.ecl_state" "${PYTHON_INSTALL_PREFIX}/tests/ecl_state" "${TEST_SOURCES}" False)
+
+addPythontest( python.test_table_manager tests.ecl_state.test_table_manager.TableManagerTest )

--- a/opm/parser/eclipse/python/tests/ecl_state/test_table_manager.py
+++ b/opm/parser/eclipse/python/tests/ecl_state/test_table_manager.py
@@ -1,0 +1,25 @@
+from unittest import TestCase
+from ert.test import TestAreaContext
+
+from opm.parser import Parser
+from opm.ecl_state import TableManager
+
+
+
+class TableManagerTest(TestCase):
+    def test_create(self):
+        with TestAreaContext("table-manager"):
+            p = Parser()
+            with open("test.DATA", "w") as fileH:
+                fileH.write("""
+TABDIMS
+ 2 /
+
+SWOF
+ 1 2 3 4
+ 5 6 7 8 /
+ 9 10 11 12 /
+""")
+            
+            deck = p.parseFile( "test.DATA")
+            table_manager = TableManager( deck )

--- a/opm/parser/eclipse/python/tests/opm_log/CMakeLists.txt
+++ b/opm/parser/eclipse/python/tests/opm_log/CMakeLists.txt
@@ -1,0 +1,6 @@
+set (TEST_SOURCES
+    __init__.py
+    test_opm_log.py)
+
+add_python_package("python.tests.log" "${PYTHON_INSTALL_PREFIX}/tests/opm_log" "${TEST_SOURCES}" False)
+addPythontest( python.test_log tests.opm_log.test_opm_log.OpmLogTest )

--- a/opm/parser/eclipse/python/tests/opm_log/test_opm_log.py
+++ b/opm/parser/eclipse/python/tests/opm_log/test_opm_log.py
@@ -1,0 +1,20 @@
+from unittest import TestCase
+from ert.test import TestAreaContext
+
+from opm.log import OpmLog, MessageType
+
+
+class OpmLogTest(TestCase):
+    def test_file_stream(self):
+        OpmLog.addStdoutLog( MessageType.ERROR )
+        OpmLog.addStderrLog( MessageType.ERROR )
+
+        with TestAreaContext("log/test"):
+            OpmLog.addFileLog( "log.txt" , MessageType.INFO )
+            OpmLog.addMessage( MessageType.INFO , "XXLine1")
+
+            with open("log.txt") as file:
+                line = file.readline()
+                line = line.strip()
+                self.assertEqual( line , "XXLine1")
+                

--- a/opm/parser/eclipse/python/tests/parse_mode/CMakeLists.txt
+++ b/opm/parser/eclipse/python/tests/parse_mode/CMakeLists.txt
@@ -1,0 +1,7 @@
+set (TEST_SOURCES
+    __init__.py
+    test_parse_mode.py)
+
+add_python_package("python.tests.parse_mode" "${PYTHON_INSTALL_PREFIX}/tests/parse_mode" "${TEST_SOURCES}" False)
+
+addPythontest( python.test_parse_mode tests.parse_mode.test_parse_mode.ParseModeTest )

--- a/opm/parser/eclipse/python/tests/parse_mode/test_parse_mode.py
+++ b/opm/parser/eclipse/python/tests/parse_mode/test_parse_mode.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+
+from ert.test import TestAreaContext,ExtendedTestCase
+
+from opm.parser import ParseMode,ErrorAction
+
+
+
+class ParseModeTest(ExtendedTestCase):
+
+    def test_parse_mode(self):
+        pm = ParseMode()
+
+        pm.update( "PARSE*" , ErrorAction.IGNORE )
+
+
+        
+    def test_action_enum(self):
+        #source_file_path = "../../../Parser/InputErrorAction.hpp"
+        #self.assertEnumIsFullyDefined(ErrorAction , "Action", source_file_path)
+
+        for (key,value) in [("THROW_EXCEPTION" , 0), ("WARN" , 1) , ("IGNORE" , 2)]:
+            self.assertTrue(ErrorAction.__dict__.has_key(key), "Enum does not have identifier: %s" % key)
+            class_value = ErrorAction.__dict__[key]
+            self.assertEqual(class_value, value, "Enum value for identifier: %s does not match: %s != %s" % (key, class_value, value))
+

--- a/opm/parser/eclipse/python/tests/parser/CMakeLists.txt
+++ b/opm/parser/eclipse/python/tests/parser/CMakeLists.txt
@@ -1,0 +1,7 @@
+set (TEST_SOURCES
+    __init__.py
+    test_parser.py)
+
+add_python_package("python.tests.parser" "${PYTHON_INSTALL_PREFIX}/tests/parser" "${TEST_SOURCES}" False)
+
+addPythontest( python.test_parser tests.parser.test_parser.ParserTest )

--- a/opm/parser/eclipse/python/tests/parser/test_parser.py
+++ b/opm/parser/eclipse/python/tests/parser/test_parser.py
@@ -1,0 +1,26 @@
+from unittest import TestCase
+
+from ert.test import TestAreaContext
+
+from opm.parser import Parser,ParseMode
+
+
+
+class ParserTest(TestCase):
+    def test_parse(self):
+        p = Parser()
+        pm = ParseMode()
+        with self.assertRaises(IOError):
+            p.parseFile("does/not/exist" , pm)
+
+        with TestAreaContext("parse-test"):
+            with open("test.DATA", "w") as fileH:
+                fileH.write("RUNSPEC\n")
+                fileH.write("DIMENS\n")
+                fileH.write(" 10 10 10 /\n")
+        
+            deck = p.parseFile( "test.DATA" , pm)
+            self.assertEqual( len(deck) , 2 )
+
+
+            


### PR DESCRIPTION
With this PR a basic infrastructure for Python wrapping of (some of) the classes in opm-parser are added.

**How it works:** The wrapping is based on the standard Python ctypes which is used to load and bind to a shared library at runtime. On top of that we are using a framework from ert to "prototype" the C functions in the shared library. Due to name mangling an extremely thin C layer is created around the C++ code, the Python code binds to these C functions.

There are other alternative frameworks for binding Python to C++, most notably Swig and Boost Python. The advantage with the current approach is that the Python classes are implemented in Python - not in some intermediate definition language. The approach based on ctypes and `ert.cwrap` has been heavily tested in Statoil for several years. The current wrappers have also seen some use in Statoil as an installed feature branch.

**To try it out:** Everything is controlled by the cmake switch `ENABLE_PYTHON` - that switch defaults to `OFF`. If `ENABLE_PYTHON` is set to `ON` the following will happen:
 
 1. The build system will force a shared build - the ctypes system requires shared libraries.
 2. A very thin C wrapper library `libcopmparser.so` is created.
 3. A tree of Python files is marked for installation, and a simple python "compilation" is performed.
 4. Several Python tests are added and i ntegrated into the `ctest` framework.

As long as the `ENABLE_PYTHON` setting is left at the default value `OFF` the opm-parser product will not be affected *at all*; and even when `ENABLE_PYTHON` is set to `ON` the additions will be as *new* files.

**Requirements:** This requires a brand new version of ert, no other external dependencies.

**Why on earth:** I am willing to bet there are more than 10 half-baked Eclipse input parser written in everything from Fortran to Perl in more or less active use in Statoil today. I feel that the current opm-parser implementation has the potential to "rule them all" - but then it must be simpler for the average reservoir engineer to use what is currently the case.


```Python
#!/usr/bin/env python
from opm import Parser
import sys

data_file = sys.argv[1]
parser = Parser( )
deck = parser.parseFile( data_file )

print("List of keywords in %s" % data_file)
for keyword in deck:
    print( keyword )
```
     