### PR TITLE
Initialisation and memory errors fixed

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -70,7 +70,7 @@ namespace Opm {
    }
 
     const std::vector< const DeckKeyword* > DeckView::getKeywordList( const std::string& keyword ) const {
-        if( !hasKeyword( keyword ) ) {};
+        if( !hasKeyword( keyword ) ) return {};
 
         const auto& indices = this->offsets( keyword );
 
@@ -120,6 +120,10 @@ namespace Opm {
         DeckView( limits.first, limits.second )
     {}
 
+    Deck::Deck() : Deck( std::vector< DeckKeyword >() ) {}
+    Deck::Deck( std::vector< DeckKeyword >&& x ) : DeckView( x.begin(), x.end() ),
+                                                   keywordList( std::move( x ) ) {}
+
     void Deck::addKeyword( DeckKeyword&& keyword ) {
         this->keywordList.push_back( std::move( keyword ) );
 
@@ -147,10 +151,12 @@ namespace Opm {
     }
 
     UnitSystem& Deck::getDefaultUnitSystem() const {
+        if( !this->defaultUnits ) const_cast< Deck* >( this )->initUnitSystem();
         return *this->defaultUnits;
     }
 
     UnitSystem& Deck::getActiveUnitSystem() const {
+        if( !this->activeUnits ) const_cast< Deck* >( this )->initUnitSystem();
         return *this->activeUnits;
     }
 

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -78,7 +78,6 @@ namespace Opm {
 
             const std::vector< size_t >& offsets( const std::string& ) const;
 
-            DeckView() = default;
             DeckView( const_iterator first, const_iterator last );
             DeckView( std::pair< const_iterator, const_iterator > );
 
@@ -100,6 +99,7 @@ namespace Opm {
             using DeckView::begin;
             using DeckView::end;
 
+            Deck();
             void addKeyword( DeckKeyword&& keyword );
             void addKeyword( const DeckKeyword& keyword );
 
@@ -110,6 +110,8 @@ namespace Opm {
             UnitSystem& getActiveUnitSystem()  const;
 
         private:
+            Deck( std::vector< DeckKeyword >&& );
+
             std::vector< DeckKeyword > keywordList;
             std::unique_ptr< UnitSystem > activeUnits;
             std::unique_ptr< UnitSystem > defaultUnits;

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -324,30 +324,6 @@ const ParserKeyword* Parser::getKeyword(const std::string& name ) const {
         return iter->second;
 }
 
-
-bool Parser::dropParserKeyword(const std::string& parserKeywordName) {
-    // remove from the internal from the internal names
-    bool erase = (m_internalParserKeywords.erase( parserKeywordName ) > 0);
-
-    // remove keyword from the deck names map
-    auto deckParserKeywordIt = m_deckParserKeywords.begin();
-    while (deckParserKeywordIt != m_deckParserKeywords.end()) {
-        if (deckParserKeywordIt->second->getName() == parserKeywordName)
-            // note the post-increment of the iterator. this is required to keep the
-            // iterator valid for while at the same time erasing it...
-            m_deckParserKeywords.erase(deckParserKeywordIt++);
-        else
-            ++ deckParserKeywordIt;
-    }
-
-    // remove the keyword from the wildcard list
-    m_wildCardKeywords.erase( parserKeywordName );
-
-    return erase;
-}
-
-
-
 const ParserKeyword* Parser::getParserKeywordFromDeckName(const std::string& deckKeywordName) const {
     if (m_deckParserKeywords.count(deckKeywordName)) {
         return m_deckParserKeywords.at(deckKeywordName);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -70,7 +70,6 @@ namespace Opm {
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(const Json::JsonObject& jsonKeyword);
         void addParserKeyword(std::unique_ptr< const ParserKeyword >&& parserKeyword);
-        bool dropParserKeyword(const std::string& parserKeywordName);
         const ParserKeyword* getKeyword(const std::string& name) const;
 
         bool isRecognizedKeyword( const std::string& deckKeywordName) const;

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -243,27 +243,11 @@ BOOST_AUTO_TEST_CASE(loadConfigFromDirectory_default) {
         BOOST_CHECK_EQUAL(true , parser->isRecognizedKeyword("DIMENS"));
 }
 
-
-BOOST_AUTO_TEST_CASE(DropKeyword) {
-    ParserPtr parser(new Parser());
-    BOOST_CHECK_EQUAL(false , parser->dropParserKeyword("DoesNotHaveThis"));
-    BOOST_CHECK_EQUAL(true , parser->isRecognizedKeyword("BPR"));
-    BOOST_CHECK_EQUAL(true  , parser->dropParserKeyword("BLOCK_PROBE"));
-    BOOST_CHECK_EQUAL(false  , parser->dropParserKeyword("BLOCK_PROBE"));
-    BOOST_CHECK_EQUAL(false , parser->isRecognizedKeyword("BPR"));
-
-    BOOST_CHECK_EQUAL(true , parser->isRecognizedKeyword("TVDPX"));
-    BOOST_CHECK_EQUAL(true , parser->dropParserKeyword("TVDP"));
-    BOOST_CHECK_EQUAL(false , parser->isRecognizedKeyword("TVDPX"));
-}
-
-
 BOOST_AUTO_TEST_CASE(ReplaceKeyword) {
     ParserPtr parser(new Parser());
     const auto* eqldims = parser->getParserKeywordFromDeckName("EQLDIMS");
 
     BOOST_CHECK( parser->loadKeywordFromFile( "testdata/parser/EQLDIMS2" ) );
-
 
     eqldims = parser->getParserKeywordFromDeckName("EQLDIMS");
     auto record = eqldims->getRecord(0);

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -56,6 +56,7 @@ namespace Opm {
 
             inline char operator[]( size_t ) const;
 
+            inline bool empty() const;
             inline size_t size() const;
             inline size_t length() const;
 
@@ -156,6 +157,10 @@ namespace Opm {
 
     inline char string_view::operator[]( size_t i ) const {
         return *(this->begin() + i);
+    }
+
+    inline bool string_view::empty() const {
+        return std::distance( this->begin(), this->end() ) == 0;
     }
 
     inline size_t string_view::size() const {


### PR DESCRIPTION
Fixes a set of flaws and vulnerabilities.

Summary:
* Default constructed Decks now have valid (albeit trivial) iterators, meaning they no longer invoker undefined behaviour under testing. (Thanks for the report!)
* Removes a buggy and unused method
* Fixes a potential buffer overflow vulnerability by checking input sizes. integer buffer size is determined from platform int size, whereas double uses a heuristic.

Testing very much welcome.