### PR TITLE
Adds Schedule::getGroups()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1581,6 +1581,14 @@ namespace Opm {
             throw std::invalid_argument("Group: " + groupName + " does not exist");
     }
 
+    std::vector< const Group* > Schedule::getGroups() const {
+        std::vector< const Group* > groups;
+
+        for( const auto& itr : m_groups )
+            groups.push_back( itr.second.get() );
+
+        return groups;
+    }
 
     void Schedule::addWellToGroup( GroupPtr newGroup , WellPtr well , size_t timeStep) {
         const std::string currentGroupName = well->getGroupName(timeStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -73,6 +73,7 @@ namespace Opm
         size_t numGroups() const;
         bool hasGroup(const std::string& groupName) const;
         std::shared_ptr< Group > getGroup(const std::string& groupName) const;
+        std::vector< const Group* > getGroups() const;
         std::shared_ptr< Tuning > getTuning() const;
 
         bool initOnly() const;


### PR DESCRIPTION
Similar to the already-existant Schedule::getWells, this simple method
returns (const) pointers to all groups, suitable for iteration, maps and
for-all-in operations.