### PR TITLE
Changes in travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ install:
     - git clone https://github.com/OPM/opm-common.git
     - git clone https://github.com/OPM/opm-data.git
 
-    - opm-common/travis/build-opm-common.sh
+    - opm-common/travis/build-opm-common-shared.sh
     - opm-parser/travis/clone-and-build-ert.sh
 
 script: opm-parser/travis/build-and-test-opm-parser.sh

--- a/travis/build-opm-parser.sh
+++ b/travis/build-opm-parser.sh
@@ -5,6 +5,6 @@ pushd . > /dev/null
 cd opm-parser
 mkdir build
 cd build
-cmake -DENABLE_PYTHON=ON -DBUILD_TESTING=OFF ../
+cmake -DBUILD_TESTING=OFF ../
 make
 popd > /dev/null


### PR DESCRIPTION
 1. The build-opm-parser.sh script - which is used by downstream
    modules, does not build the Python bindings.

 2. The main travis script uses the build-shared script from opm-common.