### PR TITLE
Fixes autogen'd .hpp installed into wrong dir

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -364,12 +364,11 @@ include( ${PROJECT_SOURCE_DIR}/cmake/Modules/install_headers.cmake )
 install_headers( "${HEADER_FILES}" "${CMAKE_INSTALL_PREFIX}" )
 install( TARGETS opmparser DESTINATION ${CMAKE_INSTALL_LIBDIR} )
 
+install(FILES ${PROJECT_BINARY_DIR}/generated-source/include/opm/parser/eclipse/Parser/ParserKeywords.hpp
+        DESTINATION include/opm/parser/eclipse/Parser)
+install(DIRECTORY ${PROJECT_BINARY_DIR}/generated-source/include/opm/parser/eclipse/Parser/ParserKeywords
+        DESTINATION include/opm/parser/eclipse/Parser)
 
-FILE( GLOB generated_header
-        ${PROJECT_BINARY_DIR}/generated-source/include/opm/parser/eclipse/Parser/ParserKeywords.hpp
-        ${PROJECT_BINARY_DIR}/generated-source/include/opm/parser/eclipse/Parser/ParserKeywords/*.hpp
-    )
-install(FILES ${generated_header} DESTINATION include/opm/parser/eclipse/Parser)
 if (ENABLE_PYTHON)
    add_subdirectory( python )
 endif()


### PR DESCRIPTION
Pretty self-explanatory. The makefile has a bug which installs autogenerated headers into the wrong directory.