### PR TITLE
simply replace throw with OpmLog functions.

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -24,6 +24,7 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 
 namespace Opm {
 
@@ -44,21 +45,21 @@ namespace Opm {
 
     const DeckKeyword& DeckView::getKeyword( const std::string& keyword, size_t index ) const {
         if( !this->hasKeyword( keyword ) )
-            throw std::invalid_argument("Keyword " + keyword + " not in deck.");
+            OpmLog::error("Keyword " + keyword + " not in deck.");
 
         return this->getKeyword( this->offsets( keyword ).at( index ) );
     }
 
     const DeckKeyword& DeckView::getKeyword( const std::string& keyword ) const {
         if( !this->hasKeyword( keyword ) )
-            throw std::invalid_argument("Keyword " + keyword + " not in deck.");
+            OpmLog::error("Keyword " + keyword + " not in deck.");
 
         return this->getKeyword( this->offsets( keyword ).back() );
     }
 
     const DeckKeyword& DeckView::getKeyword( size_t index ) const {
         if( index >= this->size() )
-            throw std::out_of_range("Keyword index " + std::to_string( index ) + " is out of range.");
+            OpmLog::debug("Keyword index " + std::to_string( index ) + " is out of range.");
 
         return *( this->begin() + index );
     }

--- a/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -19,6 +19,7 @@
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 
 #include <boost/algorithm/string.hpp>
 
@@ -110,7 +111,7 @@ namespace Opm {
     template< typename T >
     void DeckTypeItem< T >::push_back( T x ) {
         if( this->dataPointDefaulted.size() != this->data.size() )
-            throw std::logic_error("To add a value to an item, no \"pseudo defaults\" can be added before");
+            OpmLog::debug("To add a value to an item, no \"pseudo defaults\" can be added before");
 
         this->data.push_back( x );
         this->dataPointDefaulted.push_back( false );
@@ -119,7 +120,7 @@ namespace Opm {
     template< typename T >
     void DeckTypeItem< T >::push_backDefault( T data_arg ) {
         if( this->dataPointDefaulted.size() != this->data.size() )
-            throw std::logic_error("To add a value to an item, no \"pseudo defaults\" can be added before");
+            OpmLog::debug("To add a value to an item, no \"pseudo defaults\" can be added before");
 
         this->data.push_back( data_arg );
         this->dataPointDefaulted.push_back(true);
@@ -128,7 +129,7 @@ namespace Opm {
     template< typename T >
     void DeckTypeItem< T >::push_backDummyDefault() {
         if( this->dataPointDefaulted.size() != 0 )
-            throw std::logic_error("Pseudo defaults can only be specified for empty items");
+            OpmLog::debug("Pseudo defaults can only be specified for empty items");
 
         this->dataPointDefaulted.push_back( true );
     }
@@ -136,7 +137,7 @@ namespace Opm {
     template< typename T >
     void DeckTypeItem< T >::push_back( T x, size_t numValues ) {
         if( this->dataPointDefaulted.size() != this->data.size() )
-            throw std::logic_error("To add a value to an item, no \"pseudo defaults\" can be added before");
+            OpmLog::debug("To add a value to an item, no \"pseudo defaults\" can be added before");
 
         this->data.insert( this->data.end(), numValues, x );
         this->dataPointDefaulted.insert( this->dataPointDefaulted.end(), numValues, false );
@@ -181,7 +182,7 @@ namespace Opm {
 
     const std::vector< double >& DeckItemT< double >::assertSIData() const {
         if( this->dimensions.size() <= 0 )
-            throw std::invalid_argument("No dimension has been set for item:" + this->name() + " can not ask for SI data");
+            OpmLog::debug("No dimension has been set for item:" + this->name() + " can not ask for SI data");
 
         // we already converted this item to SI?
         if( this->SIdata.size() > 0 ) return this->SIdata;
@@ -246,7 +247,7 @@ namespace Opm {
         if( auto* d = dynamic_cast< DeckItemT< T >* >( ptr.get() ) )
             return d;
 
-        throw std::logic_error(
+        OpmLog::debug(
                 "Treating item " + ptr->name()
                 + " as " + typename_string< T >()
                 + ", but is "
@@ -259,7 +260,7 @@ namespace Opm {
         if( auto* d = dynamic_cast< const DeckItemT< T >* >( ptr.get() ) )
             return d;
 
-        throw std::logic_error(
+        OpmLog::debug(
                 "Treating item " + ptr->name()
                 + " as " + typename_string< T >()
                 + ", but is "

--- a/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -20,6 +20,7 @@
 #include "DeckKeyword.hpp"
 #include "DeckRecord.hpp"
 #include "DeckItem.hpp"
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 
 namespace Opm {
 
@@ -97,7 +98,7 @@ namespace Opm {
         if (m_recordList.size() == 1)
             return getRecord(0);
         else
-            throw std::range_error("Not a data keyword ?");
+            OpmLog::debug("Not a data keyword ?");
     }
 
 

--- a/opm/parser/eclipse/Deck/DeckRecord.cpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.cpp
@@ -24,6 +24,7 @@
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 
 
 namespace Opm {
@@ -35,7 +36,7 @@ namespace Opm {
 
     void DeckRecord::addItem( DeckItem&& deckItem ) {
         if( this->hasItem( deckItem.name() ) )
-            throw std::invalid_argument(
+            OpmLog::debug(
                     "Item with name: "
                     + deckItem.name()
                     + " already exists in DeckRecord");
@@ -55,7 +56,7 @@ namespace Opm {
         auto item = std::find_if( m_items.begin(), m_items.end(), eq );
 
         if( item == m_items.end() )
-            throw std::invalid_argument("Item: " + name + " does not exist.");
+            OpmLog::debug("Item: " + name + " does not exist.");
 
         return *item;
     }
@@ -64,7 +65,7 @@ namespace Opm {
         if (m_items.size() == 1)
             return getItem(0);
         else
-            throw std::range_error("Not a data keyword ?");
+            OpmLog::debug("Not a data keyword ?");
     }
 
     const DeckItem& DeckRecord::getItem( size_t index ) const {
@@ -79,7 +80,7 @@ namespace Opm {
         auto item = std::find_if( this->begin(), this->end(), eq );
 
         if( item == m_items.end() )
-            throw std::invalid_argument("Item: " + name + " does not exist.");
+            OpmLog::debug("Item: " + name + " does not exist.");
 
         return *item;
     }
@@ -88,7 +89,7 @@ namespace Opm {
         if (m_items.size() == 1)
             return getItem(0);
         else
-            throw std::range_error("Not a data keyword ?");
+            OpmLog::debug("Not a data keyword ?");
     }
 
     bool DeckRecord::hasItem(const std::string& name) const {

--- a/opm/parser/eclipse/Deck/SCHEDULESection.cpp
+++ b/opm/parser/eclipse/Deck/SCHEDULESection.cpp
@@ -23,6 +23,7 @@
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/Deck/DeckTimeStep.hpp>
 #include <opm/parser/eclipse/Deck/SCHEDULESection.hpp>
+#include <opm/parser/eclipse/OpmLog/OpmLog.hpp>
 
 namespace Opm {
 
@@ -37,7 +38,7 @@ namespace Opm {
         if (timestep < m_decktimesteps.size()) {
             return m_decktimesteps[timestep];
         } else {
-            throw std::out_of_range("No DeckTimeStep in ScheduleSection for timestep " + std::to_string(timestep));
+            OpmLog::error("No DeckTimeStep in ScheduleSection for timestep " + std::to_string(timestep));
         }
     }
 

--- a/opm/parser/eclipse/Deck/Section.cpp
+++ b/opm/parser/eclipse/Deck/Section.cpp
@@ -53,12 +53,12 @@ namespace Opm {
 
         auto first = std::find_if( deck.begin(), deck.end(), fn );
         if( first == deck.end() )
-            throw std::invalid_argument( std::string( "Deck requires a '" ) + keyword + "' section" );
+            OpmLog::error( std::string( "Deck requires a '" ) + keyword + "' section" );
 
         auto last = std::find_if( first + 1, deck.end(), &isSectionDelimiter );
 
         if( last != deck.end() && last->name() == keyword )
-            throw std::invalid_argument( std::string( "Deck contains the '" ) + keyword + "' section multiple times" );
+            OpmLog::error( std::string( "Deck contains the '" ) + keyword + "' section multiple times" );
 
         return { first, last };
     }


### PR DESCRIPTION
This PR is the first attempt to  replace throw with OpmLog functions, starts from Deck folder.
In principle, all the ``throw`` need to be replaced, due to different error type, they will be replaced with different OpmLog functions, such as error and debug. There is no clear rule to distinguish the category, but the simple rule is if the messages caused by user (Input deck), that will be an error ,warning, if it caused by the developer(such as missing parameter, wrong function names), that will be debug. 

Any comments are welcome!