### PR TITLE
Added clang support to Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: cpp
 
-compiler:
-  - gcc
+matrix:
+  fast_finish: true
+  include:
+    - os: osx
+      osx_image: xcode7.3
+      compiler: clang
+    - os: linux
+      compiler: gcc
 
 addons:
   apt:
@@ -14,9 +20,11 @@ addons:
       - g++-4.8
       - gfortran-4.8
       - liblapack-dev
+      - clang
 
 install:
-    - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
+    - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"; fi
+
     - cd ..
 
     - git clone https://github.com/OPM/opm-common.git


### PR DESCRIPTION
Travis will now build OPM/Parser on OSX with clang in addition to Linux with GCC