### PR TITLE
Add new keyword TLPMIXPA

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -280,6 +280,7 @@ EclipseState/Tables/SorwmisTable.hpp
 EclipseState/Tables/SgcwmisTable.hpp
 EclipseState/Tables/MiscTable.hpp
 EclipseState/Tables/PmiscTable.hpp
+EclipseState/Tables/TlpmixpaTable.hpp
 EclipseState/Tables/MsfnTable.hpp
 EclipseState/Tables/TableColumn.hpp
 EclipseState/Tables/ColumnSchema.hpp

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -45,6 +45,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PmiscTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
@@ -204,6 +205,7 @@ namespace Opm {
             addTables( "SGCWMIS", numMiscibleTables);
             addTables( "MISC", numMiscibleTables);
             addTables( "PMISC", numMiscibleTables);
+            addTables( "TLPMIXPA", numMiscibleTables);
         }
 
         {
@@ -271,6 +273,7 @@ namespace Opm {
             initSimpleTableContainer<SgcwmisTable>(deck, "SGCWMIS", numMiscibleTables);
             initSimpleTableContainer<MiscTable>(deck, "MISC", numMiscibleTables);
             initSimpleTableContainer<PmiscTable>(deck, "PMISC", numMiscibleTables);
+            initSimpleTableContainer<TlpmixpaTable>(deck, "TLPMIXPA", numMiscibleTables);
 
         }
 
@@ -649,6 +652,9 @@ namespace Opm {
     }
     const TableContainer& TableManager::getSorwmisTables() const {
         return getTables("SORWMIS");
+    }
+    const TableContainer& TableManager::getTlpmixpaTables() const {
+        return getTables("TLPMIXPA");
     }
 
     const std::map<int, VFPProdTable>& TableManager::getVFPProdTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -94,6 +94,7 @@ namespace Opm {
         const TableContainer& getMiscTables() const;
         const TableContainer& getPmiscTables() const;
         const TableContainer& getMsfnTables() const;
+        const TableContainer& getTlpmixpaTables() const;
 
 
         const std::vector<PvtgTable>& getPvtgTables() const;

--- a/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -44,6 +44,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/PlyshlogTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PlyviscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PmiscTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdgTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PvdsTable.hpp>
@@ -1040,6 +1041,22 @@ const TableColumn& PmiscTable::getOilPhasePressureColumn() const {
 }
 
 const TableColumn& PmiscTable::getMiscibilityColumn() const {
+    return SimpleTable::getColumn(1);
+}
+
+TlpmixpaTable::TlpmixpaTable( const DeckItem& item ) {
+    m_schema = std::make_shared< TableSchema >();
+
+    m_schema->addColumn( ColumnSchema( "OilPhasePressure" , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE) );
+    m_schema->addColumn( ColumnSchema( "Miscibility" , Table::INCREASING , Table::DEFAULT_NONE) );
+    SimpleTable::init( item );
+}
+
+const TableColumn& TlpmixpaTable::getOilPhasePressureColumn() const {
+    return SimpleTable::getColumn(0);
+}
+
+const TableColumn& TlpmixpaTable::getMiscibilityColumn() const {
     return SimpleTable::getColumn(1);
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/TlpmixpaTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TlpmixpaTable.hpp
@@ -1,0 +1,39 @@
+/*
+  Copyright (C) 2015 Statoil ASA.
+  2016 IRIS AS
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_TLPMIXPA_TABLE_HPP
+#define	OPM_PARSER_TLPMIXPA_TABLE_HPP
+
+#include "SimpleTable.hpp"
+
+namespace Opm {
+
+    class DeckItem;
+
+    class TlpmixpaTable : public SimpleTable {
+    public:
+        TlpmixpaTable( const DeckItem& item );
+
+        const TableColumn& getOilPhasePressureColumn() const;
+        const TableColumn& getMiscibilityColumn() const;
+
+    };
+}
+
+#endif

--- a/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
@@ -37,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/MiscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/PmiscTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/MsfnTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TlpmixpaTable.hpp>
 
 using namespace Opm;
 
@@ -249,3 +250,24 @@ BOOST_CHECK_EQUAL(0.3, msfnTable2.getGasSolventRelpermMultiplierColumn()[1]);
 BOOST_CHECK_EQUAL(0.7, msfnTable2.getOilRelpermMultiplierColumn()[1]);
 }
 
+const char *tlpmixpa = "\n\
+MISCIBLE\n\
+1  3 /\n\
+\n\
+TLPMIXPA\n\
+100 0.0 \n\
+200 0.5 \n\
+500 1.0 /\n\
+\n";
+
+BOOST_AUTO_TEST_CASE(PARSE_TLPMIXPA)
+{
+    ParserPtr parser(new Parser());
+
+    // test table input
+    DeckPtr deck =  parser->parseString(tlpmixpa, ParseMode());
+    Opm::TlpmixpaTable tlpmixpaTable(deck->getKeyword("TLPMIXPA").getRecord(0).getItem(0));
+    BOOST_CHECK_EQUAL(3U, tlpmixpaTable.getOilPhasePressureColumn().size());
+    BOOST_CHECK_EQUAL(200*1e5, tlpmixpaTable.getOilPhasePressureColumn()[1]);
+    BOOST_CHECK_EQUAL(0.5, tlpmixpaTable.getMiscibilityColumn()[1]);
+}

--- a/opm/parser/share/keywords/900_OPM/T/TLPMIXPA
+++ b/opm/parser/share/keywords/900_OPM/T/TLPMIXPA
@@ -1,0 +1,5 @@
+{"name" : "TLPMIXPA" , "sections" : ["PROPS"], "size" : {"keyword" : "MISCIBLE" , "item" : "NTMISC"},
+        "items" : [
+            {"name":"DATA", "value_type":"DOUBLE", "size_type" : "ALL" , "dimension" : ["Pressure","1"]}
+         ]
+}


### PR DESCRIPTION
The TLPMIXPA keyword can be used for giving pressure depended Todd-
Longstaff parameters. The implementation follows the description of
PMISC.