### PR TITLE
Removes push_back( deque ) from DeckItem

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -67,26 +67,6 @@ namespace Opm {
     }
 
     template< typename T >
-    void DeckTypeItem< T >::push_back( std::deque< T > data, size_t items ) {
-        if( m_dataPointDefaulted.size() != this->data.size() )
-            throw std::logic_error("To add a value to an item, no \"pseudo defaults\" can be added before");
-
-        for( size_t i = 0; i < items; i++ ) {
-            this->data.push_back( data[ i ] );
-            m_dataPointDefaulted.push_back( false );
-        }
-    }
-
-    template< typename T >
-    void DeckTypeItem< T >::push_back( std::deque< T > data ) {
-        if( m_dataPointDefaulted.size() != this->data.size() )
-            throw std::logic_error("To add a value to an item, no \"pseudo defaults\" can be added before");
-
-        this->push_back( data, data.size() );
-        this->m_dataPointDefaulted.push_back( false );
-    }
-
-    template< typename T >
     void DeckTypeItem< T >::push_back( T data ) {
         if( m_dataPointDefaulted.size() != this->data.size() )
             throw std::logic_error("To add a value to an item, no \"pseudo defaults\" can be added before");

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -124,8 +124,6 @@ namespace Opm {
         public:
             using DeckItem::DeckItem;
 
-            void push_back( std::deque< T > data, size_t items );
-            void push_back( std::deque< T > data );
             void push_back( T value );
             // trying to access the data of a "dummy default item" will raise an exception
             void push_backDummyDefault();

--- a/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
@@ -46,32 +46,6 @@ BOOST_AUTO_TEST_CASE(GetDoubleAtIndex_NoData_ExceptionThrown) {
 }
 
 
-
-BOOST_AUTO_TEST_CASE(PushBackDouble_VectorPushed_ElementsCorrect) {
-    DeckDoubleItem deckDoubleItem("TEST");
-    std::deque<double> pushThese;
-    pushThese.push_back(13);
-    pushThese.push_back(33);
-    deckDoubleItem.push_back(pushThese);
-    BOOST_CHECK_EQUAL(13, deckDoubleItem.getRawDouble(0));
-    BOOST_CHECK_EQUAL(33, deckDoubleItem.getRawDouble(1));
-}
-
-
-BOOST_AUTO_TEST_CASE(PushBackDouble_subVectorPushed_ElementsCorrect) {
-    DeckDoubleItem deckDoubleItem("TEST");
-    std::deque<double> pushThese;
-    pushThese.push_back(13);
-    pushThese.push_back(33);
-    pushThese.push_back(47);
-    deckDoubleItem.push_back(pushThese , 2);
-    BOOST_CHECK_EQUAL(13 , deckDoubleItem.getRawDouble(0));
-    BOOST_CHECK_EQUAL(33 , deckDoubleItem.getRawDouble(1));
-    BOOST_CHECK_EQUAL( 2U , deckDoubleItem.size());
-}
-
-
-
 BOOST_AUTO_TEST_CASE(sizeDouble_correct) {
     DeckDoubleItem deckDoubleItem("TEST");
 

--- a/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
@@ -72,31 +72,6 @@ BOOST_AUTO_TEST_CASE(InitializeDefaultApplied) {
     BOOST_CHECK( deckIntItem.size() == 0 );
 }
 
-
-
-BOOST_AUTO_TEST_CASE(PushBack_VectorPushed_ElementsCorrect) {
-    DeckIntItem deckIntItem("TEST");
-    std::deque<int> pushThese;
-    pushThese.push_back(13);
-    pushThese.push_back(33);
-    deckIntItem.push_back(pushThese);
-    BOOST_CHECK_EQUAL(13, deckIntItem.getInt(0));
-    BOOST_CHECK_EQUAL(33, deckIntItem.getInt(1));
-}
-
-BOOST_AUTO_TEST_CASE(PushBack_subVectorPushed_ElementsCorrect) {
-    DeckIntItem deckIntItem("TEST");
-    std::deque<int> pushThese;
-    pushThese.push_back(13);
-    pushThese.push_back(33);
-    pushThese.push_back(47);
-    deckIntItem.push_back(pushThese , 2);
-    BOOST_CHECK_EQUAL(13 , deckIntItem.getInt(0));
-    BOOST_CHECK_EQUAL(33 , deckIntItem.getInt(1));
-    BOOST_CHECK_EQUAL( 2U , deckIntItem.size());
-}
-
-
 BOOST_AUTO_TEST_CASE(size_correct) {
     DeckIntItem deckIntItem("TEST");
 

--- a/opm/parser/eclipse/Deck/tests/DeckStringItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckStringItemTests.cpp
@@ -51,28 +51,6 @@ BOOST_AUTO_TEST_CASE(GetStringAtIndex_NoData_ExceptionThrown) {
     BOOST_CHECK_THROW(deckStringItem.getString(1), std::out_of_range);
 }
 
-BOOST_AUTO_TEST_CASE(PushBack_VectorPushed_ElementsCorrect) {
-    DeckStringItem deckStringItem("TEST");
-    std::deque<std::string> pushThese;
-    pushThese.push_back("hei");
-    pushThese.push_back("trygve-hei");
-    deckStringItem.push_back(pushThese);
-    BOOST_CHECK_EQUAL("hei", deckStringItem.getString(0));
-    BOOST_CHECK_EQUAL("trygve-hei", deckStringItem.getString(1));
-}
-
-BOOST_AUTO_TEST_CASE(PushBack_subVectorPushed_ElementsCorrect) {
-    DeckStringItem deckStringItem("TEST");
-    std::deque<std::string> pushThese;
-    pushThese.push_back("Well-1");
-    pushThese.push_back("Well-2");
-    pushThese.push_back("Well-3");
-    deckStringItem.push_back(pushThese, 2);
-    BOOST_CHECK_EQUAL("Well-1", deckStringItem.getString(0));
-    BOOST_CHECK_EQUAL("Well-2", deckStringItem.getString(1));
-    BOOST_CHECK_EQUAL(2U, deckStringItem.size());
-}
-
 BOOST_AUTO_TEST_CASE(size_variouspushes_sizecorrect) {
     DeckStringItem deckStringItem("TEST");
 


### PR DESCRIPTION
This feature is not used at all. I suggest it is removed, and if a need arises it can be reintroduced.