### PR TITLE
Query the name of (FIP) regions in State

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -17,6 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <set>
+
 #include <boost/algorithm/string/join.hpp>
 
 #include <opm/common/OpmLog/OpmLog.hpp>
@@ -242,6 +244,18 @@ namespace Opm {
 
         m_transMult->setMultregtScanner( scanner );
     }
+
+    std::vector< int > EclipseState::getRegions( const std::string& kw ) const {
+        if( !this->get3DProperties().hasDeckIntGridProperty( kw ) ) return {};
+
+        const auto& property = this->get3DProperties().getIntGridProperty( kw );
+
+        std::set< int > regions( property.getData().begin(),
+                                 property.getData().end() );
+
+        return { regions.begin(), regions.end() };
+    }
+
 
     void EclipseState::complainAboutAmbiguousKeyword(DeckConstPtr deck, const std::string& keywordName) const {
         OpmLog::addMessage(Log::MessageType::Error, "The " + keywordName + " keyword must be unique in the deck. Ignoring all!");

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -20,9 +20,10 @@
 #ifndef OPM_ECLIPSE_STATE_HPP
 #define OPM_ECLIPSE_STATE_HPP
 
-#include <utility>
 #include <memory>
 #include <set>
+#include <utility>
+#include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
@@ -88,9 +89,11 @@ namespace Opm {
 
         const TableManager& getTableManager() const;
 
-        // the unit system used by the deck. note that it is rarely needed to
-        // convert units because internally to opm-parser everything is
-        // represented by SI units...
+        std::vector< int > getRegions( const std::string& kw ) const;
+
+        // the unit system used by the deck. note that it is rarely needed to convert
+        // units because internally to opm-parser everything is represented by SI
+        // units...
         const UnitSystem& getDeckUnitSystem()  const;
         void applyModifierDeck( std::shared_ptr<const Deck> deck);
 

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -580,3 +580,31 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
         BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(0));
     }
 }
+
+BOOST_AUTO_TEST_CASE(getRegions) {
+    const char* input =
+            "START             -- 0 \n"
+            "10 MAI 2007 / \n"
+            "RUNSPEC\n"
+            "\n"
+            "DIMENS\n"
+            " 2 2 1 /\n"
+            "GRID\n"
+            "DXV \n 2*400 /\n"
+            "DYV \n 2*400 /\n"
+            "DZV \n 1*400 /\n"
+            "REGIONS\n"
+            "FIPNUM\n"
+            "1 1 2 3 /\n";
+
+    const auto deck = Parser().parseString(input, ParseContext());
+    EclipseState es( deck, ParseContext() );
+
+    std::vector< int > ref = { 1, 2, 3 };
+    const auto regions = es.getRegions( "FIPNUM" );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS( ref.begin(), ref.end(),
+                                   regions.begin(), regions.end() );
+
+    BOOST_CHECK( es.getRegions( "EQLNUM" ).empty() );
+}


### PR DESCRIPTION
Enable support for querying what fluid-in-point regions are defined in
the deck. For now the only interesting regions are the ones specified by
the FIPNUM keyword in the REGIONS section.

The implementation is somewhat inefficient (n log n over the number of
cells in the grid), but since this is likely to only be called when
default-expanding SUMMARY section keywords this isn't too bad, since the
implementation is so dead simple. 

--

This still need some good test cases before I'm comfortable merging it. I'm also not sure if this belongs directly onto the EclipseState or if it is a grid property. Opinions very welcome.