### PR TITLE
Add support for MISCNUM

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -521,7 +521,8 @@ namespace Opm {
             SupportedIntKeywordInfo( "ENDNUM" , 1, "1" ),
             SupportedIntKeywordInfo( "FLUXNUM" , 1 , "1" ),
             SupportedIntKeywordInfo( "MULTNUM", 1 , "1" ),
-            SupportedIntKeywordInfo( "FIPNUM" , 1, "1" )
+            SupportedIntKeywordInfo( "FIPNUM" , 1, "1" ),
+            SupportedIntKeywordInfo( "MISCNUM", 1, "1" )
             });
 
         double nan = std::numeric_limits<double>::quiet_NaN();

--- a/opm/parser/share/keywords/000_Eclipse100/M/MISCNUM
+++ b/opm/parser/share/keywords/000_Eclipse100/M/MISCNUM
@@ -1,0 +1,1 @@
+{"name" : "MISCNUM", "sections" : ["REGIONS"], "data" : {"value_type" : "INT" }}


### PR DESCRIPTION
- MISCNUM is used to specify miscibility regions