### PR TITLE
[WIP] Iterator utilities

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -278,6 +278,7 @@ EclipseState/Tables/TableEnums.hpp
 EclipseState/Tables/TableSchema.hpp
 EclipseState/Tables/TableIndex.hpp
 #
+Utility/Iterator.hpp
 Utility/WconinjeWrapper.hpp
 Utility/CompdatWrapper.hpp
 Utility/WconinjWrapper.hpp

--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -103,14 +103,23 @@ namespace Opm {
             return m_emptyList;
     }
 
-    std::vector<DeckKeywordConstPtr>::const_iterator Deck::begin() const {
-        return m_keywordList.begin();
+    Deck::const_iterator Deck::begin() const {
+        auto itr = const_cast< Deck* >( this )->m_keywordList.begin();
+        return Deck::const_iterator( itr );
     }
 
-    std::vector<DeckKeywordConstPtr>::const_iterator Deck::end() const {
-        return m_keywordList.end();
+    Deck::const_iterator Deck::end() const {
+        auto itr = const_cast< Deck* >( this )->m_keywordList.end();
+        return Deck::const_iterator( itr );
     }
 
+    Deck::const_iterator Deck::cbegin() const {
+        return this->begin();
+    }
+
+    Deck::const_iterator Deck::cend() const {
+        return this->end();
+    }
 
     size_t Deck::size() const {
         return m_keywordList.size();

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -24,6 +24,9 @@
 #include <memory>
 #include <vector>
 
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Utility/Iterator.hpp>
+
 namespace Opm {
 
     class DeckKeyword;
@@ -31,6 +34,9 @@ namespace Opm {
 
     class Deck {
     public:
+
+        typedef iterator_base< const DeckKeyword > const_iterator;
+
         Deck();
         bool hasKeyword(std::shared_ptr< const DeckKeyword > keyword) const;
         bool hasKeyword( const std::string& keyword ) const;
@@ -48,8 +54,11 @@ namespace Opm {
         void initUnitSystem();
         std::shared_ptr<UnitSystem> getDefaultUnitSystem() const;
         std::shared_ptr<UnitSystem> getActiveUnitSystem()  const;
-        std::vector<std::shared_ptr< const DeckKeyword >>::const_iterator begin() const;
-        std::vector<std::shared_ptr< const DeckKeyword >>::const_iterator end() const;
+
+        const_iterator begin() const;
+        const_iterator end() const;
+        const_iterator cbegin() const;
+        const_iterator cend() const;
 
 
         template <class Keyword>

--- a/opm/parser/eclipse/Deck/DeckIterator.cpp
+++ b/opm/parser/eclipse/Deck/DeckIterator.cpp
@@ -1,0 +1,8 @@
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Utility/Iterator.hpp>
+#include <opm/parser/eclipse/Utility/Iterator.cpp>
+
+namespace Opm {
+    template class iterator_base< DeckItem >;
+    template class iterator_base< const DeckItem, DeckItem >;
+}

--- a/opm/parser/eclipse/Deck/DeckIterator.cpp
+++ b/opm/parser/eclipse/Deck/DeckIterator.cpp
@@ -1,4 +1,5 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Utility/Iterator.hpp>
 #include <opm/parser/eclipse/Utility/Iterator.cpp>
@@ -7,4 +8,5 @@ namespace Opm {
     template class iterator_base< DeckItem >;
     template class iterator_base< const DeckItem, DeckItem >;
     template class iterator_base< const DeckRecord >;
+    template class iterator_base< const DeckKeyword >;
 }

--- a/opm/parser/eclipse/Deck/DeckIterator.cpp
+++ b/opm/parser/eclipse/Deck/DeckIterator.cpp
@@ -1,8 +1,10 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Utility/Iterator.hpp>
 #include <opm/parser/eclipse/Utility/Iterator.cpp>
 
 namespace Opm {
     template class iterator_base< DeckItem >;
     template class iterator_base< const DeckItem, DeckItem >;
+    template class iterator_base< const DeckRecord >;
 }

--- a/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -91,12 +91,22 @@ namespace Opm {
         m_recordList.push_back(record);
     }
 
-    std::vector<DeckRecordConstPtr>::const_iterator DeckKeyword::begin() const {
-        return m_recordList.begin();
+    DeckKeyword::const_iterator DeckKeyword::begin() const {
+        auto itr = const_cast< DeckKeyword* >( this )->m_recordList.begin();
+        return DeckKeyword::const_iterator( itr );
     }
 
-    std::vector<DeckRecordConstPtr>::const_iterator DeckKeyword::end() const {
-        return m_recordList.end();
+    DeckKeyword::const_iterator DeckKeyword::end() const {
+        auto itr = const_cast< DeckKeyword* >( this )->m_recordList.end();
+        return DeckKeyword::const_iterator( itr );
+    }
+
+    DeckKeyword::const_iterator DeckKeyword::cbegin() const {
+        return this->begin();
+    }
+
+    DeckKeyword::const_iterator DeckKeyword::cend() const {
+        return this->end();
     }
 
     DeckRecordConstPtr DeckKeyword::getRecord(size_t index) const {

--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -12,12 +12,17 @@
 #include <vector>
 #include <memory>
 
+#include <opm/parser/eclipse/Utility/Iterator.hpp>
+
 namespace Opm {
     class ParserKeyword;
     class DeckRecord;
 
     class DeckKeyword {
     public:
+
+        typedef iterator_base< const DeckRecord > const_iterator;
+
         DeckKeyword(const std::string& keywordName);
         DeckKeyword(const std::string& keywordName, bool knownKeyword);
 
@@ -60,8 +65,11 @@ namespace Opm {
                 return false;
         }
 
-        std::vector<std::shared_ptr< const DeckRecord >>::const_iterator begin() const;
-        std::vector<std::shared_ptr< const DeckRecord >>::const_iterator end() const;
+        const_iterator begin() const;
+        const_iterator end() const;
+        const_iterator cbegin() const;
+        const_iterator cend() const;
+
     private:
         std::string m_keywordName;
         std::string m_fileName;

--- a/opm/parser/eclipse/Deck/DeckRecord.cpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.cpp
@@ -74,6 +74,31 @@ namespace Opm {
             throw std::range_error("Not a data keyword ?");
     }
 
+    DeckRecord::iterator DeckRecord::begin() {
+        return DeckRecord::iterator( this->m_items.begin() );
+    }
+
+    DeckRecord::iterator DeckRecord::end() {
+        return DeckRecord::iterator( this->m_items.end() );
+    }
+
+    DeckRecord::const_iterator DeckRecord::begin() const {
+        return DeckRecord::const_iterator( 
+                const_cast< DeckRecord* >( this )->m_items.begin()
+            );
+    }
+
+    DeckRecord::const_iterator DeckRecord::end() const {
+        return DeckRecord::const_iterator( 
+                const_cast< DeckRecord* >( this )->m_items.end()
+            );
+    }
+
+    DeckRecord::const_iterator DeckRecord::cbegin() const {
+        return this->begin();
+    }
+
+    DeckRecord::const_iterator DeckRecord::cend() const {
+        return this->end();
+    }
 }
-
-

--- a/opm/parser/eclipse/Deck/DeckRecord.hpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.hpp
@@ -24,6 +24,8 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Utility/Iterator.hpp>
 
 namespace Opm {
 
@@ -31,6 +33,10 @@ namespace Opm {
 
     class DeckRecord {
     public:
+
+        typedef iterator_base< DeckItem > iterator;
+        typedef iterator_base< const DeckItem, DeckItem > const_iterator;
+
         DeckRecord();
         size_t size() const;
         void addItem(std::shared_ptr< DeckItem > deckItem);
@@ -38,6 +44,15 @@ namespace Opm {
         std::shared_ptr< DeckItem > getItem(const std::string& name) const;
         std::shared_ptr< DeckItem > getDataItem() const;
         bool        hasItem(const std::string& name) const;
+
+        iterator begin();
+        iterator end();
+
+        const_iterator begin() const;
+        const_iterator end() const;
+
+        const_iterator cbegin() const;
+        const_iterator cend() const;
         
     template <class Item>
     std::shared_ptr< DeckItem > getItem() const {

--- a/opm/parser/eclipse/Deck/SCHEDULESection.cpp
+++ b/opm/parser/eclipse/Deck/SCHEDULESection.cpp
@@ -43,8 +43,8 @@ namespace Opm {
     void SCHEDULESection::populateDeckTimeSteps() {
         DeckTimeStepPtr currentTimeStep = std::make_shared<DeckTimeStep>();
 
-        for (auto iter = begin(); iter != end(); ++iter) {  //Loop keywords in schedule section
-            auto keyword = *iter;
+        for( size_t i = 0; i < this->size(); ++i ) {
+            auto keyword = this->getKeyword( i );
             if (keyword->name() == "TSTEP") {
                 DeckItemPtr items = keyword->getDataRecord()->getDataItem();
                 for (size_t item_iter = 0; item_iter < items->size(); ++item_iter) {
@@ -52,7 +52,7 @@ namespace Opm {
                    currentTimeStep = std::make_shared<DeckTimeStep>();
                 }
             } else if (keyword->name() == "DATES") {
-                for (auto record_iter = keyword->begin(); record_iter != keyword->end(); ++record_iter ) {
+                for( size_t record_iter = 0; record_iter < keyword->size(); ++record_iter ) {
                     m_decktimesteps.push_back(currentTimeStep);
                     currentTimeStep = std::make_shared<DeckTimeStep>();
                 }

--- a/opm/parser/eclipse/Deck/Section.cpp
+++ b/opm/parser/eclipse/Deck/Section.cpp
@@ -45,8 +45,8 @@ namespace Opm {
     void Section::populateSection(DeckConstPtr deck, const std::string& startKeywordName)
     {
         bool inSection = false;
-        for (auto iter = deck->begin(); iter != deck->end(); ++iter) {
-            auto keyword = *iter;
+        for( size_t i = 0; i < deck->size(); ++i ) {
+            auto keyword = deck->getKeyword( i );
             if (!inSection) {
                 if (keyword->name() == startKeywordName) {
                     inSection = true;

--- a/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
@@ -72,6 +72,18 @@ BOOST_AUTO_TEST_CASE(addRecord_onerecord_recordadded) {
 
 }
 
+BOOST_AUTO_TEST_CASE(iterator) {
+    DeckKeywordPtr deckKeyword(new DeckKeyword("KW"));
+    deckKeyword->addRecord(DeckRecordConstPtr(new DeckRecord()));
+    BOOST_CHECK_EQUAL(1U, deckKeyword->size());
+
+    for ( const auto& record : *deckKeyword )
+        BOOST_CHECK_EQUAL( 0U, record.size() );
+
+    for ( auto itr = deckKeyword->cbegin(); itr != deckKeyword->cend(); ++itr )
+        BOOST_CHECK_EQUAL( 0U, itr->size() );
+}
+
 BOOST_AUTO_TEST_CASE(getRecord_onerecord_recordretured) {
     DeckKeywordPtr deckKeyword(new DeckKeyword("KW"));
     DeckRecordConstPtr deckRecord(new DeckRecord());

--- a/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
@@ -90,6 +90,24 @@ BOOST_AUTO_TEST_CASE(get_indexoutofbounds_throws) {
     BOOST_CHECK_THROW(deckRecord.getItem(1), std::range_error);
 }
 
+BOOST_AUTO_TEST_CASE(iterator_traversal) {
+    DeckRecord deckRecord;
+
+    DeckIntItemPtr intItem1(new DeckIntItem("TEST1"));
+    DeckIntItemPtr intItem2(new DeckIntItem("TEST2"));
+    deckRecord.addItem(intItem1);
+    deckRecord.addItem(intItem2);
+
+    for( const auto& item : deckRecord )
+        BOOST_CHECK_EQUAL(item.size(), 0U );
+
+    for( auto& item : deckRecord )
+        BOOST_CHECK_EQUAL(item.size(), 0U );
+
+    for( auto itr = deckRecord.cbegin(); itr != deckRecord.cend(); ++itr )
+        BOOST_CHECK_EQUAL( itr->size(), 0U );
+}
+
 BOOST_AUTO_TEST_CASE(get_byName_returnsItem) {
     DeckRecord deckRecord;
     DeckIntItemPtr intItem1(new DeckIntItem("TEST"));

--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -137,7 +137,21 @@ BOOST_AUTO_TEST_CASE(getKeyword_multipleKeyword_keywordReturned) {
     BOOST_CHECK_EQUAL(keyword3, deck.getKeyword("TRULS"));
 }
 
+BOOST_AUTO_TEST_CASE(iterator) {
+    Deck deck;
+    DeckKeywordPtr keyword1 = DeckKeywordPtr(new DeckKeyword("TRULS"));
+    DeckKeywordPtr keyword2 = DeckKeywordPtr(new DeckKeyword("TRULS"));
+    DeckKeywordPtr keyword3 = DeckKeywordPtr(new DeckKeyword("TRULS"));
+    deck.addKeyword(keyword1);
+    deck.addKeyword(keyword2);
+    deck.addKeyword(keyword3);
 
+    for ( const auto& keyword : deck )
+        BOOST_CHECK_EQUAL( 0U, keyword.size() );
+
+    for ( auto itr = deck.cbegin(); itr != deck.cend(); ++itr )
+        BOOST_CHECK_EQUAL( 0U, itr->size() );
+}
 
 BOOST_AUTO_TEST_CASE(getKeyword_outOfRange_throws) {
     Deck deck;

--- a/opm/parser/eclipse/Deck/tests/SectionTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/SectionTests.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(IteratorTest) {
 
     int numberOfItems = 0;
     for (auto iter=section.begin(); iter != section.end(); ++iter) {
-        std::cout << (*iter)->name() << std::endl;
+        std::cout << iter->name() << std::endl;
         numberOfItems++;
     }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -300,11 +300,10 @@ namespace Opm {
     void EclipseState::setMULTFLT(std::shared_ptr<const Section> section) const {
         for (size_t index=0; index < section->count("MULTFLT"); index++) {
             DeckKeywordConstPtr faultsKeyword = section->getKeyword("MULTFLT" , index);
-            for (auto iter = faultsKeyword->begin(); iter != faultsKeyword->end(); ++iter) {
+            for( auto& faultRecord : *faultsKeyword ) {
 
-                DeckRecordConstPtr faultRecord = *iter;
-                const std::string& faultName = faultRecord->getItem(0)->getString(0);
-                double multFlt = faultRecord->getItem(1)->getRawDouble(0);
+                const std::string& faultName = faultRecord.getItem(0)->getString(0);
+                double multFlt = faultRecord.getItem(1)->getRawDouble(0);
 
                 m_faults->setTransMult( faultName , multFlt );
             }
@@ -1375,9 +1374,9 @@ namespace Opm {
 
             if (keyword->isKeyword<MULTFLT>()) {
                 for (const auto& record : *keyword) {
-                    const std::string& faultName = record->getItem<MULTFLT::fault>()->getString(0);
+                    const std::string& faultName = record.getItem<MULTFLT::fault>()->getString(0);
                     auto fault = m_faults->getFault( faultName );
-                    double tmpMultFlt = record->getItem<MULTFLT::factor>()->getRawDouble(0);
+                    double tmpMultFlt = record.getItem<MULTFLT::factor>()->getRawDouble(0);
                     double oldMultFlt = fault->getTransMult( );
                     double newMultFlt = oldMultFlt * tmpMultFlt;
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -943,8 +943,8 @@ namespace Opm {
     void EclipseState::scanSection(std::shared_ptr<Opm::Section> section,
                                    int enabledTypes) {
         BoxManager boxManager(m_eclipseGrid->getNX( ) , m_eclipseGrid->getNY() , m_eclipseGrid->getNZ());
-        for (auto iter = section->begin(); iter != section->end(); ++iter) {
-            DeckKeywordConstPtr deckKeyword = *iter;
+        for( size_t i = 0; i < section->size(); ++i ) {
+            auto deckKeyword = section->getKeyword( i );section->getKeyword( i );
 
             if (supportsGridProperty(deckKeyword->name(), enabledTypes) )
                 loadGridPropertyFromDeckKeyword(boxManager.getActiveBox(), deckKeyword,  enabledTypes);
@@ -1372,8 +1372,8 @@ namespace Opm {
         using namespace ParserKeywords;
         for (const auto& keyword : *deck) {
 
-            if (keyword->isKeyword<MULTFLT>()) {
-                for (const auto& record : *keyword) {
+            if (keyword.isKeyword<MULTFLT>()) {
+                for (const auto& record : keyword) {
                     const std::string& faultName = record.getItem<MULTFLT::fault>()->getString(0);
                     auto fault = m_faults->getFault( faultName );
                     double tmpMultFlt = record.getItem<MULTFLT::factor>()->getRawDouble(0);

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -43,16 +43,15 @@ namespace Opm {
 
         for (auto keyword_iter = faultKeywords.begin(); keyword_iter != faultKeywords.end(); ++keyword_iter) {
             std::shared_ptr<const DeckKeyword> faultsKeyword = *keyword_iter;
-            for (auto iter = faultsKeyword->begin(); iter != faultsKeyword->end(); ++iter) {
-                DeckRecordConstPtr faultRecord = *iter;
-                const std::string& faultName = faultRecord->getItem(0)->getString(0);
-                int I1 = faultRecord->getItem(1)->getInt(0) - 1;
-                int I2 = faultRecord->getItem(2)->getInt(0) - 1;
-                int J1 = faultRecord->getItem(3)->getInt(0) - 1;
-                int J2 = faultRecord->getItem(4)->getInt(0) - 1;
-                int K1 = faultRecord->getItem(5)->getInt(0) - 1;
-                int K2 = faultRecord->getItem(6)->getInt(0) - 1;
-                FaceDir::DirEnum faceDir = FaceDir::FromString( faultRecord->getItem(7)->getString(0) );
+            for( const auto& faultRecord : *faultsKeyword ) {
+                const std::string& faultName = faultRecord.getItem(0)->getString(0);
+                int I1 = faultRecord.getItem(1)->getInt(0) - 1;
+                int I2 = faultRecord.getItem(2)->getInt(0) - 1;
+                int J1 = faultRecord.getItem(3)->getInt(0) - 1;
+                int J2 = faultRecord.getItem(4)->getInt(0) - 1;
+                int K1 = faultRecord.getItem(5)->getInt(0) - 1;
+                int K2 = faultRecord.getItem(6)->getInt(0) - 1;
+                FaceDir::DirEnum faceDir = FaceDir::FromString( faultRecord.getItem(7)->getString(0) );
                 std::shared_ptr<const FaultFace> face = std::make_shared<const FaultFace>(grid->getNX() , grid->getNY() , grid->getNZ(),
                                                                                           static_cast<size_t>(I1) , static_cast<size_t>(I2) ,
                                                                                           static_cast<size_t>(J1) , static_cast<size_t>(J2) ,

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -68,17 +68,17 @@ namespace Opm {
 
 
 
-    MULTREGTRecord::MULTREGTRecord(DeckRecordConstPtr deckRecord , const std::string& defaultRegion) :
+    MULTREGTRecord::MULTREGTRecord(const DeckRecord& deckRecord , const std::string& defaultRegion) :
         m_srcRegion("SRC_REGION"),
         m_targetRegion("TARGET_REGION"),
         m_region("REGION" , defaultRegion)
     {
-        DeckItemConstPtr srcItem = deckRecord->getItem("SRC_REGION");
-        DeckItemConstPtr targetItem = deckRecord->getItem("TARGET_REGION");
-        DeckItemConstPtr tranItem = deckRecord->getItem("TRAN_MULT");
-        DeckItemConstPtr dirItem = deckRecord->getItem("DIRECTIONS");
-        DeckItemConstPtr nncItem = deckRecord->getItem("NNC_MULT");
-        DeckItemConstPtr defItem = deckRecord->getItem("REGION_DEF");
+        DeckItemConstPtr srcItem = deckRecord.getItem("SRC_REGION");
+        DeckItemConstPtr targetItem = deckRecord.getItem("TARGET_REGION");
+        DeckItemConstPtr tranItem = deckRecord.getItem("TRAN_MULT");
+        DeckItemConstPtr dirItem = deckRecord.getItem("DIRECTIONS");
+        DeckItemConstPtr nncItem = deckRecord.getItem("NNC_MULT");
+        DeckItemConstPtr defItem = deckRecord.getItem("REGION_DEF");
 
 
         if (!srcItem->defaultApplied(0))
@@ -163,8 +163,8 @@ namespace Opm {
 
 
     void MULTREGTScanner::assertKeywordSupported(DeckKeywordConstPtr deckKeyword, const std::string& defaultRegion) {
-        for (auto iter = deckKeyword->begin(); iter != deckKeyword->end(); ++iter) {
-            MULTREGTRecord record( *iter , defaultRegion);
+        for( const auto& iter : *deckKeyword ) {
+            MULTREGTRecord record( iter , defaultRegion);
 
             if (record.m_nncBehaviour == MULTREGT::NOAQUNNC)
                 throw std::invalid_argument("Sorry - currently we do not support \'NOAQUNNC\' for MULTREGT.");
@@ -177,7 +177,6 @@ namespace Opm {
 
             if (record.m_srcRegion.getValue() == record.m_targetRegion.getValue())
                 throw std::invalid_argument("Sorry - multregt applied internally to a region is not yet supported");
-
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -50,7 +50,7 @@ namespace Opm {
 
     class MULTREGTRecord {
     public:
-        MULTREGTRecord(std::shared_ptr< const DeckRecord > deckRecord , const std::string& defaultRegion);
+        MULTREGTRecord(const DeckRecord& deckRecord , const std::string& defaultRegion);
 
         Value<int> m_srcRegion;
         Value<int> m_targetRegion;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -316,8 +316,8 @@ namespace Opm {
 
 
     void Schedule::handleCOMPORD(const ParseMode& parseMode, std::shared_ptr<const DeckKeyword> compordKeyword, size_t /* currentStep */) {
-        for (const auto record : (*compordKeyword)) {
-            auto methodItem = record->getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
+        for (const auto& record : (*compordKeyword)) {
+            auto methodItem = record.getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if ((methodItem->getString(0) != "TRACK")  && (methodItem->getString(0) != "INPUT")) {
                 std::string msg = "The COMPORD keyword only handles 'TRACK' or 'INPUT' order.";
                 parseMode.handleError( ParseMode::UNSUPPORTED_COMPORD_TYPE , msg );

--- a/opm/parser/eclipse/Utility/Iterator.cpp
+++ b/opm/parser/eclipse/Utility/Iterator.cpp
@@ -1,0 +1,65 @@
+#include <opm/parser/eclipse/Utility/Iterator.hpp>
+
+namespace Opm {
+
+    template< typename T, typename S >
+    iterator_base< T, S >::iterator_base( typename std::vector< elem_type >::iterator itr ) :
+        itr( itr )
+    {}
+
+    template< typename T, typename S >
+    iterator_base< T, S >& iterator_base< T, S >::operator++() {
+        ++this->itr;
+        return *this;
+    }
+
+    template< typename T, typename S >
+    iterator_base< T, S > iterator_base< T, S >::operator++( int ) {
+        auto orig = *this;
+        ++*this;
+        return orig;
+    }
+
+    template< typename T, typename S >
+    iterator_base< T, S >& iterator_base< T, S >::operator--() {
+        --this->itr;
+        return *this;
+    }
+
+    template< typename T, typename S >
+    iterator_base< T, S > iterator_base< T, S >::operator--( int ) {
+        auto orig = *this;
+        --*this;
+        return orig;
+    }
+
+    template< typename T, typename S >
+    T& iterator_base< T, S >::operator*() {
+        return **this->itr;
+    }
+
+    template< typename T, typename S >
+    T* iterator_base< T, S >::operator->() {
+        return this->itr->get();
+    }
+
+    template< typename T, typename S >
+    const T& iterator_base< T, S >::operator*() const {
+        return **this->itr;
+    }
+
+    template< typename T, typename S >
+    const T* iterator_base< T, S >::operator->() const {
+        return this->itr->get();
+    }
+
+    template< typename T, typename S >
+    bool iterator_base< T, S >::operator==( const iterator_base< T, S >& rhs ) const {
+        return !( *this != rhs );
+    }
+
+    template< typename T, typename S >
+    bool iterator_base< T, S >::operator!=( const iterator_base< T, S >& rhs ) const {
+        return this->itr != rhs.itr;
+    }
+}

--- a/opm/parser/eclipse/Utility/Iterator.hpp
+++ b/opm/parser/eclipse/Utility/Iterator.hpp
@@ -1,0 +1,79 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef PARSER_UTILITY_ITERATOR_HPP
+#define PARSER_UTILITY_ITERATOR_HPP
+
+#include <iterator>
+#include <memory>
+#include <vector>
+
+namespace Opm {
+
+    /*
+     * Currently, the iterator_base is templated on two parameters - this is a
+     * necessary, but temporary, hack to enable different underlying storage *types*.
+     *
+     * DeckRecord stores its items as vector< shared_ptr >, which when const'd
+     * as a template parameter is vector< const shared_ptr >, where we want
+     * vector< shared_ptr< const > >. Additionally, shared_ptr< const > is
+     * different from shared_ptr<> and you can't change between the two without
+     * copying (i.e. modifying Deck*'s structure).
+     *
+     * To overcome this we always store as vector< shared_ptr > and make sure
+     * the *interface* enforces the immutability. As soon as Deck* stores its
+     * items as non-shared-ptr or applies const more conveniently, the second
+     * template paramter can go away.
+     */
+
+    template< typename T, typename S = T >
+    class iterator_base {
+        private:
+            using elem_type = typename std::remove_cv< std::shared_ptr< S > >::type;
+            using base = typename std::vector< elem_type >::iterator;
+
+        public:
+            typedef typename base::difference_type difference_type;
+            typedef T value_type;
+            typedef T* pointer;
+            typedef T& reference;
+            typedef std::random_access_iterator_tag iterator_category;
+
+            iterator_base() = default;
+            iterator_base( typename std::vector< elem_type >::iterator );
+
+            iterator_base& operator++();
+            iterator_base operator++(int);
+            iterator_base& operator--();
+            iterator_base operator--(int);
+
+            T& operator*();
+            T* operator->();
+            const T& operator*() const;
+            const T* operator->() const;
+
+            bool operator==( const iterator_base& rhs ) const;
+            bool operator!=( const iterator_base& rhs ) const;
+
+        private:
+            typename std::vector< std::shared_ptr< S > >::iterator itr;
+    };
+}
+
+#endif //PARSER_UTILITY_ITERATOR_HPP


### PR DESCRIPTION
Patch set that provides iterator support.

Previously Deck* classes that had begin/end iterator support returned std::vector::iterator, which directly exposed the underlying data structures. These new iterators changes that behaviour to rather match the expected behaviour of std::iterator, in addition to implement begin/end consistently over all Deck* classes.

In the future more beefed-up containers might get iterator or revised iterator support, in which case this implementation can also be used.
