### PR TITLE
Allow 'WAT' when parsing type string in WCONINJE.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.cpp
@@ -385,6 +385,8 @@ namespace Opm {
                 return OIL;
             else if (stringValue == "WATER")
                 return WATER;
+            else if (stringValue == "WAT")
+                return WATER;
             else if (stringValue == "GAS")
                 return GAS;
             else if (stringValue == "MULTI")

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleEnumTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleEnumTests.cpp
@@ -271,6 +271,7 @@ BOOST_AUTO_TEST_CASE(TestInjectorEnumFromString) {
     BOOST_CHECK_THROW( WellInjector::TypeFromString("XXX") , std::invalid_argument );
     BOOST_CHECK_EQUAL( WellInjector::OIL   , WellInjector::TypeFromString("OIL"));
     BOOST_CHECK_EQUAL( WellInjector::WATER , WellInjector::TypeFromString("WATER"));
+    BOOST_CHECK_EQUAL( WellInjector::WATER , WellInjector::TypeFromString("WAT"));
     BOOST_CHECK_EQUAL( WellInjector::GAS   , WellInjector::TypeFromString("GAS"));
     BOOST_CHECK_EQUAL( WellInjector::MULTI , WellInjector::TypeFromString("MULTI"));
 }


### PR DESCRIPTION
Should fix: https://github.com/OPM/opm-parser/issues/722