### PR TITLE
RawKeyword iterator support and correct RawRecord management

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -363,8 +363,7 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
                     break;
                 }
                 else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::paths) {
-                    for (size_t i = 0; i < parserState->rawKeyword->size(); i++) {
-                            auto& record = parserState->rawKeyword->getRecord(i);
+                    for( const auto& record : *parserState->rawKeyword ) {
                             std::string pathName = readValueToken<std::string>(record.getItem(0));
                             std::string pathValue = readValueToken<std::string>(record.getItem(1));
                             parserState->pathMap->insert(std::pair<std::string, std::string>(pathName, pathValue));

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -107,7 +107,7 @@ namespace Opm {
 
 
     RawRecord& RawKeyword::getRecord(size_t index) {
-        return this->m_records.at( index );
+        return *std::next( this->m_records.begin(), index );
     }
 
     bool RawKeyword::isKeywordPrefix(const std::string& line, std::string& keywordName) {

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -107,6 +107,12 @@ namespace Opm {
 
 
     RawRecord& RawKeyword::getRecord(size_t index) {
+        if( index >= this->m_records.size() )
+            throw std::out_of_range(
+                "Error: looking up record " + std::to_string( index )
+                + ", but RawKeyword has only "
+                + std::to_string( this->m_records.size() ) + " records." );
+
         return *std::next( this->m_records.begin(), index );
     }
 
@@ -158,6 +164,13 @@ namespace Opm {
         return m_lineNR;
     }
 
+    RawKeyword::const_iterator RawKeyword::begin() const {
+        return this->m_records.begin();
+    }
+
+    RawKeyword::const_iterator RawKeyword::end() const {
+        return this->m_records.end();
+    }
 
     Raw::KeywordSizeEnum RawKeyword::getSizeType() const {
         return m_sizeType;

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -57,6 +57,10 @@ namespace Opm {
         const std::string& getFilename() const;
         size_t getLineNR() const;
 
+        using const_iterator = std::list< RawRecord >::const_iterator;
+
+        const_iterator begin() const;
+        const_iterator end() const;
 
     private:
         Raw::KeywordSizeEnum m_sizeType;

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -23,6 +23,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <list>
 
 #include <opm/parser/eclipse/RawDeck/RawEnums.hpp>
 
@@ -64,7 +65,7 @@ namespace Opm {
         size_t m_numTables;
         size_t m_currentNumTables;
         std::string m_name;
-        std::vector< RawRecord > m_records;
+        std::list< RawRecord > m_records;
         std::string m_partialRecordString;
 
         size_t m_lineNR;


### PR DESCRIPTION
Removes some undefined behaviour introduced by iterator invalidation (string_view's) caused by reallocation of the `m_records` vector.

The quick solution has been to replace `std::vector` with `std::list`. Performance-wise this takes us back to square one, but we're no worse off than we were storing a vector of `std::shared_ptr`.

Additionally, iterators have been introduced on `RawKeyword`, since expected use of `RawKeyword` is to facilitate iteration over `RawRecords`.