### PR TITLE
fixing the unit of the compressibility in PVCDO keyword.

### DIFF
--- a/opm/parser/share/keywords/000_Eclipse100/P/PVCDO
+++ b/opm/parser/share/keywords/000_Eclipse100/P/PVCDO
@@ -1,7 +1,7 @@
 {"name" : "PVCDO" , "sections" : ["PROPS"], "size" : {"keyword":"TABDIMS" , "item":"NTPVT"}, "items":
     [   {"name":"P_REF", "value_type" : "DOUBLE", "dimension":"Pressure" },
         {"name":"OIL_VOL_FACTOR", "value_type" : "DOUBLE","dimension":"1"},
-        {"name":"OIL_COMPRESSIBILITY", "value_type" : "DOUBLE","dimension":"1"},
+        {"name":"OIL_COMPRESSIBILITY", "value_type" : "DOUBLE","dimension":"1/Pressure"},
         {"name":"OIL_VISCOSITY", "value_type" : "DOUBLE","dimension":"Viscosity"},
-        {"name":"OIL_VISCOSIBILITY", "value_type" : "DOUBLE","dimension":"1"}
+        {"name":"OIL_VISCOSIBILITY", "value_type" : "DOUBLE","dimension":"1/Pressure"}
 ]}


### PR DESCRIPTION
Fixing the unit of the oil compressibility. Make one of my simulation with PVCDO keyword much better.

Should affect OPM/opm-autodiff#568, while not sure how yet. 