### PR TITLE
Minor fixes

### DIFF
--- a/opm/parser/eclipse/Utility/Functional.hpp
+++ b/opm/parser/eclipse/Utility/Functional.hpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iterator>
 #include <vector>
+#include <numeric>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/Utility/tests/FunctionalTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/FunctionalTests.cpp
@@ -2,7 +2,9 @@
 
 #include <vector>
 
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 #include <iostream>


### PR DESCRIPTION
Fix a missing include (accumulate is in the algorithm header) and silence boost warnings.

Another thing I noticed is that the new files do not carry the copyright/license block at the top as it should. It is good to add hooks to your editor to always add this, if possible.