### PR TITLE
Parser stores keywords as unique_ptr

### DIFF
--- a/opm/parser/eclipse/Applications/opm-eclkw.cpp
+++ b/opm/parser/eclipse/Applications/opm-eclkw.cpp
@@ -26,7 +26,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 
 
-static void printKeyword(Opm::ParserKeywordConstPtr keyword)
+static void printKeyword( const Opm::ParserKeyword* keyword)
 {
     std::string indent = " ";
     std::cout << keyword->getName() << std::endl;
@@ -65,7 +65,7 @@ static void printItem(Opm::ParserItemConstPtr item, std::string indent)
     std::cout << std::endl;
 }
 
-static void printItems(Opm::ParserKeywordConstPtr keyword)
+static void printItems( const Opm::ParserKeyword* keyword)
 {
     std::string indent = "  ";
     std::cout << std::endl;
@@ -80,7 +80,7 @@ static void printItems(Opm::ParserKeywordConstPtr keyword)
 static void printKeywords (Opm::ParserPtr parser, std::vector<std::string>& keywords)
 {
     for (auto iterator = keywords.begin(); iterator != keywords.end(); ++iterator) {
-        Opm::ParserKeywordConstPtr keyword = parser->getParserKeywordFromDeckName(*iterator);
+        const auto* keyword = parser->getParserKeywordFromDeckName(*iterator);
         printKeyword(keyword);
         printItems(keyword);
     }

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -37,32 +37,30 @@
 
 using namespace Opm;
 
-std::shared_ptr<ParserKeyword> createFixedSized(const std::string& kw , size_t size) {
-    std::shared_ptr<ParserKeyword> pkw = std::make_shared<ParserKeyword>(kw);
+std::unique_ptr< ParserKeyword > createFixedSized(const std::string& kw , size_t size) {
+    std::unique_ptr< ParserKeyword > pkw( new ParserKeyword( kw ) );
     pkw->setFixedSize( size );
     return pkw;
 }
 
-std::shared_ptr<ParserKeyword> createDynamicSized(const std::string& kw) {
-    std::shared_ptr<ParserKeyword> pkw = std::make_shared<ParserKeyword>(kw);
+std::unique_ptr< ParserKeyword > createDynamicSized(const std::string& kw) {
+    std::unique_ptr< ParserKeyword > pkw( new ParserKeyword( kw ) );
     pkw->setSizeType(SLASH_TERMINATED);
     return pkw;
 }
 
-
-
 static ParserPtr createWWCTParser() {
-    ParserKeywordPtr parserKeyword = createDynamicSized("WWCT");
+    auto parserKeyword = createDynamicSized("WWCT");
     {
         std::shared_ptr<ParserRecord> record = std::make_shared<ParserRecord>();
         record->addItem( ParserStringItemConstPtr(new ParserStringItem("WELL", ALL)) );
         parserKeyword->addRecord( record );
     }
-    ParserKeywordPtr summaryKeyword = createFixedSized("SUMMARY" , (size_t) 0);
+    auto summaryKeyword = createFixedSized("SUMMARY" , (size_t) 0);
 
     ParserPtr parser(new Parser());
-    parser->addParserKeyword(parserKeyword);
-    parser->addParserKeyword(summaryKeyword);
+    parser->addParserKeyword( std::move( parserKeyword ) );
+    parser->addParserKeyword( std::move( summaryKeyword ) );
     return parser;
 }
 
@@ -143,7 +141,7 @@ BOOST_AUTO_TEST_CASE(parser_internal_name_vs_deck_name) {
 }
 
 static ParserPtr createBPRParser() {
-    ParserKeywordPtr parserKeyword = createDynamicSized("BPR");
+    auto parserKeyword = createDynamicSized("BPR");
     {
         std::shared_ptr<ParserRecord> bprRecord = std::make_shared<ParserRecord>();
         bprRecord->addItem(ParserIntItemConstPtr(new ParserIntItem("I", SINGLE)));
@@ -151,10 +149,10 @@ static ParserPtr createBPRParser() {
         bprRecord->addItem(ParserIntItemConstPtr(new ParserIntItem("K", SINGLE)));
         parserKeyword->addRecord( bprRecord );
     }
-    ParserKeywordPtr summaryKeyword = createFixedSized("SUMMARY" , (size_t) 0);
+    auto summaryKeyword = createFixedSized("SUMMARY" , (size_t) 0);
     ParserPtr parser(new Parser());
-    parser->addParserKeyword(parserKeyword);
-    parser->addParserKeyword(summaryKeyword);
+    parser->addParserKeyword( std::move( parserKeyword ) );
+    parser->addParserKeyword( std::move( summaryKeyword ) );
     return parser;
 }
 
@@ -233,7 +231,7 @@ BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {
     BOOST_CHECK(lastItem_1.defaultApplied(0));
     BOOST_CHECK_EQUAL(lastItem_1.get< int >(0), 1);
 
-    ParserKeywordConstPtr parserKeyword = parser->getParserKeywordFromDeckName("RADFIN4");
+    auto* parserKeyword = parser->getParserKeywordFromDeckName("RADFIN4");
     ParserRecordConstPtr parserRecord = parserKeyword->getRecord(0);
     ParserItemConstPtr nwmaxItem = parserRecord->get("NWMAX");
     ParserIntItemConstPtr intItem = std::static_pointer_cast<const ParserIntItem>(nwmaxItem);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <vector>
 
+#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
+
 namespace boost {
     namespace filesystem {
         class path;
@@ -40,7 +42,6 @@ namespace Opm {
 
     class Deck;
     class ParseMode;
-    class ParserKeyword;
     class RawKeyword;
     struct ParserState;
 
@@ -68,12 +69,12 @@ namespace Opm {
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(const Json::JsonObject& jsonKeyword);
-        void addParserKeyword(std::shared_ptr< const ParserKeyword > parserKeyword);
+        void addParserKeyword(std::unique_ptr< const ParserKeyword >&& parserKeyword);
         bool dropParserKeyword(const std::string& parserKeywordName);
-        std::shared_ptr< const ParserKeyword > getKeyword(const std::string& name) const;
+        const ParserKeyword* getKeyword(const std::string& name) const;
 
         bool isRecognizedKeyword( const std::string& deckKeywordName) const;
-        std::shared_ptr< const ParserKeyword > getParserKeywordFromDeckName(const std::string& deckKeywordName) const;
+        const ParserKeyword* getParserKeywordFromDeckName(const std::string& deckKeywordName) const;
         std::vector<std::string> getAllDeckNames () const;
 
         void loadKeywords(const Json::JsonObject& jsonKeywords);
@@ -98,26 +99,26 @@ namespace Opm {
         /*!
          * \brief Retrieve a ParserKeyword object given an internal keyword name.
          */
-        std::shared_ptr< const ParserKeyword > getParserKeywordFromInternalName(const std::string& internalKeywordName) const;
+        const ParserKeyword* getParserKeywordFromInternalName(const std::string& internalKeywordName) const;
 
 
         template <class T>
         void addKeyword() {
-            addParserKeyword( std::make_shared<T>());
+            addParserKeyword( std::unique_ptr< ParserKeyword >( new T ) );
         }
 
 
     private:
         // associative map of the parser internal name and the corresponding ParserKeyword object
-        std::map<std::string, std::shared_ptr< const ParserKeyword >> m_internalParserKeywords;
+        std::map<std::string, std::unique_ptr< const ParserKeyword > > m_internalParserKeywords;
         // associative map of deck names and the corresponding ParserKeyword object
-        std::map<std::string, std::shared_ptr< const ParserKeyword >> m_deckParserKeywords;
+        std::map<std::string, const ParserKeyword* > m_deckParserKeywords;
         // associative map of the parser internal names and the corresponding
         // ParserKeyword object for keywords which match a regular expression
-        std::map<std::string, std::shared_ptr< const ParserKeyword >> m_wildCardKeywords;
+        std::map<std::string, const ParserKeyword* > m_wildCardKeywords;
 
         bool hasWildCardKeyword(const std::string& keyword) const;
-        std::shared_ptr< const ParserKeyword > matchingKeyword(const std::string& keyword) const;
+        const ParserKeyword* matchingKeyword(const std::string& keyword) const;
 
         bool tryParseKeyword(std::shared_ptr<ParserState> parserState) const;
         bool parseState(std::shared_ptr<ParserState> parserState) const;

--- a/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
@@ -23,6 +23,7 @@
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParseMode.hpp>
 

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -35,8 +35,8 @@
 
 using namespace Opm;
 
-std::shared_ptr<ParserKeyword> createDynamicSized(const std::string& kw) {
-    std::shared_ptr<ParserKeyword> pkw = std::make_shared<ParserKeyword>(kw);
+std::unique_ptr< ParserKeyword > createDynamicSized(const std::string& kw) {
+    std::unique_ptr< ParserKeyword > pkw( new ParserKeyword( kw ) );
     pkw->setSizeType(SLASH_TERMINATED);
     return pkw;
 }
@@ -53,10 +53,7 @@ BOOST_AUTO_TEST_CASE(Initializing) {
 
 BOOST_AUTO_TEST_CASE(addKeyword_keyword_doesntfail) {
     Parser parser;
-    {
-        ParserKeywordPtr equilKeyword = createDynamicSized("EQUIL");
-        parser.addParserKeyword(equilKeyword);
-    }
+    parser.addParserKeyword( createDynamicSized( "EQUIL" ) );
 }
 
 
@@ -69,25 +66,21 @@ BOOST_AUTO_TEST_CASE(canParseDeckKeyword_returnstrue) {
 
 BOOST_AUTO_TEST_CASE(getKeyword_haskeyword_returnskeyword) {
     ParserPtr parser(new Parser());
-    ParserKeywordConstPtr parserKeyword = createDynamicSized("FJAS");
-    parser->addParserKeyword(parserKeyword);
-    BOOST_CHECK_EQUAL(parserKeyword, parser->getParserKeywordFromDeckName("FJAS"));
+    parser->addParserKeyword( createDynamicSized( "FJAS" ) );
+    BOOST_CHECK_EQUAL("FJAS", parser->getParserKeywordFromDeckName("FJAS")->getName());
 }
 
 BOOST_AUTO_TEST_CASE(getKeyword_hasnotkeyword_getKeywordThrowsException) {
     ParserPtr parser(new Parser());
-    ParserKeywordConstPtr parserKeyword = createDynamicSized("FJAS");
-    parser->addParserKeyword(parserKeyword);
+    parser->addParserKeyword( createDynamicSized( "FJAS" ) );
     BOOST_CHECK_THROW(parser->getParserKeywordFromDeckName("FJASS"), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(getAllDeckNames_hasTwoKeywords_returnsCompleteList) {
     ParserPtr parser(new Parser(false));
     std::cout << parser->getAllDeckNames().size() << std::endl;
-    ParserKeywordConstPtr firstParserKeyword = createDynamicSized("FJAS");
-    parser->addParserKeyword(firstParserKeyword);
-    ParserKeywordConstPtr secondParserKeyword = createDynamicSized("SAJF");
-    parser->addParserKeyword(secondParserKeyword);
+    parser->addParserKeyword( createDynamicSized( "FJAS" ) );
+    parser->addParserKeyword( createDynamicSized( "SAJF" ) );
     BOOST_CHECK_EQUAL(2U, parser->getAllDeckNames().size());
 }
 
@@ -104,7 +97,7 @@ BOOST_AUTO_TEST_CASE(getAllDeckNames_hasNoKeywords_returnsEmptyList) {
 BOOST_AUTO_TEST_CASE(addParserKeywordJSON_isRecognizedKeyword_returnstrue) {
     ParserPtr parser(new Parser());
     Json::JsonObject jsonConfig("{\"name\": \"BPR\", \"sections\":[\"SUMMARY\"], \"size\" : 100 ,  \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\"}]}");
-    parser->addParserKeyword(std::make_shared<const ParserKeyword>( jsonConfig ));
+    parser->addParserKeyword( jsonConfig );
     BOOST_CHECK(parser->isRecognizedKeyword("BPR"));
 }
 
@@ -112,7 +105,7 @@ BOOST_AUTO_TEST_CASE(addParserKeywordJSON_isRecognizedKeyword_returnstrue) {
 BOOST_AUTO_TEST_CASE(addParserKeywordJSON_size_isObject_allGood) {
     ParserPtr parser(new Parser());
     Json::JsonObject jsonConfig("{\"name\": \"EQUIXL\", \"sections\":[], \"size\" : {\"keyword\":\"EQLDIMS\" , \"item\" : \"NTEQUL\"},  \"items\" :[{\"name\":\"ItemX\" , \"size_type\":\"SINGLE\" , \"value_type\" : \"DOUBLE\"}]}");
-    parser->addParserKeyword(std::make_shared<const ParserKeyword>( jsonConfig ));
+    parser->addParserKeyword( jsonConfig );
     BOOST_CHECK(parser->isRecognizedKeyword("EQUIXL"));
 }
 
@@ -266,7 +259,7 @@ BOOST_AUTO_TEST_CASE(DropKeyword) {
 
 BOOST_AUTO_TEST_CASE(ReplaceKeyword) {
     ParserPtr parser(new Parser());
-    ParserKeywordConstPtr eqldims = parser->getParserKeywordFromDeckName("EQLDIMS");
+    const auto* eqldims = parser->getParserKeywordFromDeckName("EQLDIMS");
 
     BOOST_CHECK( parser->loadKeywordFromFile( "testdata/parser/EQLDIMS2" ) );
 
@@ -287,9 +280,9 @@ BOOST_AUTO_TEST_CASE(WildCardTest) {
 
     BOOST_CHECK(!parser->isRecognizedKeyword("TVDP"));
 
-    ParserKeywordConstPtr keyword1 = parser->getParserKeywordFromDeckName("TVDPA");
-    ParserKeywordConstPtr keyword2 = parser->getParserKeywordFromDeckName("TVDPBC");
-    ParserKeywordConstPtr keyword3 = parser->getParserKeywordFromDeckName("TVDPXXX");
+    const auto* keyword1 = parser->getParserKeywordFromDeckName("TVDPA");
+    const auto* keyword2 = parser->getParserKeywordFromDeckName("TVDPBC");
+    const auto* keyword3 = parser->getParserKeywordFromDeckName("TVDPXXX");
 
     BOOST_CHECK_EQUAL( keyword1 , keyword2 );
     BOOST_CHECK_EQUAL( keyword1 , keyword3 );
@@ -308,10 +301,4 @@ BOOST_AUTO_TEST_CASE( quoted_comments ) {
     BOOST_CHECK_EQUAL( Parser::stripComments("ABC'--'DEF'GHI") , "ABC'--'DEF'GHI");
     BOOST_CHECK_EQUAL( Parser::stripComments("ABC'--'DEF'--GHI") , "ABC'--'DEF'--GHI");
 }
-
-
-
-
-
-
 

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -296,23 +296,6 @@ BOOST_AUTO_TEST_CASE(WildCardTest) {
 }
 
 
-
-/***************** Simple Int parsing ********************************/
-
-static ParserKeywordPtr __attribute__((unused)) setupParserKeywordInt(std::string name, int numberOfItems) {
-    ParserKeywordPtr parserKeyword = createDynamicSized(name);
-    ParserRecordPtr parserRecord = parserKeyword->getRecord(0);
-
-    for (int i = 0; i < numberOfItems; i++) {
-        std::string another_name = "ITEM_" + boost::lexical_cast<std::string>(i);
-        ParserItemPtr intItem(new ParserIntItem(another_name, SINGLE));
-        parserRecord->addItem(intItem);
-    }
-
-    return parserKeyword;
-}
-
-
 BOOST_AUTO_TEST_CASE( quoted_comments ) {
     BOOST_CHECK_EQUAL( Parser::stripComments( "ABC" ) , "ABC");
     BOOST_CHECK_EQUAL( Parser::stripComments( "--ABC") , "");


### PR DESCRIPTION
Removes shared_ptr< ParserKeyword > exchange in Parser interface and
replaces it with unique_ptr storage and raw pointers for return values.
This has some implications:

* addParserKeyword() no longer takes shared_ptr<>, but unique_ptr&&
  addParserKeyword has been modified to create unique_ptr instead of
  shared_ptr.

* generated-source/ParserKeyword* no longer use make_shared which had a
  -massive- impact on compile times, which are now more-or-less
  trivialised (on my machine: 7.5s -> 1s per file). This because the
  compiler no longer generates a bunch of forwarding make_shared
  instances of subclasses that are immediately thrown away, but rather
  uses an inline make_unique that instantiates the -parent- class
  unique_ptr.