### PR TITLE
Internalise SUMMARY section

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -14,6 +14,7 @@ add_subdirectory(EclipseState/Grid/tests)
 add_subdirectory(EclipseState/Util/tests)
 add_subdirectory(EclipseState/IOConfig/tests)
 add_subdirectory(EclipseState/InitConfig/tests)
+add_subdirectory(EclipseState/Summary/tests)
 
 add_subdirectory(Applications)
 add_subdirectory(IntegrationTests)
@@ -129,6 +130,7 @@ EclipseState/Grid/PinchMode.cpp
 EclipseState/InitConfig/InitConfig.cpp
 EclipseState/SimulationConfig/SimulationConfig.cpp
 EclipseState/SimulationConfig/ThresholdPressure.cpp
+EclipseState/Summary/Summary.cpp
 EclipseState/IOConfig/IOConfig.cpp)
 #
 
@@ -224,6 +226,7 @@ EclipseState/Grid/NNC.hpp
 EclipseState/InitConfig/InitConfig.hpp
 EclipseState/SimulationConfig/SimulationConfig.hpp
 EclipseState/SimulationConfig/ThresholdPressure.hpp
+EclipseState/Summary/Summary.hpp
 EclipseState/IOConfig/IOConfig.hpp
 #
 EclipseState/Tables/Tabdims.hpp

--- a/opm/parser/eclipse/EclipseState/Summary/Summary.cpp
+++ b/opm/parser/eclipse/EclipseState/Summary/Summary.cpp
@@ -1,0 +1,152 @@
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
+#include <opm/parser/eclipse/EclipseState/Summary/Summary.hpp>
+
+#include <ert/ecl/ecl_smspec.h>
+
+namespace Opm {
+
+    namespace fun {
+
+        /*
+         * map :: (a -> b) -> [a] -> [b]
+         *
+         * C can be any foreach-compatible container (that supports .begin,
+         * .end), but will always return a vector.
+         */
+        template< typename F, typename C >
+        std::vector< typename std::result_of< F( typename C::const_iterator::value_type& ) >::type >
+        map( F&& f, const C& src ) {
+            using A = typename C::const_iterator::value_type;
+            using B = typename std::result_of< F( A& ) >::type;
+            std::vector< B > ret;
+            ret.reserve( src.size() );
+
+            std::transform( src.begin(), src.end(), std::back_inserter( ret ), f );
+            return ret;
+        }
+
+        template< typename A >
+        std::vector< A > concat( std::vector< std::vector< A > >&& src ) {
+
+            const auto size = std::accumulate( src.begin(), src.end(), 0,
+                []( std::size_t acc, const std::vector< A >& x ) {
+                    return acc + x.size();
+                }
+            );
+
+            std::vector< A > dst;
+            dst.reserve( size );
+
+            for( auto& x : src )
+                std::move( x.begin(), x.end(), std::back_inserter( dst ) );
+
+            return dst;
+        }
+
+    }
+
+    static std::string wellName( const std::shared_ptr< const Well >& well ) {
+        return well->name();
+    }
+
+    static std::string groupName( const Group* group ) {
+        return group->name();
+    }
+
+    static inline std::vector< ERT::smspec_node > keywordWG(
+            ecl_smspec_var_type var_type,
+            const DeckKeyword& keyword,
+            const EclipseState& es ) {
+
+        const auto mknode = [&keyword,var_type]( const std::string& name ) {
+            return ERT::smspec_node( var_type, name, keyword.name() );
+        };
+
+        const auto find = []( ecl_smspec_var_type v, const EclipseState& est ) {
+            if( v == ECL_SMSPEC_WELL_VAR )
+                return fun::map( wellName, est.getSchedule()->getWells() );
+            else
+                return fun::map( groupName, est.getSchedule()->getGroups() );
+        };
+
+        const auto& item = keyword.getDataRecord().getDataItem();
+        const auto wgnames = item.size() > 0 && item.hasValue( 0 )
+            ? item.getData< std::string >()
+            : find( var_type, es );
+
+        return fun::map( mknode, wgnames );
+    }
+
+    static inline std::vector< ERT::smspec_node > keywordF(
+            const DeckKeyword& keyword,
+            const EclipseState& es ) {
+
+        std::vector< ERT::smspec_node > res;
+        res.push_back( ERT::smspec_node( keyword.name() ) );
+        return res;
+    }
+
+    static inline std::vector< ERT::smspec_node > keywordB(
+            const DeckKeyword& keyword,
+            const EclipseState& es ) {
+
+        std::array< int, 3 > dims = {
+            int( es.getEclipseGrid()->getNX() ),
+            int( es.getEclipseGrid()->getNY() ),
+            int( es.getEclipseGrid()->getNZ() )
+        };
+
+        const auto mkrecord = [&dims,&keyword]( const DeckRecord& record ) {
+
+            std::array< int , 3 > ijk = {
+                record.getItem( 0 ).get< int >( 0 ) - 1,
+                record.getItem( 1 ).get< int >( 0 ) - 1,
+                record.getItem( 2 ).get< int >( 0 ) - 1
+            };
+
+            return ERT::smspec_node( keyword.name(), dims.data(), ijk.data() );
+        };
+
+        return fun::map( mkrecord, keyword );
+    }
+
+    std::vector< ERT::smspec_node > handleKW( const DeckKeyword& keyword, const EclipseState& es ) {
+        const auto var_type = ecl_smspec_identify_var_type( keyword.name().c_str() );
+
+        switch( var_type ) {
+            case ECL_SMSPEC_WELL_VAR: /* intentional fall-through */
+            case ECL_SMSPEC_GROUP_VAR: return keywordWG( var_type, keyword, es );
+            case ECL_SMSPEC_FIELD_VAR: return keywordF( keyword, es );
+            case ECL_SMSPEC_BLOCK_VAR: return keywordB( keyword, es );
+
+            default: return {};
+        }
+    }
+
+    Summary::Summary( const Deck& deck, const EclipseState& es ) {
+
+        SUMMARYSection section( deck );
+        const auto handler = [&es]( const DeckKeyword& kw ) {
+            return handleKW( kw, es );
+        };
+        this->keywords = fun::concat( fun::map( handler, section ) );
+    }
+
+    Summary::const_iterator Summary::begin() const {
+        return this->keywords.cbegin();
+    }
+
+    Summary::const_iterator Summary::end() const {
+        return this->keywords.cend();
+    }
+
+}

--- a/opm/parser/eclipse/EclipseState/Summary/Summary.hpp
+++ b/opm/parser/eclipse/EclipseState/Summary/Summary.hpp
@@ -1,0 +1,48 @@
+/*
+  Copyright 2015 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_SUMMARY_HPP
+#define OPM_SUMMARY_HPP
+
+#include <vector>
+
+#include <ert/ecl/Smspec.hpp>
+
+namespace Opm {
+
+    class Deck;
+    class EclipseState;
+    class ParserKeyword;
+
+    class Summary {
+        public:
+            typedef std::vector< ERT::smspec_node >::const_iterator const_iterator;
+
+            Summary( const Deck&, const EclipseState& );
+
+            const_iterator begin() const;
+            const_iterator end() const;
+
+        private:
+            std::vector< ERT::smspec_node > keywords;
+    };
+
+} //namespace Opm
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Summary/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/Summary/tests/CMakeLists.txt
@@ -1,0 +1,2 @@
+opm_add_test(runSummaryTests SOURCES SummaryTests.cpp 
+                                  LIBRARIES opmparser ${Boost_LIBRARIES})

--- a/opm/parser/eclipse/EclipseState/Summary/tests/SummaryTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Summary/tests/SummaryTests.cpp
@@ -1,0 +1,124 @@
+/*
+  Copyright 2013 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#define BOOST_TEST_MODULE SummaryTests
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/EclipseState/Summary/Summary.hpp>
+#include <opm/parser/eclipse/Parser/ParseMode.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+using namespace Opm;
+
+static DeckPtr createDeck( const std::string& summary ) {
+    Opm::Parser parser;
+    std::string input = 
+            "START             -- 0 \n"
+            "10 MAI 2007 / \n"
+            "RUNSPEC\n"
+            "\n"
+            "DIMENS\n"
+            " 10 10 10 /\n"
+            "GRID\n"
+            "SCHEDULE\n"
+            "WELSPECS\n"
+            "     \'W_1\'        \'OP\'   30   37  3.33       \'OIL\'  7* /   \n"
+            "     \'WX2\'        \'OP\'   30   37  3.33       \'OIL\'  7* /   \n"
+            "     \'W_3\'        \'OP\'   20   51  3.92       \'OIL\'  7* /  \n"
+            "/\n"
+            "SUMMARY\n"
+            + summary;
+
+    return parser.parseString(input, ParseMode());
+}
+
+static std::vector< std::string > sorted_names( const Summary& summary ) {
+    std::vector< std::string > ret;
+    for( const auto& x : summary )
+        ret.push_back( x.wgname() );
+
+    std::sort( ret.begin(), ret.end() );
+    return ret;
+}
+
+static std::vector< std::string > sorted_keywords( const Summary& summary ) {
+    std::vector< std::string > ret;
+    for( const auto& x : summary )
+        ret.push_back( x.keyword() );
+
+    std::sort( ret.begin(), ret.end() );
+    return ret;
+}
+
+static Summary createSummary( std::string input ) {
+    auto deck = createDeck( input );
+    EclipseState state( deck, ParseMode() );
+    return Summary( *deck, state );
+}
+
+BOOST_AUTO_TEST_CASE(wells_all) {
+    const auto input = "WWCT\n/\n";
+    const auto summary = createSummary( input );
+
+    const auto wells = { "WX2", "W_1", "W_3" };
+    const auto names = sorted_names( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            wells.begin(), wells.end(),
+            names.begin(), names.end() );
+}
+
+BOOST_AUTO_TEST_CASE(wells_select) {
+    const auto input = "WWCT\n'W_1' 'WX2' /\n";
+    const auto summary = createSummary( input );
+    const auto wells = { "WX2", "W_1" };
+    const auto names = sorted_names( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            wells.begin(), wells.end(),
+            names.begin(), names.end() );
+}
+
+BOOST_AUTO_TEST_CASE(fields) {
+    const auto input = "FOPT\n";
+    const auto summary = createSummary( input );
+    const auto keywords = { "FOPT" };
+    const auto names = sorted_keywords( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            keywords.begin(), keywords.end(),
+            names.begin(), names.end() );
+}
+
+BOOST_AUTO_TEST_CASE(blocks) {
+    const auto input = "BPR\n"
+                       "3 3 6 /\n"
+                       "4 3 6 /\n"
+                       "/";
+    const auto summary = createSummary( input );
+    const auto keywords = { "BPR", "BPR" };
+    const auto names = sorted_keywords( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            keywords.begin(), keywords.end(),
+            names.begin(), names.end() );
+}


### PR DESCRIPTION
This will be rebased on master once https://github.com/OPM/opm-parser/pull/677 is merged as it depends on it.

This patch internalises a representation of the SUMMARY section of an input deck, data that can later be passed to some writers that determines what to output.

Uses ERT::smspec_node for the internal representation.