### PR TITLE
Parser performance improvements

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -138,6 +138,7 @@ EclipseState/IOConfig/IOConfig.cpp)
 
 set( utility_source
 Utility/Functional.cpp
+Utility/Stringview.cpp
 )
 
 set( HEADER_FILES
@@ -287,9 +288,11 @@ EclipseState/Tables/ColumnSchema.hpp
 EclipseState/Tables/TableEnums.hpp
 EclipseState/Tables/TableSchema.hpp
 EclipseState/Tables/TableIndex.hpp
-Utility/Functional.hpp)
+#
+Utility/Functional.hpp
+Utility/Stringview.hpp)
 
-add_library(buildParser ${rawdeck_source} ${build_parser_source} ${deck_source} ${unit_source} ${generator_source})
+add_library(buildParser ${rawdeck_source} ${build_parser_source} ${deck_source} ${unit_source} ${generator_source} ${utility_source})
 target_link_libraries(buildParser opmjson ${Boost_LIBRARIES}  ${ERT_LIBRARIES})
 
 #-----------------------------------------------------------------

--- a/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -43,7 +43,7 @@ namespace Opm {
             const std::vector< T >& getData() const;
 
         protected:
-            DeckTypeItem( const std::string&  );
+            DeckTypeItem( const std::string&, size_t );
 
         private:
             std::string item_name;
@@ -83,9 +83,12 @@ namespace Opm {
     };
 
     template< typename T >
-    DeckTypeItem< T >::DeckTypeItem( const std::string& name ) :
+    DeckTypeItem< T >::DeckTypeItem( const std::string& name, size_t size ) :
         item_name( name )
-    {}
+    {
+        this->dataPointDefaulted.reserve( size );
+        this->data.reserve( size );
+    }
 
     template< typename T >
     const std::string& DeckTypeItem< T >::name() const {
@@ -275,8 +278,8 @@ namespace Opm {
     {}
 
     template< typename T >
-    DeckItem DeckItem::make( const std::string& name ) {
-        return DeckItem( std::unique_ptr< DeckItemBase > { new DeckItemT< T >( name ) } );
+    DeckItem DeckItem::make( const std::string& name, size_t size ) {
+        return DeckItem( std::unique_ptr< DeckItemBase > { new DeckItemT< T >( name, size ) } );
     }
 
     const std::string& DeckItem::name() const {
@@ -375,9 +378,9 @@ namespace Opm {
     template class DeckItemT< double >;
     template class DeckItemT< std::string >;
 
-    template DeckItem DeckItem::make< int >( const std::string& );
-    template DeckItem DeckItem::make< double >( const std::string& );
-    template DeckItem DeckItem::make< std::string >( const std::string& );
+    template DeckItem DeckItem::make< int >( const std::string&, size_t );
+    template DeckItem DeckItem::make< double >( const std::string&, size_t );
+    template DeckItem DeckItem::make< std::string >( const std::string&, size_t );
 
     template const int& DeckItem::get< int >( size_t ) const;
     template const double& DeckItem::get< double >( size_t ) const;

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -59,7 +59,9 @@ namespace Opm {
             fdouble = 3
         };
 
-        template< typename T > static DeckItem make( const std::string& );
+        template< typename T >
+        static DeckItem make( const std::string&, size_t = 1 );
+
         const std::string& name() const;
 
         // return true if the default value was used for a given data point

--- a/opm/parser/eclipse/Deck/DeckRecord.cpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.cpp
@@ -29,6 +29,10 @@
 namespace Opm {
 
 
+    DeckRecord::DeckRecord( size_t size ) {
+        this->m_items.reserve( size );
+    }
+
     size_t DeckRecord::size() const {
         return m_items.size();
     }

--- a/opm/parser/eclipse/Deck/DeckRecord.hpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.hpp
@@ -32,6 +32,9 @@ namespace Opm {
     public:
         typedef std::vector< DeckItem >::const_iterator const_iterator;
 
+        DeckRecord() = default;
+        DeckRecord( size_t );
+
         size_t size() const;
         void addItem( DeckItem&& deckItem );
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -389,14 +389,14 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
                 else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::paths) {
                     for (size_t i = 0; i < parserState->rawKeyword->size(); i++) {
                             RawRecordConstPtr record = parserState->rawKeyword->getRecord(i);
-                            std::string pathName = readValueToken<std::string>(record->getItem(0).string());
-                            std::string pathValue = readValueToken<std::string>(record->getItem(1).string());
+                            std::string pathName = readValueToken<std::string>(record->getItem(0));
+                            std::string pathValue = readValueToken<std::string>(record->getItem(1));
                             parserState->pathMap->insert(std::pair<std::string, std::string>(pathName, pathValue));
                     }
                 }
                 else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::include) {
                     RawRecordConstPtr firstRecord = parserState->rawKeyword->getRecord(0);
-                    std::string includeFileAsString = readValueToken<std::string>(firstRecord->getItem(0).string());
+                    std::string includeFileAsString = readValueToken<std::string>(firstRecord->getItem(0));
                     boost::filesystem::path includeFile = getIncludeFilePath(*parserState, includeFileAsString);
                     std::shared_ptr<ParserState> newParserState = parserState->includeState( includeFile );
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -491,7 +491,7 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
 
 
 
-    std::string Parser::doSpecialHandlingForTitleKeyword(std::string line, std::shared_ptr<ParserState> parserState) const {
+    static inline std::string& doSpecialHandlingForTitleKeyword(std::string& line, std::shared_ptr<ParserState> parserState) {
         if ((parserState->rawKeyword != NULL) && (parserState->rawKeyword->getKeywordName() == "TITLE"))
                 line = line.append("/");
         return line;

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -388,14 +388,14 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
                 else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::paths) {
                     for (size_t i = 0; i < parserState->rawKeyword->size(); i++) {
                             RawRecordConstPtr record = parserState->rawKeyword->getRecord(i);
-                            std::string pathName = readValueToken<std::string>(record->getItem(0));
-                            std::string pathValue = readValueToken<std::string>(record->getItem(1));
+                            std::string pathName = readValueToken<std::string>(record->getItem(0).string());
+                            std::string pathValue = readValueToken<std::string>(record->getItem(1).string());
                             parserState->pathMap->insert(std::pair<std::string, std::string>(pathName, pathValue));
                     }
                 }
                 else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::include) {
                     RawRecordConstPtr firstRecord = parserState->rawKeyword->getRecord(0);
-                    std::string includeFileAsString = readValueToken<std::string>(firstRecord->getItem(0));
+                    std::string includeFileAsString = readValueToken<std::string>(firstRecord->getItem(0).string());
                     boost::filesystem::path includeFile = getIncludeFilePath(*parserState, includeFileAsString);
                     std::shared_ptr<ParserState> newParserState = parserState->includeState( includeFile );
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <cctype>
 #include <fstream>
 #include <memory>
 
@@ -497,9 +498,19 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
         return line;
     }
 
-    bool Parser::tryParseKeyword(std::shared_ptr<ParserState> parserState) const {
-        std::string line;
+    static inline std::string& trim_right( std::string& str ) {
+        /* because cctype functions can be macros, manually find the
+         * position to erase from. Written using isspace for performance.
+         */
 
+        size_t i = str.size();
+        for( ; i >= 1; --i )
+            if( !isspace( str[ i - 1 ] ) ) break;
+
+        return str.erase( i );
+    }
+
+    bool Parser::tryParseKeyword(std::shared_ptr<ParserState> parserState) const {
         if (parserState->nextKeyword.length() > 0) {
             parserState->rawKeyword = createRawKeyword(parserState->nextKeyword, parserState);
             parserState->nextKeyword = "";
@@ -508,11 +519,12 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
         if (parserState->rawKeyword && parserState->rawKeyword->isFinished())
             return true;
 
+        std::string line;
         while (std::getline(*parserState->inputstream, line)) {
             if (line.find("--") != std::string::npos)
                 line = stripComments( line );
 
-            boost::algorithm::trim_right(line); // Removing garbage (eg. \r)
+            line = trim_right( line ); // Removing garbage (eg. \r)
             line = doSpecialHandlingForTitleKeyword(line, parserState);
             std::string keywordString;
             parserState->lineNR++;
@@ -536,7 +548,6 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
                     }
                 }
                 parserState->rawKeyword->addRawRecordString(line);
-                line = "";
             }
 
             if (parserState->rawKeyword

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -124,8 +124,6 @@ namespace Opm {
         bool parseState(std::shared_ptr<ParserState> parserState) const;
         std::shared_ptr< RawKeyword > createRawKeyword(const std::string& keywordString, std::shared_ptr<ParserState> parserState) const;
         void addDefaultKeywords();
-
-        std::string doSpecialHandlingForTitleKeyword(std::string line, std::shared_ptr<ParserState> parserState) const;
     };
 
 

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -151,7 +151,7 @@ namespace Opm {
 
         if (self->sizeType() == ALL) {
             while (rawRecord->size() > 0) {
-                std::string token = rawRecord->pop_front();
+                auto token = rawRecord->pop_front();
 
                 std::string countString;
                 std::string valueString;
@@ -168,7 +168,7 @@ namespace Opm {
                             deckItem.push_backDefault( value );
                     }
                 } else {
-                    ValueType value = readValueToken<ValueType>(token);
+                    ValueType value = readValueToken<ValueType>(token.string());
                     deckItem.push_back(value);
                 }
             }
@@ -186,7 +186,7 @@ namespace Opm {
             } else {
                 // The '*' should be interpreted as a repetition indicator, but it must
                 // be preceeded by an integer...
-                std::string token = rawRecord->pop_front();
+                auto token = rawRecord->pop_front();
                 std::string countString;
                 std::string valueString;
                 if (isStarToken(token, countString, valueString)) {
@@ -212,7 +212,7 @@ namespace Opm {
                     for (size_t i=0; i < st.count() - 1; i++)
                         rawRecord->push_front(singleRepetition);
                 } else {
-                    ValueType value = readValueToken<ValueType>(token);
+                    ValueType value = readValueToken<ValueType>(token.string() );
                     deckItem.push_back(value);
                 }
             }

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -147,7 +147,7 @@ namespace Opm {
     /// NOTE: data are popped from the rawRecords deque!
     template<typename ParserItemType, typename ValueType>
     DeckItem ParserItemScan(const ParserItemType * self , std::shared_ptr< RawRecord > rawRecord) {
-        auto deckItem = DeckItem::make< ValueType >( self->name() );
+        auto deckItem = DeckItem::make< ValueType >( self->name(), rawRecord->size() );
 
         if (self->sizeType() == ALL) {
             while (rawRecord->size() > 0) {
@@ -215,7 +215,8 @@ namespace Opm {
                 }
             }
         }
-        return std::move( deckItem );
+
+        return deckItem;
     }
 
 

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -168,8 +168,7 @@ namespace Opm {
                             deckItem.push_backDefault( value );
                     }
                 } else {
-                    ValueType value = readValueToken<ValueType>( token );
-                    deckItem.push_back(value);
+                    deckItem.push_back( readValueToken<ValueType>( token ) );
                 }
             }
         } else {
@@ -212,8 +211,7 @@ namespace Opm {
                     for (size_t i=0; i < st.count() - 1; i++)
                         rawRecord->push_front(singleRepetition);
                 } else {
-                    ValueType value = readValueToken<ValueType>( token );
-                    deckItem.push_back(value);
+                    deckItem.push_back( readValueToken<ValueType>( token ) );
                 }
             }
         }

--- a/opm/parser/eclipse/Parser/ParserItem.hpp
+++ b/opm/parser/eclipse/Parser/ParserItem.hpp
@@ -168,7 +168,7 @@ namespace Opm {
                             deckItem.push_backDefault( value );
                     }
                 } else {
-                    ValueType value = readValueToken<ValueType>(token.string());
+                    ValueType value = readValueToken<ValueType>( token );
                     deckItem.push_back(value);
                 }
             }
@@ -212,7 +212,7 @@ namespace Opm {
                     for (size_t i=0; i < st.count() - 1; i++)
                         rawRecord->push_front(singleRepetition);
                 } else {
-                    ValueType value = readValueToken<ValueType>(token.string() );
+                    ValueType value = readValueToken<ValueType>( token );
                     deckItem.push_back(value);
                 }
             }

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -16,8 +16,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <string>
+#include <algorithm>
+#include <cctype>
 #include <stdexcept>
+#include <string>
 
 #include <opm/json/JsonObject.hpp>
 
@@ -244,11 +246,19 @@ namespace Opm {
         return result;
     }
 
+    static inline std::string uppercase( std::string str ) {
+        /* the cctype toupper etc. are often implemented as macros, so its
+         * unreliable with std algorithms. Hand-rolling map instead
+         */
+        for( auto& c : str ) c = toupper( c );
+        return str;
+    }
+
     bool ParserKeyword::validDeckName(const std::string& name) {
         // make the keyword string ALL_UPPERCASE because Eclipse seems
         // to be case-insensitive (although this is one of its
         // undocumented features...)
-        std::string upperCaseName = boost::to_upper_copy(name);
+        auto upperCaseName = uppercase( name );
 
         if (!validNameStart(upperCaseName))
             return false;

--- a/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -118,7 +118,7 @@ namespace Opm {
 
     DeckRecord ParserRecord::parse(const ParseMode& parseMode , RawRecordPtr rawRecord) const {
         std::string recordBeforeParsing = rawRecord->getRecordString();
-        DeckRecord deckRecord;
+        DeckRecord deckRecord( size() );
         for (size_t i = 0; i < size(); i++) {
             auto parserItem = get(i);
             deckRecord.addItem( parserItem->scan( rawRecord ) );

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -34,6 +34,10 @@ namespace Opm {
         const std::string endinclude = "ENDINC";
         const std::string paths = "PATHS";
         const unsigned int maxKeywordLength = 8;
+
+        static inline bool is_separator( char ch ) {
+            return ch == '\t' || ch == ' ';
+        }
     }
 }
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -103,14 +103,11 @@ namespace Opm {
         }
     }
 
-    bool RawKeyword::isTerminator(std::string line) {
-        boost::algorithm::trim_left( line );
-        if (line[0] == RawConsts::slash) {
-            return true;
-        } else
-            return false;
+    bool RawKeyword::isTerminator( const std::string& line ) {
+        auto fst = std::find_if_not( line.begin(), line.end(),
+                RawConsts::is_separator );
+        return fst != line.end() && *fst == RawConsts::slash;
     }
-
 
 
     RawRecordPtr RawKeyword::getRecord(size_t index) const {

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -69,8 +69,11 @@ namespace Opm {
         return m_records.size();
     }
 
-
-
+    static inline bool isTerminator( const std::string& line ) {
+        auto fst = std::find_if_not( line.begin(), line.end(),
+                RawConsts::is_separator );
+        return fst != line.end() && *fst == RawConsts::slash;
+    }
 
     /// Important method, being repeatedly called. When a record is terminated,
     /// it is added to the list of records, and a new record is started.
@@ -101,12 +104,6 @@ namespace Opm {
                     m_isFinished = true;
             }
         }
-    }
-
-    bool RawKeyword::isTerminator( const std::string& line ) {
-        auto fst = std::find_if_not( line.begin(), line.end(),
-                RawConsts::is_separator );
-        return fst != line.end() && *fst == RawConsts::slash;
     }
 
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -47,7 +47,7 @@ namespace Opm {
         std::shared_ptr< RawRecord > getRecord(size_t index) const;
 
         static bool isKeywordPrefix(const std::string& line, std::string& keywordName);
-        static bool isTerminator(std::string line);
+        static bool isTerminator( const std::string& line );
 
 
         bool isPartialRecordStringEmpty() const;

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -47,8 +47,6 @@ namespace Opm {
         std::shared_ptr< RawRecord > getRecord(size_t index) const;
 
         static bool isKeywordPrefix(const std::string& line, std::string& keywordName);
-        static bool isTerminator( const std::string& line );
-
 
         bool isPartialRecordStringEmpty() const;
         bool isFinished() const;

--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -46,14 +46,10 @@ namespace Opm {
         return terminatingSlash;
     }
 
-    static inline bool is_whitespace( char ch ) {
-        return ch == '\t' || ch == ' ';
-    }
-
     static inline std::string::const_iterator first_nonspace (
             std::string::const_iterator begin,
             std::string::const_iterator end ) {
-        return std::find_if_not( begin, end, is_whitespace );
+        return std::find_if_not( begin, end, RawConsts::is_separator );
     }
 
     static std::deque< string_view > splitSingleRecordString( const std::string& record ) {
@@ -69,7 +65,7 @@ namespace Opm {
                 dst.push_back( { current, quote_end } );
                 current = quote_end;
             } else {
-                auto token_end = std::find_if( current, record.end(), is_whitespace );
+                auto token_end = std::find_if( current, record.end(), RawConsts::is_separator );
                 dst.push_back( { current, token_end } );
                 current = token_end;
             }

--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -126,8 +126,8 @@ namespace Opm {
         std::cout << "RecordDump: ";
         for (size_t i = 0; i < m_recordItems.size(); i++) {
             std::cout
-                << this->m_recordItems[i].string() << "/"
-                << getItem( i ).string() << " ";
+                << this->m_recordItems[i] << "/"
+                << getItem( i ) << " ";
         }
         std::cout << std::endl;
     }

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -20,9 +20,12 @@
 #ifndef RECORD_HPP
 #define RECORD_HPP
 
-#include <string>
 #include <deque>
 #include <memory>
+#include <string>
+#include <vector>
+
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
 
 namespace Opm {
 
@@ -34,32 +37,27 @@ namespace Opm {
     public:
         RawRecord(const std::string& singleRecordString, const std::string& fileName = "", const std::string& keywordName = "");
 
-        std::string pop_front();
+        string_view pop_front();
         void push_front(std::string token);
         size_t size() const;
 
         const std::string& getRecordString() const;
-        const std::string& getItem(size_t index) const;
+        string_view getItem(size_t index) const;
         const std::string& getFileName() const;
         const std::string& getKeywordName() const;
 
         static bool isTerminatedRecordString(const std::string& candidateRecordString);
-        virtual ~RawRecord();
-        void dump() const;
+
+       void dump() const;
 
     private:
         std::string m_sanitizedRecordString;
-        std::deque<std::string> m_recordItems;
+        std::deque< string_view > m_recordItems;
+        std::vector< std::string > expanded_items;
         const std::string m_fileName;
         const std::string m_keywordName;
 
         void setRecordString(const std::string& singleRecordString);
-        void splitSingleRecordString();
-        void processSeparatorCharacter(std::string& currentToken, const char& currentChar, char& tokenStarter);
-        void processQuoteCharacters(std::string& currentToken, const char& currentChar, char& tokenStarter);
-        void processNonSpecialCharacters(std::string& currentToken, const char& currentChar);
-        bool charIsSeparator(char candidate);
-        static unsigned int findTerminatingSlash(const std::string& singleRecordString);
     };
     typedef std::shared_ptr<RawRecord> RawRecordPtr;
     typedef std::shared_ptr<const RawRecord> RawRecordConstPtr;

--- a/opm/parser/eclipse/RawDeck/StarToken.cpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.cpp
@@ -20,13 +20,21 @@
 #include <string>
 #include <stdexcept>
 #include <boost/lexical_cast.hpp>
+
 #include <opm/parser/eclipse/RawDeck/StarToken.hpp>
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
 
 
 
 namespace Opm {
 
     bool isStarToken(const std::string& token,
+                           std::string& countString,
+                           std::string& valueString) {
+        return isStarToken( string_view( token.begin(), token.end() ), countString, valueString );
+    }
+
+    bool isStarToken(const string_view& token,
                            std::string& countString,
                            std::string& valueString) {
         // find first character which is not a digit
@@ -113,7 +121,7 @@ namespace Opm {
             return valueString;
     }
 
-    void StarToken::init_( const std::string& token ) {
+    void StarToken::init_( const string_view& token ) {
         // special-case the interpretation of a lone star as "1*" but do not
         // allow constructs like "*123"...
         if (m_countString == "") {

--- a/opm/parser/eclipse/RawDeck/StarToken.hpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.hpp
@@ -24,8 +24,6 @@
 
 #include <opm/parser/eclipse/Utility/Stringview.hpp>
 
-#include <boost/lexical_cast.hpp>
-
 namespace Opm {
     bool isStarToken(const string_view& token,
                            std::string& countString,
@@ -36,12 +34,12 @@ namespace Opm {
                            std::string& valueString);
 
     template <class T>
-    T readValueToken(const std::string& valueString);
+    T readValueToken( string_view );
 
 class StarToken {
 public:
     StarToken(const std::string& token) :
-        StarToken( string_view( token.begin(), token.end() ) )
+        StarToken( string_view( token ) )
     {}
 
     StarToken(const string_view& token)

--- a/opm/parser/eclipse/RawDeck/StarToken.hpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.hpp
@@ -22,7 +22,15 @@
 
 #include <string>
 
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
+
+#include <boost/lexical_cast.hpp>
+
 namespace Opm {
+    bool isStarToken(const string_view& token,
+                           std::string& countString,
+                           std::string& valueString);
+
     bool isStarToken(const std::string& token,
                            std::string& countString,
                            std::string& valueString);
@@ -32,14 +40,18 @@ namespace Opm {
 
 class StarToken {
 public:
-    StarToken(const std::string& token)
+    StarToken(const std::string& token) :
+        StarToken( string_view( token.begin(), token.end() ) )
+    {}
+
+    StarToken(const string_view& token)
     {
         if (!isStarToken(token, m_countString, m_valueString))
-            throw std::invalid_argument("Token \""+token+"\" is not a repetition specifier");
+            throw std::invalid_argument("Token \""+ token.string() +"\" is not a repetition specifier");
         init_(token);
     }
 
-    StarToken(const std::string& token, const std::string& countStr, const std::string& valueStr)
+    StarToken(const string_view& token, const std::string& countStr, const std::string& valueStr)
         : m_countString(countStr)
         , m_valueString(valueStr)
     {
@@ -73,7 +85,7 @@ public:
 private:
     // internal initialization method. the m_countString and m_valueString attributes
     // must be set before calling this method.
-    void init_(const std::string& token);
+    void init_(const string_view& token);
 
     ssize_t m_count;
     std::string m_countString;

--- a/opm/parser/eclipse/RawDeck/StarToken.hpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.hpp
@@ -47,7 +47,7 @@ public:
     StarToken(const string_view& token)
     {
         if (!isStarToken(token, m_countString, m_valueString))
-            throw std::invalid_argument("Token \""+ token.string() +"\" is not a repetition specifier");
+            throw std::invalid_argument("Token \""+ token +"\" is not a repetition specifier");
         init_(token);
     }
 

--- a/opm/parser/eclipse/RawDeck/tests/RawKeywordTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/RawKeywordTests.cpp
@@ -147,18 +147,6 @@ BOOST_AUTO_TEST_CASE(isFinished_FixedsizeMulti) {
 
 }
 
-
-
-BOOST_AUTO_TEST_CASE(isKeywordTerminator) {
-    BOOST_CHECK( RawKeyword::isTerminator("/"));
-    BOOST_CHECK( RawKeyword::isTerminator("  /"));
-    BOOST_CHECK( RawKeyword::isTerminator("/  "));
-    BOOST_CHECK( RawKeyword::isTerminator("  /"));
-    BOOST_CHECK( RawKeyword::isTerminator("  /"));
-
-    BOOST_CHECK( !RawKeyword::isTerminator("  X/  "));
-}
-
 BOOST_AUTO_TEST_CASE(isTableCollection) {
     RawKeyword keyword1("TEST" , "FILE" , 10U, 4U , false);
     RawKeyword keyword2("TEST2", Raw::SLASH_TERMINATED , "FILE" , 10U);

--- a/opm/parser/eclipse/RawDeck/tests/RawRecordTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/RawRecordTests.cpp
@@ -22,11 +22,6 @@
 #include <boost/test/unit_test.hpp>
 #include <opm/parser/eclipse/RawDeck/RawRecord.hpp>
 
-BOOST_AUTO_TEST_CASE(RawRecordGetRecordStringReturnsTrimmedString) {
-    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20                                       /"));
-    const std::string& recordString = record->getRecordString();
-    BOOST_CHECK_EQUAL("'NODIR '  'REVERS'  1  20", recordString);
-}
 
 BOOST_AUTO_TEST_CASE(RawRecordGetRecordsCorrectElementsReturned) {
     Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20                                       /"));
@@ -91,7 +86,6 @@ BOOST_AUTO_TEST_CASE(Rawrecord_sizeEmpty_OK) {
 
 BOOST_AUTO_TEST_CASE(Rawrecord_spaceOnlyEmpty_OK) {
     Opm::RawRecordPtr record(new Opm::RawRecord("   /"));
-    BOOST_CHECK_EQUAL("", record->getRecordString());
     BOOST_CHECK_EQUAL(0U, record->size());
 }
 

--- a/opm/parser/eclipse/RawDeck/tests/StarTokenTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/StarTokenTests.cpp
@@ -99,15 +99,15 @@ BOOST_AUTO_TEST_CASE( ContainsStar_WithStar_ReturnsTrue ) {
 }
 
 BOOST_AUTO_TEST_CASE( readValueToken_basic_validity_tests ) {
-    BOOST_CHECK_THROW( Opm::readValueToken<int>("3.3"), std::invalid_argument );
-    BOOST_CHECK_THROW( Opm::readValueToken<double>("truls"), std::invalid_argument );
-    BOOST_CHECK_EQUAL( "3.3", Opm::readValueToken<std::string>("3.3") );
-    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>("3.3e0"), 1e-6 );
-    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>("3.3d0"), 1e-6 );
-    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>("3.3E0"), 1e-6 );
-    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>("3.3D0"), 1e-6 );
-    BOOST_CHECK_EQUAL( "OLGA", Opm::readValueToken<std::string>("OLGA") );
-    BOOST_CHECK_EQUAL( "OLGA", Opm::readValueToken<std::string>("'OLGA'") );
-    BOOST_CHECK_EQUAL( "123*456", Opm::readValueToken<std::string>("123*456") );
-    BOOST_CHECK_EQUAL( "123*456", Opm::readValueToken<std::string>("'123*456'") );
+    BOOST_CHECK_THROW( Opm::readValueToken<int>( std::string( "3.3" ) ), std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "truls" ) ), std::invalid_argument );
+    BOOST_CHECK_EQUAL( "3.3", Opm::readValueToken<std::string>( std::string( "3.3" ) ) );
+    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3e0" ) ), 1e-6 );
+    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3d0" ) ), 1e-6 );
+    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3E0" ) ), 1e-6 );
+    BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3D0" ) ), 1e-6 );
+    BOOST_CHECK_EQUAL( "OLGA", Opm::readValueToken<std::string>( std::string( "OLGA" ) ) );
+    BOOST_CHECK_EQUAL( "OLGA", Opm::readValueToken<std::string>( std::string( "'OLGA'" ) ) );
+    BOOST_CHECK_EQUAL( "123*456", Opm::readValueToken<std::string>( std::string( "123*456" ) ) );
+    BOOST_CHECK_EQUAL( "123*456", Opm::readValueToken<std::string>( std::string( "'123*456'" ) ) );
 }

--- a/opm/parser/eclipse/Utility/Stringview.cpp
+++ b/opm/parser/eclipse/Utility/Stringview.cpp
@@ -1,0 +1,9 @@
+#include <iterator>
+#include <ostream>
+
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
+
+std::ostream& operator<<( std::ostream& stream, const Opm::string_view& view ) {
+    std::copy( view.begin(), view.end(), std::ostream_iterator< char >( stream ) );
+    return stream;
+}

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -1,0 +1,236 @@
+/*
+  Copyright (C) 2016 by Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_UTILITY_SUBSTRING_HPP
+#define OPM_UTILITY_SUBSTRING_HPP
+
+#include <iosfwd>
+#include <stdexcept>
+#include <string>
+
+namespace Opm {
+    /*
+     * string_view is a simple view-into-substring feature whose primary
+     * usecase is to avoid deep copying strings in the inner loops of the
+     * parser. Relies on whatever it's viewing into is kept alive (as all
+     * iterators do):
+     *
+     * auto rec = make_raw_record();
+     * string_view view = rec.getItem( 3 );
+     *
+     * view.size(); view[ 10 ]; // ok
+     * ~rec();
+     * view[ 3 ]; // not ok
+     *
+     * This is desired to fill out a gap in the C++ standard library, since
+     * string_view has yet to be standardised
+     *
+     * http://en.cppreference.com/w/cpp/experimental/basic_string_view
+     */
+    class string_view {
+        public:
+            using const_iterator = std::string::const_iterator;
+
+            inline string_view() = default;
+            inline string_view( const std::string& );
+            inline string_view( std::string::const_iterator, std::string::const_iterator );
+
+            inline const_iterator begin() const;
+            inline const_iterator end() const;
+
+            inline char operator[]( size_t ) const;
+
+            inline size_t size() const;
+            inline size_t length() const;
+
+            /*
+             * substr operations are bounds checked, i.e. if to > from or to >
+             * size then exceptions are thrown.
+             *
+             * returns the substring [from,to), meaning
+             * view = "sample";
+             * view.substr( 0, view.size() ) => sample
+             * view.substr( 0, 5 ) => sampl
+             */
+            inline std::string string() const;
+            inline std::string substr( size_t from = 0 ) const;
+            inline std::string substr( size_t from, size_t to ) const;
+
+        private:
+            const_iterator fst;
+            const_iterator lst;
+    };
+}
+
+/*
+ * The implementation of string_view is inline and therefore the definitions
+ * are also in this file. The reason for this is performance; string_view's
+ * logic is trivial and function call and indirection overhead is significant
+ * compared to the useful work it does. Additionally, string_view is a *very*
+ * much used class in the inner loops of the parser - inlining the
+ * implementation measured to improve performance by some 10%.
+ */
+
+std::ostream& operator<<( std::ostream& stream, const Opm::string_view& view );
+
+inline std::string operator+( std::string str, const Opm::string_view& view ) {
+    return str.append( view.begin(), view.end() );
+}
+
+inline std::string operator+( const Opm::string_view& view, const std::string& str ) {
+    return view.string().append( str.begin(), str.end() );
+}
+
+inline bool operator==( const Opm::string_view& view, const std::string& rhs ) {
+    return rhs.size() == view.size() &&
+        std::equal( view.begin(), view.end(), std::begin( rhs ) );
+}
+
+inline bool operator==( const Opm::string_view& view, const char* rhs ) {
+    return std::equal( view.begin(), view.end(), rhs );
+}
+
+inline bool operator==( const std::string& lhs, const Opm::string_view& view ) {
+    return view == lhs;
+}
+
+inline bool operator==( const char* lhs, const Opm::string_view& view ) {
+    return view == lhs;
+}
+
+inline bool operator!=( const Opm::string_view& view, const std::string& rhs ) {
+    return !( view == rhs );
+}
+
+inline bool operator!=( const std::string& lhs, const Opm::string_view& view ) {
+    return !( view == lhs );
+}
+
+inline bool operator!=( const Opm::string_view& view, const char* rhs ) {
+    return !( view == rhs );
+}
+
+inline bool operator!=( const char* lhs, const Opm::string_view& view ) {
+    return !( view == lhs );
+}
+
+
+namespace boost { namespace test_tools {
+    /* This is an unfortunate consequence of using boost.test.
+     * For reference, see
+     * http://stackoverflow.com/questions/17572583/boost-check-fails-to-compile-operator-for-custom-types
+     *
+     * In short, boost.test is unable to select the correct operator overloads,
+     * even in the global scope, inside its test macros. As a consequence, in
+     * order for boost.test to function we pry open its internals and creates a
+     * specialised instantiaten of string_view, as well as custom
+     * boost-namespace-specific overloads of comparison operators (that simply
+     * forward to the propoer implementations.
+     */
+
+    template< typename T > struct print_log_value;
+
+    template<>
+    struct print_log_value< Opm::string_view > {
+        void operator()( std::ostream& os, const Opm::string_view& view ) {
+            ::operator<<( os, view );
+        }
+
+    };
+
+    namespace tt_detail {
+
+        template< typename T >
+        inline bool operator==( const Opm::string_view& o, const T& x ) {
+            return ::operator==( o, x );
+        }
+
+        template< typename T >
+        inline bool operator==( const T& x, const Opm::string_view& o ) {
+            return ::operator==( o, x );
+        }
+
+        template< typename T >
+        inline bool operator!=( const Opm::string_view& o, const T& x ) {
+            return ::operator!=( o, x );
+        }
+
+        template< typename T >
+        inline bool operator!=( const T& x, const Opm::string_view& o ) {
+            return ::operator!=( o, x );
+        }
+    }
+}}
+
+namespace Opm {
+    inline string_view::string_view( std::string::const_iterator begin,
+                              std::string::const_iterator end ) :
+        fst( begin ),
+        lst( end )
+    {}
+
+    inline string_view::string_view( const std::string& str ) :
+        fst( str.begin() ),
+        lst( str.end() )
+    {}
+
+    inline string_view::const_iterator string_view::begin() const {
+        return this->fst;
+    }
+
+    inline string_view::const_iterator string_view::end() const {
+        return this->lst;
+    }
+
+    inline char string_view::operator[]( size_t i ) const {
+        return *(this->begin() + i);
+    }
+
+    inline size_t string_view::size() const {
+        return std::distance( this->begin(), this->end() );
+    }
+
+    inline size_t string_view::length() const {
+        return std::distance( this->begin(), this->end() );
+    }
+
+    inline std::string string_view::string() const {
+        return this->substr();
+    }
+
+    inline std::string string_view::substr( size_t from ) const {
+        return this->substr( from, this->size() );
+    }
+
+    inline std::string string_view::substr( size_t from, size_t to ) const {
+        if( from > this->size() )
+            throw std::out_of_range( "'from' is greater than length" );
+
+        if( to > this->size() )
+            throw std::out_of_range( "'to' is greater than length" );
+
+        if( from > to )
+            throw std::invalid_argument( "'from' is greater than 'to'" );
+
+        return std::string( this->begin() + from, this->begin() + to );
+    }
+
+}
+
+#endif //OPM_UTILITY_SUBSTRING_HPP

--- a/opm/parser/eclipse/Utility/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/Utility/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-foreach(tapp FunctionalTests )
+foreach(tapp FunctionalTests StringviewTests )
 
     opm_add_test(run${tapp}  SOURCES ${tapp}.cpp
                              LIBRARIES opmparser ${Boost_LIBRARIES})

--- a/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
@@ -1,0 +1,96 @@
+#define BOOST_TEST_MODULE StringviewTests
+
+#include <sstream>
+#include <string>
+
+#include <opm/common/utility/platform_dependent/disable_warnings.h>
+#include <boost/test/unit_test.hpp>
+#include <opm/common/utility/platform_dependent/reenable_warnings.h>
+
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
+
+using namespace Opm;
+
+BOOST_AUTO_TEST_CASE(fullStringView) {
+    std::string srcstr = "lorem ipsum";
+    string_view view( srcstr.begin(), srcstr.end() );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            srcstr.begin(), srcstr.end(),
+            view.begin(), view.end() );
+}
+
+BOOST_AUTO_TEST_CASE(viewCorrectSize) {
+    std::string srcstr = "lorem ipsum";
+    string_view view( srcstr.begin(), srcstr.begin() + 5 );
+
+    BOOST_CHECK_EQUAL( 5, view.size() );
+    BOOST_CHECK_EQUAL( 5, view.length() );
+}
+
+BOOST_AUTO_TEST_CASE(viewOperatorAt) {
+    std::string srcstr = "lorem ipsum";
+    string_view view( srcstr.begin(), srcstr.end() );
+
+    for( size_t i = 0; i < view.size(); ++i )
+        BOOST_CHECK_EQUAL( view[ i ], srcstr[ i ] );
+}
+
+BOOST_AUTO_TEST_CASE(viewSubstr) {
+    std::string srcstr = "lorem ipsum";
+    string_view view( srcstr.begin(), srcstr.end() );
+
+    BOOST_CHECK_NO_THROW( view.string() );
+    BOOST_CHECK_EQUAL( srcstr, view.string() );
+    BOOST_CHECK_EQUAL( srcstr, view.substr() );
+    BOOST_CHECK_EQUAL( "", view.substr( 0, 0 ) );
+
+    BOOST_CHECK_EQUAL( srcstr.substr( 1 ), view.substr( 1 ) );
+
+    BOOST_CHECK_THROW( view.substr( srcstr.size() + 1 ), std::out_of_range );
+    BOOST_CHECK_THROW( view.substr( 0, srcstr.size() + 1 ), std::out_of_range );
+    BOOST_CHECK_THROW( view.substr( 1, 0 ), std::invalid_argument );
+    BOOST_CHECK_NO_THROW( view.substr( 0, 0 ) );
+}
+
+BOOST_AUTO_TEST_CASE(viewStream) {
+    std::string srcstr = "lorem ipsum";
+    string_view view( srcstr.begin(), srcstr.end() );
+
+    std::stringstream str;
+    str << view;
+
+    BOOST_CHECK_EQUAL( srcstr, str.str() );
+}
+
+BOOST_AUTO_TEST_CASE(equalityOperators) {
+    std::string srcstr = "lorem ipsum";
+    std::string diffstr = "lorem";
+    string_view view( srcstr.begin(), srcstr.end() );
+
+    BOOST_CHECK_EQUAL( srcstr, view );
+    BOOST_CHECK_NE( diffstr, view );
+
+    BOOST_CHECK_EQUAL( view, srcstr );
+    BOOST_CHECK_NE( view, diffstr );
+
+    BOOST_CHECK_EQUAL( "lorem ipsum", view );
+    BOOST_CHECK_NE( "lorem", view );
+
+    BOOST_CHECK_EQUAL( view, "lorem ipsum" );
+    BOOST_CHECK_NE( view, "lorem" );
+}
+
+BOOST_AUTO_TEST_CASE(plusOperator) {
+    std::string total = "lorem ipsum";
+    std::string lhs = "lorem";
+    std::string ws = " ";
+    std::string rhs = "ipsum";
+
+    string_view lhs_view( lhs.begin(), lhs.end() );
+    string_view rhs_view( rhs.begin(), rhs.end() );
+
+    BOOST_CHECK_EQUAL( total, lhs_view + ws + rhs_view );
+    BOOST_CHECK_EQUAL( lhs + ws, lhs_view + ws );
+    BOOST_CHECK_EQUAL( ws + rhs, ws + rhs_view );
+}


### PR DESCRIPTION
Depends on https://github.com/OPM/opm-parser/pull/705

This patch set addresses some of the performance shortcomings and inefficiencies in opm-parsers, mostly tracked down using valgrind (callgrind). Each individual commit addresses some specific aspect. A short summary:

* string_view is a std::string interface compatible (not completely, but on a by-need basis) view into a (sub)string to avoid copying too many strings.
* boost algorithms have been replaced by faster hand-rolled (locale-ignoring) versions.
* some containers take size hints and preallocates memory.
* some algorithmic improvements and heuristics applied.