### PR TITLE
EclipseState: remove deprecated has{Int,Double}GridProperty() methods

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -81,11 +81,6 @@ namespace Opm {
         bool hasDeckIntGridProperty(const std::string& keyword) const;
         bool hasDeckDoubleGridProperty(const std::string& keyword) const;
 
-        bool hasIntGridProperty(const std::string& keyword) const __attribute__((deprecated("use hasDeckIntGridProperty() instead")))
-        { return hasDeckIntGridProperty(keyword); }
-        bool hasDoubleGridProperty(const std::string& keyword) const __attribute__((deprecated("use hasDeckDoubleGridProperty() instead")))
-        { return hasDeckDoubleGridProperty(keyword); }
-
         void loadGridPropertyFromDeckKeyword(std::shared_ptr<const Box> inputBox,
                                              const DeckKeyword& deckKeyword,
                                              int enabledTypes = AllProperties);


### PR DESCRIPTION
these methods have been renamed to hasDeck{Int,Double}GridProperty().
my reason why I kept the deprecated names initially was to avoid a
"hard" break for the downstream OPM modules. since all of these
modules have since been adapted to use the new names, there's IMO no
reason to keep the deprecated methods.

(Note that since we currently do *not* keep compatibility between
releases, the deprecated has*GridProperty() methods can be removed
immediately instead of waiting until after the next release.)