### PR TITLE
Turn off building of tests in travis

### DIFF
--- a/travis/build-opm-parser.sh
+++ b/travis/build-opm-parser.sh
@@ -5,6 +5,6 @@ pushd . > /dev/null
 cd opm-parser
 mkdir build
 cd build
-cmake -DENABLE_PYTHON=ON ../
+cmake -DENABLE_PYTHON=ON -DBUILD_TESTING=OFF ../
 make
 popd > /dev/null


### PR DESCRIPTION
This will turn off building of tests when opm-parser is only built as a dependency.