### PR TITLE
Replace opmLog in ParseContext with MessageContainer.

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -105,7 +105,7 @@ namespace Opm {
     }
 
 
-    EclipseState::EclipseState(DeckConstPtr deck , const ParseContext& parseContext)
+    EclipseState::EclipseState(DeckConstPtr deck , ParseContext& parseContext)
         : m_deckUnitSystem( deck->getActiveUnitSystem() ),
           m_defaultRegion("FLUXNUM"),
           m_parseContext( parseContext )

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -60,7 +60,7 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
-        EclipseState(std::shared_ptr< const Deck > deck , const ParseContext& parseContext);
+        EclipseState(std::shared_ptr< const Deck > deck , ParseContext& parseContext);
 
         const ParseContext& getParseContext() const;
         std::shared_ptr< const Schedule > getSchedule() const;
@@ -168,7 +168,7 @@ namespace Opm {
         std::shared_ptr<FaultCollection> m_faults;
         std::shared_ptr<NNC> m_nnc;
         std::string m_defaultRegion;
-        const ParseContext& m_parseContext;
+        ParseContext& m_parseContext;
     };
 
     typedef std::shared_ptr<EclipseState> EclipseStatePtr;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/ADDREGTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/ADDREGTests.cpp
@@ -54,7 +54,8 @@ static Opm::DeckPtr createDeckInvalidArray() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -72,7 +73,8 @@ static Opm::DeckPtr createDeckInvalidRegion() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -92,7 +94,8 @@ static Opm::DeckPtr createDeckInvalidValue() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -113,7 +116,8 @@ static Opm::DeckPtr createDeckUnInitializedRegion() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -134,7 +138,8 @@ static Opm::DeckPtr createDeckUnInitializedVector() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -166,7 +171,8 @@ static Opm::DeckPtr createValidIntDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -206,7 +212,8 @@ static Opm::DeckPtr createValidPERMXDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -217,38 +224,44 @@ static Opm::DeckPtr createValidPERMXDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::DeckPtr deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::DeckPtr deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedRegionThrows) {
     Opm::DeckPtr deck = createDeckUnInitializedRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitializedVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::DeckPtr deck = createValidIntDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
     std::shared_ptr<const Opm::GridProperty<int> > property = state.getIntGridProperty( "SATNUM");
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {
@@ -263,7 +276,8 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
 
 BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::DeckPtr deck = createValidPERMXDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
     std::shared_ptr<const Opm::GridProperty<double> > permx = state.getDoubleGridProperty( "PERMX");
 
     for (size_t j=0; j< 5; j++)

--- a/opm/parser/eclipse/EclipseState/Grid/tests/CopyRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/CopyRegTests.cpp
@@ -55,7 +55,8 @@ static Opm::DeckPtr createDeckInvalidArray1() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 static Opm::DeckPtr createDeckInvalidArray2() {
@@ -74,7 +75,8 @@ static Opm::DeckPtr createDeckInvalidArray2() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -94,7 +96,8 @@ static Opm::DeckPtr createDeckInvalidTypeMismatch() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -115,7 +118,8 @@ static Opm::DeckPtr createDeckInvalidRegion() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -136,7 +140,8 @@ static Opm::DeckPtr createDeckUnInitialized() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -165,7 +170,8 @@ static Opm::DeckPtr createValidIntDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -173,19 +179,22 @@ static Opm::DeckPtr createValidIntDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows1) {
     Opm::DeckPtr deck = createDeckInvalidArray1();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows2) {
     Opm::DeckPtr deck = createDeckInvalidArray2();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
@@ -193,20 +202,23 @@ BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(TypeMismatchThrows) {
     Opm::DeckPtr deck = createDeckInvalidTypeMismatch();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::DeckPtr deck = createValidIntDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext() );
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
     std::shared_ptr<const Opm::GridProperty<int> > property = state.getIntGridProperty( "FLUXNUM");
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -62,7 +62,8 @@ static Opm::DeckPtr createDeckHeaders() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -75,7 +76,8 @@ static Opm::DeckPtr createDeckMissingDIMS() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 BOOST_AUTO_TEST_CASE(MissingDimsThrows) {
@@ -119,7 +121,8 @@ static Opm::DeckPtr createCPDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -142,7 +145,8 @@ static Opm::DeckPtr createPinchedCPDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -167,7 +171,8 @@ static Opm::DeckPtr createMinpvDefaultCPDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -190,7 +195,8 @@ static Opm::DeckPtr createMinpvCPDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -214,7 +220,8 @@ static Opm::DeckPtr createMinpvFilCPDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -237,7 +244,8 @@ static Opm::DeckPtr createCARTDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -260,7 +268,8 @@ static Opm::DeckPtr createCARTDeckDEPTHZ() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -281,7 +290,8 @@ static Opm::DeckPtr createCARTInvalidDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(CREATE_SIMPLE) {
@@ -397,7 +407,8 @@ static Opm::DeckPtr createInvalidDXYZCARTDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -427,7 +438,8 @@ static Opm::DeckPtr createInvalidDXYZCARTDeckDEPTHZ() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -458,7 +470,8 @@ static Opm::DeckPtr createOnlyTopDZCartGrid() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -481,7 +494,8 @@ static Opm::DeckPtr createInvalidDEPTHZDeck1 () {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -510,7 +524,8 @@ static Opm::DeckPtr createInvalidDEPTHZDeck2 () {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(CreateCartesianGRIDInvalidDEPTHZ2) {
@@ -562,7 +577,8 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchCOORD) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck = parser->parseString(deckData, parseContext);
     const auto& zcorn = deck->getKeyword("ZCORN");
     BOOST_CHECK_EQUAL( 8000U , zcorn.getDataSize( ));
 
@@ -587,7 +603,8 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchZCORN) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck = parser->parseString(deckData, parseContext);
     BOOST_CHECK_THROW((void)Opm::EclipseGrid(deck), std::invalid_argument);
 }
 
@@ -609,7 +626,8 @@ BOOST_AUTO_TEST_CASE(CornerPointSizeMismatchACTNUM) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck = parser->parseString(deckData, parseContext);
     BOOST_CHECK_THROW((void)Opm::EclipseGrid( deck ) , std::invalid_argument);
 }
 
@@ -630,7 +648,8 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck = parser->parseString(deckData, parseContext);
 
     Opm::EclipseGrid grid(deck);
     BOOST_CHECK_EQUAL( 1000U , grid.getNumActive());
@@ -665,7 +684,8 @@ BOOST_AUTO_TEST_CASE(Fwrite) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck = parser->parseString(deckData, parseContext);
     Opm::EclipseGrid grid1(deck );
 
     grid1.fwriteEGRID( "TEST.EGRID" , true);
@@ -694,7 +714,8 @@ BOOST_AUTO_TEST_CASE(ConstructorNORUNSPEC) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck1 = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck1 = parser->parseString(deckData, parseContext);
     Opm::DeckConstPtr deck2 = createCPDeck();
 
     Opm::EclipseGrid grid1(deck1);
@@ -718,7 +739,8 @@ BOOST_AUTO_TEST_CASE(ConstructorNoSections) {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck1 = parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck1 = parser->parseString(deckData, parseContext);
     Opm::DeckConstPtr deck2 = createCPDeck();
 
     Opm::EclipseGrid grid1(deck1);

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EqualRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EqualRegTests.cpp
@@ -53,7 +53,8 @@ static Opm::DeckPtr createDeckInvalidArray() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -71,7 +72,8 @@ static Opm::DeckPtr createDeckInvalidRegion() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -89,7 +91,8 @@ static Opm::DeckPtr createDeckInvalidValue() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -108,7 +111,8 @@ static Opm::DeckPtr createDeckUnInitialized() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -143,7 +147,8 @@ static Opm::DeckPtr createValidIntDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -185,7 +190,8 @@ static Opm::DeckPtr createValidPERMXDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -193,31 +199,36 @@ static Opm::DeckPtr createValidPERMXDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::DeckPtr deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::DeckPtr deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::DeckPtr deck = createValidIntDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
     std::shared_ptr<const Opm::GridProperty<int> > property = state.getIntGridProperty( "SATNUM");
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {
@@ -232,7 +243,8 @@ BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
 
 BOOST_AUTO_TEST_CASE(UnitAppliedCorrectly) {
     Opm::DeckPtr deck = createValidPERMXDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
     std::shared_ptr<const Opm::GridProperty<double> > permx = state.getDoubleGridProperty( "PERMX");
     std::shared_ptr<const Opm::GridProperty<double> > permy = state.getDoubleGridProperty( "PERMY");
     std::shared_ptr<const Opm::GridProperty<double> > permz = state.getDoubleGridProperty( "PERMZ");

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -48,7 +48,8 @@ static const Opm::DeckKeyword createSATNUMKeyword( ) {
     "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckPtr deck = parser->parseString(deckData, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::DeckPtr deck = parser->parseString(deckData, parseContext);
     return deck->getKeyword("SATNUM");
 }
 
@@ -59,7 +60,8 @@ static const Opm::DeckKeyword createTABDIMSKeyword( ) {
     "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckPtr deck = parser->parseString(deckData, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::DeckPtr deck = parser->parseString(deckData, parseContext);
     return deck->getKeyword("TABDIMS");
 }
 
@@ -414,14 +416,16 @@ static Opm::DeckPtr createDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(GridPropertyPostProcessors) {
     typedef Opm::GridPropertySupportedKeywordInfo<double> SupportedKeywordInfo;
 
     Opm::DeckPtr deck = createDeck();
-    Opm::EclipseState st( deck, Opm::ParseContext() ) ;
+    Opm::ParseContext parseContext;
+    Opm::EclipseState st( deck, parseContext );
     std::shared_ptr<Opm::EclipseGrid> grid = std::make_shared<Opm::EclipseGrid>(deck);
 
     SupportedKeywordInfo kwInfo1("MULTPV" , 1.0 , "1");

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
@@ -93,7 +93,8 @@ static Opm::DeckPtr createInvalidMULTREGTDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -163,7 +164,8 @@ static Opm::DeckPtr createNotSupportedMULTREGTDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -229,12 +231,14 @@ static Opm::DeckPtr createCopyMULTNUMDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
 
 BOOST_AUTO_TEST_CASE(MULTREGT_COPY_MULTNUM) {
     Opm::DeckPtr deck = createCopyMULTNUMDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
 }

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MultiRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MultiRegTests.cpp
@@ -53,7 +53,8 @@ static Opm::DeckPtr createDeckInvalidArray() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -74,7 +75,8 @@ static Opm::DeckPtr createDeckInvalidRegion() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -95,7 +97,8 @@ static Opm::DeckPtr createDeckInvalidValue() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -116,7 +119,8 @@ static Opm::DeckPtr createDeckMissingVector() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -135,7 +139,8 @@ static Opm::DeckPtr createDeckUnInitialized() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -171,7 +176,8 @@ static Opm::DeckPtr createValidIntDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -181,36 +187,42 @@ static Opm::DeckPtr createValidIntDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::DeckPtr deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::DeckPtr deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(MissingRegionVectorThrows) {
     Opm::DeckPtr deck = createDeckMissingVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( new Opm::EclipseState( deck, parseContext) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {
     Opm::DeckPtr deck = createValidIntDeck();
-    Opm::EclipseState state(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::EclipseState state(deck , parseContext);
     std::shared_ptr<const Opm::GridProperty<int> > property = state.getIntGridProperty( "SATNUM");
     for (size_t j=0; j< 5; j++)
         for (size_t i = 0; i < 5; i++) {

--- a/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
@@ -56,7 +56,8 @@ static Opm::DeckPtr createCARTDeck() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -84,7 +85,8 @@ static Opm::DeckPtr createDeckWithPORO() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -115,7 +117,8 @@ static Opm::DeckPtr createDeckWithPORVPORO() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -155,7 +158,8 @@ static Opm::DeckPtr createDeckWithMULTPV() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -187,7 +191,8 @@ static Opm::DeckPtr createDeckWithBOXPORV() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
@@ -222,13 +227,15 @@ static Opm::DeckPtr createDeckWithNTG() {
 
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(PORV_cartesianDeck) {
     /* Check that an exception is raised if we try to create a PORV field without PORO. */
     Opm::DeckPtr deck = createCARTDeck();
-    auto state = std::make_shared<Opm::EclipseState>(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck , parseContext);
     auto poro = state->getDoubleGridProperty("PORO");
     BOOST_CHECK( poro->containsNaN() );
     BOOST_CHECK_THROW( state->getDoubleGridProperty("PORV") , std::logic_error );
@@ -237,7 +244,8 @@ BOOST_AUTO_TEST_CASE(PORV_cartesianDeck) {
 BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
     /* Check that the PORV field is correctly calculated from PORO. */
     Opm::DeckPtr deck = createDeckWithPORO();
-    auto state = std::make_shared<Opm::EclipseState>(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck , parseContext);
     auto poro = state->getDoubleGridProperty("PORO");
     BOOST_CHECK( !poro->containsNaN() );
 
@@ -257,7 +265,8 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoro) {
 BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
     /* Check that explicit PORV and CellVOlume * PORO can be combined. */
     Opm::DeckPtr deck = createDeckWithPORVPORO();
-    auto state = std::make_shared<Opm::EclipseState>(deck, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck, parseContext);
     auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
@@ -274,7 +283,8 @@ BOOST_AUTO_TEST_CASE(PORV_initFromPoroWithCellVolume) {
 BOOST_AUTO_TEST_CASE(PORV_multpv) {
     /* Check that MULTPV is correctly accounted for. */
     Opm::DeckPtr deck = createDeckWithMULTPV();
-    auto state = std::make_shared<Opm::EclipseState>(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck , parseContext);
     auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
 
@@ -295,7 +305,8 @@ BOOST_AUTO_TEST_CASE(PORV_multpv) {
 BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work */
     Opm::DeckPtr deck = createDeckWithBOXPORV();
-    auto state = std::make_shared<Opm::EclipseState>(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck , parseContext);
     auto porv = state->getDoubleGridProperty("PORV");
 
     BOOST_CHECK_CLOSE( 1234.56 , porv->iget(0,0,0) , 0.001);
@@ -309,7 +320,8 @@ BOOST_AUTO_TEST_CASE(PORV_mutipleBoxAndMultpv) {
 BOOST_AUTO_TEST_CASE(PORV_multpvAndNtg) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work and NTG */
     Opm::DeckPtr deck = createDeckWithNTG();
-    auto state = std::make_shared<Opm::EclipseState>(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck , parseContext);
     auto porv = state->getDoubleGridProperty("PORV");
     double cell_volume = 0.25 * 0.25 * 0.25;
     double poro = 0.20;
@@ -336,13 +348,15 @@ static Opm::DeckPtr createDeckNakedGRID() {
         "\n";
 
     Opm::ParserPtr parser(new Opm::Parser());
-    return parser->parseString(deckData, Opm::ParseContext()) ;
+    Opm::ParseContext parseContext;
+    return parser->parseString(deckData, parseContext);
 }
 
 
 BOOST_AUTO_TEST_CASE(NAKED_GRID_THROWS) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work and NTG */
     Opm::DeckPtr deck = createDeckNakedGRID();
-    auto state = std::make_shared<Opm::EclipseState>(deck , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    auto state = std::make_shared<Opm::EclipseState>(deck , parseContext);
     BOOST_CHECK_THROW( state->getDoubleGridProperty("PORV") , std::invalid_argument );
 }

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -188,13 +188,15 @@ const std::string deckStr_RFT = "RUNSPEC\n"
 
 static DeckPtr createDeck(const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 
 BOOST_AUTO_TEST_CASE( RFT_TIME) {
     DeckPtr deck = createDeck(deckStr_RFT);
-    EclipseState state( deck , Opm::ParseContext() );
+    Opm::ParseContext parseContext;
+    EclipseState state( deck , parseContext );
     std::shared_ptr<const IOConfig> ioConfig = state.getIOConfigConst();
 
 
@@ -213,8 +215,8 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(*deck);
     ioConfigPtr->handleGridSection(gridSection);
     ioConfigPtr->handleRunspecSection(runspecSection);
-
-    Schedule schedule(ParseContext() , grid , deck, ioConfigPtr);
+    Opm::ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfigPtr);
 
     TimeMapConstPtr timemap   = schedule.getTimeMap();
     const TimeMap* const_tmap = timemap.get();

--- a/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
@@ -104,7 +104,8 @@ const std::string& deckWithEquil =
 
 static DeckPtr createDeck(const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(InitConfigTest) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -61,7 +61,7 @@
 
 namespace Opm {
 
-    Schedule::Schedule(const ParseContext& parseContext , std::shared_ptr<const EclipseGrid> grid , DeckConstPtr deck, IOConfigPtr ioConfig)
+    Schedule::Schedule(ParseContext& parseContext , std::shared_ptr<const EclipseGrid> grid , DeckConstPtr deck, IOConfigPtr ioConfig)
         : m_grid(grid)
     {
         initFromDeck(parseContext , deck, ioConfig);
@@ -71,7 +71,7 @@ namespace Opm {
         return m_timeMap->getStartTime(/*timeStepIdx=*/0);
     }
 
-    void Schedule::initFromDeck(const ParseContext& parseContext , DeckConstPtr deck, IOConfigPtr ioConfig) {
+    void Schedule::initFromDeck(ParseContext& parseContext , DeckConstPtr deck, IOConfigPtr ioConfig) {
         initializeNOSIM(deck);
         createTimeMap(deck);
         m_tuning.reset(new Tuning(m_timeMap));
@@ -113,7 +113,7 @@ namespace Opm {
         m_timeMap.reset(new TimeMap(startTime));
     }
 
-    void Schedule::iterateScheduleSection(const ParseContext& parseContext , const SCHEDULESection& section, IOConfigPtr ioConfig) {
+    void Schedule::iterateScheduleSection(ParseContext& parseContext , const SCHEDULESection& section, IOConfigPtr ioConfig) {
         /*
           geoModifiers is a list of geo modifiers which can be found in the schedule
           section. This is only partly supported, support is indicated by the bool
@@ -314,7 +314,7 @@ namespace Opm {
     }
 
 
-    void Schedule::handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
+    void Schedule::handleCOMPORD(ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
         for (const auto& record : compordKeyword) {
             const auto& methodItem = record.getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if ((methodItem.get< std::string >(0) != "TRACK")  && (methodItem.get< std::string >(0) != "INPUT")) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -54,7 +54,7 @@ namespace Opm
 
     class Schedule {
     public:
-        Schedule(const ParseContext& parseContext , std::shared_ptr<const EclipseGrid> grid , std::shared_ptr< const Deck > deck, std::shared_ptr< IOConfig > ioConfig);
+        Schedule(ParseContext& parseContext , std::shared_ptr<const EclipseGrid> grid , std::shared_ptr< const Deck > deck, std::shared_ptr< IOConfig > ioConfig);
         boost::posix_time::ptime getStartTime() const;
         std::shared_ptr< const TimeMap > getTimeMap() const;
 
@@ -98,16 +98,16 @@ namespace Opm
 
         void updateWellStatus(std::shared_ptr<Well> well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( std::shared_ptr< Group > newGroup , std::shared_ptr< Well > well , size_t timeStep);
-        void initFromDeck(const ParseContext& parseContext , std::shared_ptr< const Deck > deck, std::shared_ptr< IOConfig > ioConfig);
+        void initFromDeck(ParseContext& parseContext , std::shared_ptr< const Deck > deck, std::shared_ptr< IOConfig > ioConfig);
         void initializeNOSIM(std::shared_ptr< const Deck > deck);
         void createTimeMap(std::shared_ptr< const Deck > deck);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
         void initOilVaporization(std::shared_ptr< const TimeMap > timeMap);
-        void iterateScheduleSection(const ParseContext& parseContext ,  const SCHEDULESection&  section, std::shared_ptr< IOConfig > ioConfig);
+        void iterateScheduleSection(ParseContext& parseContext ,  const SCHEDULESection&  section, std::shared_ptr< IOConfig > ioConfig);
         bool handleGroupFromWELSPECS(const std::string& groupName, std::shared_ptr< GroupTree > newTree) const;
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, size_t timeStep, WellCompletion::CompletionOrderEnum wellCompletionOrder);
-        void handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t currentStep);
+        void handleCOMPORD(ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t currentStep);
         void checkWELSPECSConsistency(std::shared_ptr< const Well > well, const DeckKeyword& keyword, size_t recordIdx) const;
         void handleWELSPECS( const SCHEDULESection&, const DeckKeyword& keyword, size_t currentStep);
         void handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -49,6 +49,7 @@ using namespace Opm;
 
 static DeckPtr createDeck() {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
         "START\n"
         "8 MAR 1998 /\n"
@@ -56,11 +57,12 @@ static DeckPtr createDeck() {
         "SCHEDULE\n"
         "\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithWells() {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
             "START             -- 0 \n"
             "10 MAI 2007 / \n"
@@ -80,11 +82,12 @@ static DeckPtr createDeckWithWells() {
             "     \'W_3\'        \'OP\'   20   51  3.92       \'OIL\'  7* /  \n"
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckForTestingCrossFlow() {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
             "START             -- 0 \n"
             "10 MAI 2007 / \n"
@@ -145,11 +148,12 @@ static DeckPtr createDeckForTestingCrossFlow() {
             "/\n";
 
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithWellsOrdered() {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
             "START             -- 0 \n"
             "10 MAI 2007 / \n"
@@ -160,11 +164,12 @@ static DeckPtr createDeckWithWellsOrdered() {
             "     \'AW_3\'        \'OP\'   20   51  3.92       \'OIL\'  7* /  \n"
             "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithWellsAndCompletionData() {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
       "START             -- 0 \n"
       "1 NOV 1979 / \n"
@@ -194,7 +199,7 @@ static DeckPtr createDeckWithWellsAndCompletionData() {
       " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
       "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
@@ -202,7 +207,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     deck->addKeyword( DeckKeyword( "SCHEDULE" ) );
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1983  , boost::gregorian::Jan , 1)));
 }
 
@@ -210,7 +216,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     DeckPtr deck = createDeckWithWellsOrdered();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(100,100,100);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     std::vector<WellConstPtr> wells = schedule.getWells();
 
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
@@ -222,7 +229,8 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     DeckPtr deck = createDeck();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1998  , boost::gregorian::Mar , 8)));
 }
 
@@ -232,14 +240,16 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {
     deck->addKeyword( DeckKeyword( "SCHEDULE" ) );
 
     IOConfigPtr ioConfig;
-    BOOST_CHECK_NO_THROW(Schedule schedule(ParseContext() , grid , deck, ioConfig));
+    ParseContext parseContext;
+    BOOST_CHECK_NO_THROW(Schedule schedule(parseContext, grid , deck, ioConfig));
 }
 
 BOOST_AUTO_TEST_CASE(EmptyScheduleHasNoWells) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( 0U , schedule.numWells() );
     BOOST_CHECK_EQUAL( false , schedule.hasWell("WELL1") );
     BOOST_CHECK_THROW( schedule.getWell("WELL2") , std::invalid_argument );
@@ -249,7 +259,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForT
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     BOOST_CHECK_EQUAL("FIELD", schedule.getGroupTree(0)->getNode("FIELD")->name());
 }
 
@@ -275,7 +286,8 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
     auto grid = std::make_shared<const EclipseGrid>(10,10,10);
     auto deck = deckWithGRUPTREE();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     GroupTreeNodePtr fieldNode = schedule.getGroupTree(0)->getNode("FIELD");
     BOOST_CHECK_EQUAL("FIELD", fieldNode->name());
     GroupTreeNodePtr FAREN = fieldNode->getChildGroup("FAREN");
@@ -286,7 +298,8 @@ BOOST_AUTO_TEST_CASE(GetGroups) {
     auto deck = deckWithGRUPTREE();
     auto grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
 
     auto groups = schedule.getGroups();
 
@@ -305,7 +318,8 @@ BOOST_AUTO_TEST_CASE(EmptyScheduleHasFIELDGroup) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext , grid , deck, ioConfig);
     BOOST_CHECK_EQUAL( 1U , schedule.numGroups() );
     BOOST_CHECK_EQUAL( true , schedule.hasGroup("FIELD") );
     BOOST_CHECK_EQUAL( false , schedule.hasGroup("GROUP") );
@@ -316,7 +330,8 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeck();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     size_t timeStep = 0;
     std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(0U, wells_alltimesteps.size());
@@ -330,7 +345,8 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWells();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     size_t timeStep = 0;
 
     std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
@@ -345,7 +361,8 @@ BOOST_AUTO_TEST_CASE(WellsIteratorWithRegex_HasWells_WellsReturned) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWells();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     std::string wellNamePattern;
     std::vector<WellPtr> wells;
 
@@ -366,7 +383,8 @@ BOOST_AUTO_TEST_CASE(ReturnNumWellsTimestep) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWells();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(schedule.numWells(0), 1);
     BOOST_CHECK_EQUAL(schedule.numWells(1), 1);
@@ -378,7 +396,8 @@ BOOST_AUTO_TEST_CASE(ReturnMaxNumCompletionsForWellsInTimestep) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionData();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
 
     BOOST_CHECK_EQUAL(schedule.getMaxNumCompletionsForWells(1), 7);
     BOOST_CHECK_EQUAL(schedule.getMaxNumCompletionsForWells(3), 9);
@@ -388,7 +407,8 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckForTestingCrossFlow();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
 
     WellPtr well_ban = schedule.getWell("BAN");
     BOOST_CHECK_EQUAL(well_ban->getAllowCrossFlow(), false);
@@ -413,6 +433,7 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
 
 static DeckPtr createDeckWithWellsAndCompletionDataWithWELOPEN() {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
             "START             -- 0 \n"
                     "1 NOV 1979 / \n"
@@ -462,14 +483,15 @@ static DeckPtr createDeckWithWellsAndCompletionDataWithWELOPEN() {
                     " 'OP_1' SHUT 0 0 0 0 0 / \n "
                     "/\n";
 
-    return parser.parseString(input, ParseContext());
+    return parser.parseString(input, parseContext);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionDataWithWELOPEN();
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     WellPtr well;
     well = schedule.getWell("OP_1");
     size_t currentStep = 0;
@@ -586,6 +608,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1_ThrowsExcpetion) {
     Opm::Parser parser;
+    ParseContext parseContext;
     std::string input =
             "START             -- 0 \n"
                     "1 NOV 1979 / \n"
@@ -615,10 +638,10 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1_ThrowsExcpetion) {
                     "/\n";
 
 
-    DeckPtr deck = parser.parseString(input, ParseContext());
+    DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     IOConfigPtr ioConfig;
-    BOOST_CHECK_THROW(Schedule schedule(ParseContext() , grid , deck, ioConfig), std::exception);
+    BOOST_CHECK_THROW(Schedule schedule(parseContext, grid , deck, ioConfig), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1andC2_ThrowsExcpetion) {
@@ -651,11 +674,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC1andC2_ThrowsExcpetion) 
                     " 10  NOV 2008 / \n"
                     "/\n";
 
-
-    DeckPtr deck = parser.parseString(input, ParseContext());
+    ParseContext parseContext;
+    DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     IOConfigPtr ioConfig;
-    BOOST_CHECK_THROW(Schedule schedule(ParseContext() , grid , deck, ioConfig), std::exception);
+    BOOST_CHECK_THROW(Schedule schedule(parseContext, grid , deck, ioConfig), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC2_ThrowsExcpetion) {
@@ -688,11 +711,11 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithC2_ThrowsExcpetion) {
                     " 10  NOV 2008 / \n"
                     "/\n";
 
-
-    DeckPtr deck = parser.parseString(input, ParseContext());
+    ParseContext parseContext;
+    DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     IOConfigPtr ioConfig;
-    BOOST_CHECK_THROW(Schedule schedule(ParseContext() , grid , deck, ioConfig), std::exception);
+    BOOST_CHECK_THROW(Schedule schedule(parseContext, grid , deck, ioConfig), std::exception);
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithDefaultValuesInWELOPEN) {
@@ -726,9 +749,10 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithDefaultValuesInWELOPEN) {
                     "/\n";
 
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
-    DeckPtr deck = parser.parseString(input, ParseContext());
+    ParseContext parseContext;
+    DeckPtr deck = parser.parseString(input, parseContext);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     WellPtr well;
     well = schedule.getWell("OP_1");
     size_t currentStep = 3;
@@ -1141,7 +1165,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHED) {
     BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(3));
 
 
-    DeckPtr deck1 = parser.parseString(deckData1, ParseContext());
+    DeckPtr deck1 = parser.parseString(deckData1, parseContext);
     IOConfigPtr ioConfig1 = std::make_shared<IOConfig>();
     Schedule schedule1(parseContext , grid , deck1, ioConfig1);
 
@@ -1153,7 +1177,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithRPTSCHED) {
 
     //Older ECLIPSE 100 data set may use integer controls instead of mnemonics
 
-    DeckPtr deck2 = parser.parseString(deckData2, ParseContext()) ;
+    DeckPtr deck2 = parser.parseString(deckData2, parseContext) ;
     IOConfigPtr ioConfig2 = std::make_shared<IOConfig>();
     Schedule schedule2(parseContext , grid , deck2, ioConfig2);
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
@@ -234,7 +234,8 @@ BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
         " 6 7 /\n";
 
     Opm::ParserPtr parser(new Opm::Parser(/*addDefault=*/true));
-    Opm::DeckPtr deck = parser->parseString(deckData, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::DeckPtr deck = parser->parseString(deckData, parseContext);
     Opm::TimeMap tmap(deck);
 
     BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/0),
@@ -305,7 +306,8 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
         " 6 7 /\n";
 
     Opm::ParserPtr parser(new Opm::Parser(true));
-    Opm::DeckPtr deck = parser->parseString(deckData, Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::DeckPtr deck = parser->parseString(deckData, parseContext);
     const Opm::TimeMap tmap(deck);
 
     Opm::TimeMap* writableTimemap = const_cast<Opm::TimeMap*>(&tmap);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TuningTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TuningTests.cpp
@@ -63,7 +63,8 @@ const std::string& deckStr =  "START\n"
 
 static DeckPtr createDeck(const std::string& input) {
     Opm::Parser parser;
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 
@@ -73,7 +74,8 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   DeckPtr deck = createDeck(deckStr);
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
   IOConfigPtr ioConfig;
-  Schedule schedule(ParseContext() , grid , deck, ioConfig);
+  ParseContext parseContext;
+  Schedule schedule(parseContext, grid , deck, ioConfig);
   TuningPtr tuning = schedule.getTuning();
 
 
@@ -325,7 +327,8 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
   DeckPtr deck = createDeck(deckStr);
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
   IOConfigPtr ioConfig;
-  Schedule schedule(ParseContext() , grid , deck, ioConfig);
+  ParseContext parseContext;
+  Schedule schedule(parseContext, grid , deck, ioConfig);
   TuningPtr tuning = schedule.getTuning();
 
 
@@ -354,7 +357,8 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
   DeckPtr deck = createDeck(deckStr);
   std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
   IOConfigPtr ioConfig;
-  Schedule schedule(ParseContext() , grid , deck, ioConfig);
+  ParseContext parseContext;
+  Schedule schedule(parseContext, grid , deck, ioConfig);
   TuningPtr tuning = schedule.getTuning();
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellPropertiesTests.cpp
@@ -86,8 +86,8 @@ namespace {
 
         Opm::WellProductionProperties properties(const std::string& input) {
             Opm::Parser parser;
-
-            Opm::DeckPtr deck = parser.parseString(input, Opm::ParseContext());
+            Opm::ParseContext parseContext;
+            Opm::DeckPtr deck = parser.parseString(input, parseContext);
             const auto& record = deck->getKeyword("WCONHIST").getRecord(0);
             Opm::WellProductionProperties hist = Opm::WellProductionProperties::history( 100 , record);;
 
@@ -111,8 +111,8 @@ namespace {
         properties(const std::string& input)
         {
             Opm::Parser parser;
-
-            Opm::DeckPtr             deck   = parser.parseString(input, Opm::ParseContext());
+            Opm::ParseContext parseContext;
+            Opm::DeckPtr deck   = parser.parseString(input, parseContext);
             const auto& kwd     = deck->getKeyword("WCONHIST");
             const auto&  record = kwd.getRecord(0);
             Opm::WellProductionProperties pred = Opm::WellProductionProperties::prediction( record, false );

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
@@ -49,8 +49,8 @@ static DeckPtr createDeckWithOutSolvent() {
             "/\n"
             "WCONINJE\n"
             "     'W_1' 'WATER' 'OPEN' 'BHP' 1 2 3/\n/\n";
-
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithGasInjector() {
@@ -68,8 +68,8 @@ static DeckPtr createDeckWithGasInjector() {
             "WSOLVENT\n"
             "     'W_1'        1 / \n "
             "/\n";
-
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithDynamicWSOLVENT() {
@@ -99,8 +99,8 @@ static DeckPtr createDeckWithDynamicWSOLVENT() {
             "WSOLVENT\n"
             "     'W_1'        0 / \n "
             "/\n";
-
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithOilInjector() {
@@ -118,8 +118,8 @@ static DeckPtr createDeckWithOilInjector() {
             "WSOLVENT\n"
             "     'W_1'        1 / \n "
             "/\n";
-
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 static DeckPtr createDeckWithWaterInjector() {
@@ -137,14 +137,15 @@ static DeckPtr createDeckWithWaterInjector() {
             "WSOLVENT\n"
             "     'W_1'        1 / \n "
             "/\n";
-
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 BOOST_AUTO_TEST_CASE(TestNoSolvent) {
     DeckPtr deck = createDeckWithOutSolvent();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    Opm::ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     BOOST_CHECK(!deck->hasKeyword("WSOLVENT"));
 }
 
@@ -152,7 +153,8 @@ BOOST_AUTO_TEST_CASE(TestGasInjector) {
     DeckPtr deck = createDeckWithGasInjector();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext(), grid , deck, ioConfig );
+    Opm::ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig );
     BOOST_CHECK(deck->hasKeyword("WSOLVENT"));
 
 }
@@ -161,7 +163,8 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     DeckPtr deck = createDeckWithDynamicWSOLVENT();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    Schedule schedule(ParseContext() , grid , deck, ioConfig);
+    Opm::ParseContext parseContext;
+    Schedule schedule(parseContext, grid , deck, ioConfig);
     BOOST_CHECK(deck->hasKeyword("WSOLVENT"));
     const auto& keyword = deck->getKeyword("WSOLVENT");
     BOOST_CHECK_EQUAL(keyword.size(),1);
@@ -179,12 +182,14 @@ BOOST_AUTO_TEST_CASE(TestOilInjector) {
     DeckPtr deck = createDeckWithOilInjector();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    BOOST_CHECK_THROW (Schedule(ParseContext() , grid , deck, ioConfig), std::invalid_argument);
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW (Schedule(parseContext, grid , deck, ioConfig), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(TestWaterInjector) {
     DeckPtr deck = createDeckWithWaterInjector();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     IOConfigPtr ioConfig;
-    BOOST_CHECK_THROW (Schedule(ParseContext(), grid , deck, ioConfig), std::invalid_argument);
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW (Schedule(parseContext, grid , deck, ioConfig), std::invalid_argument);
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -200,7 +200,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( 10 , 10 , 10 );
     Opm::IOConfigPtr ioConfig;
-    Opm::Schedule schedule(Opm::ParseContext() , grid , deck, ioConfig);
+    Opm::Schedule schedule(parseContext, grid , deck, ioConfig);
     Opm::WellPtr op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
@@ -242,7 +242,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( 10 , 10 , 10 );
     Opm::IOConfigPtr ioConfig;
-    Opm::Schedule schedule(Opm::ParseContext() , grid , deck, ioConfig);
+    Opm::Schedule schedule(parseContext, grid , deck, ioConfig);
     Opm::WellPtr op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( 10 , 10 , 10 );
     Opm::IOConfigPtr ioConfig;
-    Opm::Schedule schedule(Opm::ParseContext() , grid , deck, ioConfig);
+    Opm::Schedule schedule(parseContext, grid , deck, ioConfig);
     Opm::WellPtr op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -45,7 +45,7 @@
 
 namespace Opm {
 
-    SimulationConfig::SimulationConfig(const ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) :
+    SimulationConfig::SimulationConfig(ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) :
         m_useCPR(false),
         m_DISGAS(false),
         m_VAPOIL(false)
@@ -71,7 +71,7 @@ namespace Opm {
     }
 
 
-    void SimulationConfig::initThresholdPressure(const ParseContext& parseContext, DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
+    void SimulationConfig::initThresholdPressure(ParseContext& parseContext, DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties) {
         m_ThresholdPressure = std::make_shared<const ThresholdPressure>(parseContext , deck, gridProperties);
     }
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -33,7 +33,7 @@ namespace Opm {
 
     public:
 
-        SimulationConfig(const ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
+        SimulationConfig(ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
 
         std::shared_ptr<const ThresholdPressure> getThresholdPressure() const;
         bool hasThresholdPressure() const;
@@ -43,7 +43,7 @@ namespace Opm {
 
     private:
 
-        void initThresholdPressure(const ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
+        void initThresholdPressure(ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties);
 
         std::shared_ptr< const ThresholdPressure > m_ThresholdPressure;
         bool m_useCPR;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -29,7 +29,7 @@
 
 namespace Opm {
 
-    ThresholdPressure::ThresholdPressure(const ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties)
+    ThresholdPressure::ThresholdPressure(ParseContext& parseContext , DeckConstPtr deck, std::shared_ptr<GridProperties<int>> gridProperties)
         : m_parseContext( parseContext )
     {
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -36,7 +36,7 @@ namespace Opm {
 
     public:
 
-        ThresholdPressure(const ParseContext& parseContext , std::shared_ptr< const Deck > deck, std::shared_ptr<GridProperties<int>> gridProperties);
+        ThresholdPressure(ParseContext& parseContext , std::shared_ptr< const Deck > deck, std::shared_ptr<GridProperties<int>> gridProperties);
 
 
         /*
@@ -78,7 +78,7 @@ namespace Opm {
 
         std::vector<std::pair<bool,double>> m_thresholdPressureTable;
         std::map<std::pair<int,int> , std::pair<bool , double> > m_pressureTable;
-        const ParseContext& m_parseContext;
+        ParseContext& m_parseContext;
     };
 
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -105,7 +105,7 @@ const std::string& inputStr_vap_dis = "RUNSPEC\n"
                                       "REGIONS\n"
                                       "\n";
 
-static DeckPtr createDeck(const ParseContext& parseContext , const std::string& input) {
+static DeckPtr createDeck(ParseContext& parseContext , const std::string& input) {
     Opm::Parser parser;
     return parser.parseString(input, parseContext);
 }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -134,7 +134,7 @@ const std::string& inputStrMissingPressure = "RUNSPEC\n"
 
 
 
-static DeckPtr createDeck(const ParseContext& parseContext , const std::string& input) {
+static DeckPtr createDeck(ParseContext& parseContext , const std::string& input) {
     Opm::Parser parser;
     return parser.parseString(input , parseContext);
 }

--- a/opm/parser/eclipse/EclipseState/Summary/tests/SummaryTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Summary/tests/SummaryTests.cpp
@@ -47,8 +47,8 @@ static DeckPtr createDeck( const std::string& summary ) {
             "/\n"
             "SUMMARY\n"
             + summary;
-
-    return parser.parseString(input, ParseContext());
+    Opm::ParseContext parseContext;
+    return parser.parseString(input, parseContext);
 }
 
 static std::vector< std::string > sorted_names( const Summary& summary ) {
@@ -71,7 +71,8 @@ static std::vector< std::string > sorted_keywords( const Summary& summary ) {
 
 static Summary createSummary( std::string input ) {
     auto deck = createDeck( input );
-    EclipseState state( deck, ParseContext() );
+    Opm::ParseContext parseContext;
+    EclipseState state( deck, parseContext );
     return Summary( *deck, state );
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/PvtxTableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/PvtxTableTests.cpp
@@ -101,7 +101,8 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables3 ) {
         "/\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
 
     auto ranges = PvtxTable::recordRanges( deck->getKeyword<ParserKeywords::PVTO>() );
     BOOST_CHECK_EQUAL( 2 ,ranges.size() );

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -45,7 +45,8 @@ std::shared_ptr<const Opm::Deck> createSWOFDeck() {
         " 9 10 11 12 /\n";
 
     Opm::Parser parser;
-    Opm::DeckConstPtr deck(parser.parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser.parseString(deckData, parseContext));
     return deck;
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -59,7 +59,8 @@ std::shared_ptr<const Opm::Deck> createSingleRecordDeck() {
         " 9 10 11 12 /\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
     return deck;
 }
 
@@ -89,7 +90,8 @@ BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
         " 17 18 19 20/\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
 
     Opm::SwofTable swof1Table(deck->getKeyword("SWOF").getRecord(0).getItem(0));
     Opm::SwofTable swof2Table(deck->getKeyword("SWOF").getRecord(1).getItem(0));
@@ -132,7 +134,8 @@ BOOST_AUTO_TEST_CASE(SgwfnTable_Tests) {
         " 17 18 19 20/\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
 
 
     Opm::SgwfnTable sgwfn1Table(deck->getKeyword("SGWFN").getRecord(0).getItem(0));
@@ -175,7 +178,8 @@ BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
         " 17 18 19 20/\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
 
     Opm::SgofTable sgof1Table(deck->getKeyword("SGOF").getRecord(0).getItem(0));
     Opm::SgofTable sgof2Table(deck->getKeyword("SGOF").getRecord(1).getItem(0));
@@ -221,7 +225,8 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "2.00    0.000030\n"
             "3.00    0.000030 /\n";
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(correctDeckData, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(correctDeckData, parseContext));
         const auto& plyadsKeyword = deck->getKeyword("PLYADS");
         Opm::PlyadsTable plyadsTable(plyadsKeyword.getRecord(0).getItem(0));
 
@@ -250,7 +255,8 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "2.00    0.000030\n"
             "3.00    0.000030 /\n";
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(incorrectDeckData, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(incorrectDeckData, parseContext));
         const auto& plyadsKeyword = deck->getKeyword("PLYADS");
 
         BOOST_CHECK_THROW(Opm::PlyadsTable(plyadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
@@ -273,7 +279,8 @@ BOOST_AUTO_TEST_CASE(PlyadsTable_Tests) {
             "2.00    0.000030\n"
             "3.00    0.000029 /\n";
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(incorrectDeckData, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(incorrectDeckData, parseContext));
         const auto& plyadsKeyword = deck->getKeyword("PLYADS");
 
         BOOST_CHECK_THROW(Opm::PlyadsTable(plyadsKeyword.getRecord(0).getItem(0)), std::invalid_argument);
@@ -321,7 +328,8 @@ VFPPROD \n\
 2 2 2 2 46.5 47.5 48.5 / \n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
     std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
     const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
 
@@ -448,7 +456,8 @@ VFPPROD \n\
 1 1 1 1 1.5 /    \n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
     const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
     std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
 
@@ -560,7 +569,8 @@ VFPPROD \n\
 1 1 1 1 1.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, parseContext));
         const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
@@ -597,7 +607,8 @@ VFPPROD \n\
 1 1 1 1 1.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, parseContext));
         const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
@@ -632,7 +643,8 @@ VFPPROD \n\
 1 1 1 1 1.5 2.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_metadata, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_metadata, parseContext));
         const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
@@ -668,7 +680,8 @@ VFPPROD \n\
 1 1 1 1 1.5 2.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(wrong_metadata, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(wrong_metadata, parseContext));
         const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
@@ -703,7 +716,8 @@ VFPPROD \n\
 1 1 1 1 1.5 2.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_axes, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_axes, parseContext));
         const auto& vfpprodKeyword = deck->getKeyword("VFPPROD");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPPROD"), 1);
@@ -736,7 +750,8 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(deckData, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(deckData, parseContext));
     const auto& vfpprodKeyword = deck->getKeyword("VFPINJ");
     std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
 
@@ -838,7 +853,8 @@ VFPINJ \n\
 2 4.5 5.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, parseContext));
         const auto& vfpinjKeyword = deck->getKeyword("VFPINJ");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPINJ"), 1);
@@ -869,7 +885,8 @@ VFPINJ \n\
 1 1.5 2.5 3.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_values, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_values, parseContext));
         const auto& vfpinjKeyword = deck->getKeyword("VFPINJ");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPINJ"), 1);
@@ -899,7 +916,8 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_metadata, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_metadata, parseContext));
         const auto& vfpinjKeyword = deck->getKeyword("VFPINJ");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPINJ"), 1);
@@ -930,7 +948,8 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(wrong_metadata, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(wrong_metadata, parseContext));
         const auto& vfpinjKeyword = deck->getKeyword("VFPINJ");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPINJ"), 1);
@@ -960,7 +979,8 @@ VFPINJ \n\
 2 4.5 5.5 6.5 /    \n";
 
         Opm::ParserPtr parser(new Opm::Parser);
-        Opm::DeckConstPtr deck(parser->parseString(missing_axes, Opm::ParseContext()));
+        Opm::ParseContext parseContext;
+        Opm::DeckConstPtr deck(parser->parseString(missing_axes, parseContext));
         const auto& vfpinjKeyword = deck->getKeyword("VFPINJ");
         std::shared_ptr<Opm::UnitSystem> units(Opm::UnitSystem::newMETRIC());
         BOOST_CHECK_EQUAL(deck->count("VFPINJ"), 1);
@@ -982,7 +1002,8 @@ BOOST_AUTO_TEST_CASE( TestPLYROCK ) {
         " 10 20 30 40 50 /\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(data, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(data, parseContext));
     Opm::TableManager tables( *deck );
     const Opm::TableContainer& plyrock = tables.getPlyrockTables();
 
@@ -1010,7 +1031,8 @@ BOOST_AUTO_TEST_CASE( TestPLYMAX ) {
         " 10 20 /\n";
 
     Opm::ParserPtr parser(new Opm::Parser);
-    Opm::DeckConstPtr deck(parser->parseString(data, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck(parser->parseString(data, parseContext));
     Opm::TableManager tables( *deck );
     const Opm::TableContainer& plymax = tables.getPlymaxTables();
 
@@ -1034,5 +1056,6 @@ BOOST_AUTO_TEST_CASE( TestParseTABDIMS ) {
       "TABDIMS\n"
       "  1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 /\n";
     Opm::ParserPtr parser(new Opm::Parser);
-    BOOST_CHECK_NO_THROW( parser->parseString(data, Opm::ParseContext()));
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_NO_THROW( parser->parseString(data, parseContext));
 }

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -92,14 +92,16 @@ static DeckPtr createDeckTOP() {
         "\n";
 
     ParserPtr parser(new Parser());
-    return parser->parseString(deckData, ParseContext()) ;
+    ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
 
 BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     DeckPtr deck = createDeckTOP();
-    EclipseState state(deck , ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck , parseContext);
 
     std::shared_ptr<const GridProperty<double> > poro = state.getDoubleGridProperty( "PORO" );
     std::shared_ptr<const GridProperty<double> > permx = state.getDoubleGridProperty( "PERMX" );
@@ -152,7 +154,8 @@ static DeckPtr createDeck() {
         "\n";
 
     ParserPtr parser(new Parser());
-    return parser->parseString(deckData, ParseContext()) ;
+    ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -180,13 +183,15 @@ static DeckPtr createDeckNoFaults() {
         "\n";
 
     ParserPtr parser(new Parser());
-    return parser->parseString(deckData, ParseContext()) ;
+    ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck , ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck ,parseContext);
     ScheduleConstPtr schedule = state.getSchedule();
     EclipseGridConstPtr eclipseGrid = state.getEclipseGrid();
 
@@ -218,14 +223,16 @@ static DeckPtr createDeckSimConfig() {
 
 
     ParserPtr parser(new Parser());
-    return parser->parseString(inputStr, ParseContext()) ;
+    ParseContext parseContext;
+    return parser->parseString(inputStr, parseContext) ;
 }
 
 
 BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
 
     DeckPtr deck = createDeckSimConfig();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
     SimulationConfigConstPtr simulationConfig = state.getSimulationConfig();
     std::shared_ptr<const ThresholdPressure> thresholdPressure = simulationConfig->getThresholdPressure();
     BOOST_CHECK_EQUAL(thresholdPressure->size(), 3);
@@ -235,7 +242,8 @@ BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
 
 BOOST_AUTO_TEST_CASE(PhasesCorrect) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
 
     BOOST_CHECK(  state.hasPhase( Phase::PhaseEnum::OIL ));
     BOOST_CHECK(  state.hasPhase( Phase::PhaseEnum::GAS ));
@@ -245,7 +253,8 @@ BOOST_AUTO_TEST_CASE(PhasesCorrect) {
 
 BOOST_AUTO_TEST_CASE(TitleCorrect) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
 
     BOOST_CHECK_EQUAL( state.getTitle(), "The title");
 }
@@ -253,7 +262,8 @@ BOOST_AUTO_TEST_CASE(TitleCorrect) {
 
 BOOST_AUTO_TEST_CASE(IntProperties) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
 
     BOOST_CHECK_EQUAL( false , state.supportsGridProperty("NONO"));
     BOOST_CHECK_EQUAL( true  , state.supportsGridProperty("SATNUM"));
@@ -266,7 +276,8 @@ BOOST_AUTO_TEST_CASE(PropertiesNotSupportedThrows) {
     std::shared_ptr<CounterLog> counter = std::make_shared<CounterLog>(Log::MessageType::Error);
     OpmLog::addBackend("COUNTER" , counter);
     DeckPtr deck = createDeck();
-    EclipseState state(deck , ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck , parseContext);
     const auto& swat = deck->getKeyword("SWAT");
     BOOST_CHECK_EQUAL( false , state.supportsGridProperty("SWAT"));
     state.loadGridPropertyFromDeckKeyword(std::make_shared<const Box>(10,10,10), swat);
@@ -276,7 +287,8 @@ BOOST_AUTO_TEST_CASE(PropertiesNotSupportedThrows) {
 
 BOOST_AUTO_TEST_CASE(GetProperty) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
 
     std::shared_ptr<const GridProperty<int> > satNUM = state.getIntGridProperty( "SATNUM" );
 
@@ -290,7 +302,8 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
 
 BOOST_AUTO_TEST_CASE(GetTransMult) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
     std::shared_ptr<const TransMult> transMult = state.getTransMult();
 
 
@@ -302,7 +315,8 @@ BOOST_AUTO_TEST_CASE(GetTransMult) {
 
 BOOST_AUTO_TEST_CASE(GetFaults) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck , ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck , parseContext);
     std::shared_ptr<const FaultCollection> faults = state.getFaults();
 
     BOOST_CHECK( faults->hasFault("F1") );
@@ -323,7 +337,8 @@ BOOST_AUTO_TEST_CASE(GetFaults) {
 
 BOOST_AUTO_TEST_CASE(FaceTransMults) {
     DeckPtr deck = createDeckNoFaults();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
     std::shared_ptr<const TransMult> transMult = state.getTransMult();
 
     for (int i = 0; i < 10; ++ i) {
@@ -377,7 +392,8 @@ static DeckPtr createDeckNoGridOpts() {
         "  1000*1 /\n";
 
     ParserPtr parser(new Parser());
-    return parser->parseString(deckData, ParseContext()) ;
+    ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
@@ -396,13 +412,15 @@ static DeckPtr createDeckWithGridOpts() {
         "  1000*1 /\n";
 
     ParserPtr parser(new Parser());
-    return parser->parseString(deckData, ParseContext()) ;
+    ParseContext parseContext;
+    return parser->parseString(deckData, parseContext) ;
 }
 
 
 BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
     DeckPtr deck = createDeckNoGridOpts();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
     auto multnum = state.getIntGridProperty("MULTNUM");
     auto fluxnum = state.getIntGridProperty("FLUXNUM");
     auto def_property = state.getDefaultRegion();
@@ -413,7 +431,8 @@ BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
 
 BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     DeckPtr deck = createDeckWithGridOpts();
-    EclipseState state(deck, ParseContext());
+    ParseContext parseContext;
+    EclipseState state(deck, parseContext);
     auto multnum = state.getIntGridProperty("MULTNUM");
     auto fluxnum = state.getIntGridProperty("FLUXNUM");
     auto def_property = state.getDefaultRegion();
@@ -448,8 +467,9 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
 
 
     ParserPtr parser(new Parser());
-    DeckPtr deck = parser->parseString(deckData, ParseContext()) ;
-    EclipseState state(deck , ParseContext());
+    ParseContext parseContext;
+    DeckPtr deck = parser->parseString(deckData, parseContext) ;
+    EclipseState state(deck , parseContext);
 
     IOConfigConstPtr ioConfig = state.getIOConfigConst();
 

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -42,8 +42,9 @@ EclipseState makeState(const std::string& fileName);
 EclipseState makeState(const std::string& fileName) {
     ParserPtr parser(new Parser( ));
     boost::filesystem::path boxFile(fileName);
-    DeckPtr deck =  parser->parseFile(boxFile.string(), ParseContext());
-    EclipseState state(deck , ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(boxFile.string(), parseContext);
+    EclipseState state(deck , parseContext);
     return state;
 }
 

--- a/opm/parser/eclipse/IntegrationTests/CheckDeckValidity.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CheckDeckValidity.cpp
@@ -49,8 +49,8 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "PROPS\n"
             "SOLUTION\n"
             "SCHEDULE\n";
-
-        auto deck = parser->parseString(correctDeckString, Opm::ParseContext());
+        Opm::ParseContext parseContext;
+        auto deck = parser->parseString(correctDeckString, parseContext);
         BOOST_CHECK(Opm::checkDeck(deck, parser));
     }
 
@@ -62,8 +62,8 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "PROPS\n"
             "SOLUTION\n"
             "SCHEDULE\n";
-
-        auto deck = parser->parseString(correctDeckString, Opm::ParseContext());
+        Opm::ParseContext parseContext;
+        auto deck = parser->parseString(correctDeckString, parseContext);
         BOOST_CHECK(!Opm::checkDeck(deck, parser));
         BOOST_CHECK(Opm::checkDeck(deck, parser, ~Opm::SectionTopology));
     }
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE( KeywordInCorrectSection ) {
             "PROPS\n"
             "SOLUTION\n"
             "SCHEDULE\n";
-
-        auto deck = parser->parseString(incorrectDeckString, Opm::ParseContext());
+        Opm::ParseContext parseContext;
+        auto deck = parser->parseString(incorrectDeckString, parseContext);
         BOOST_CHECK(!Opm::checkDeck(deck, parser));
 
         // this is supposed to succeed as we don't ensure that all keywords are in the

--- a/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/CompletionsFromDeck.cpp
@@ -44,7 +44,8 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromRecord ) {
 
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMPDAT1");
-    DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(scheduleFile.string(), parseContext);
     const auto& COMPDAT1 = deck->getKeyword("COMPDAT" , 0);
     const auto& line0 = COMPDAT1.getRecord(0);
     const auto& line1 = COMPDAT1.getRecord(1);
@@ -90,7 +91,8 @@ BOOST_AUTO_TEST_CASE( CreateCompletionsFromKeyword ) {
 
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/SCHEDULE/SCHEDULE_COMPDAT1");
-    DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(scheduleFile.string(), parseContext);
     const auto& COMPDAT1 = deck->getKeyword("COMPDAT" , 1);
 
     std::map< std::string , std::vector<CompletionPtr> > completions = Completion::completionsFromCOMPDATKeyword( COMPDAT1 );

--- a/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
@@ -38,7 +38,8 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
-    DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(scheduleFile.string(), parseContext);
     std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
     BOOST_CHECK_EQUAL( 10U  , grid->getNX( ));
@@ -51,7 +52,8 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
 BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
-    DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(scheduleFile.string(), parseContext);
     std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
     BOOST_CHECK_EQUAL(  10U , grid->getNX( ));
@@ -64,7 +66,8 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
 BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
-    DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(scheduleFile.string(), parseContext);
 
     std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 
@@ -81,7 +84,8 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
 BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
-    DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(scheduleFile.string(), parseContext);
 
     std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
 

--- a/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
@@ -151,7 +151,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     path datafile;
     ParserPtr parser(new Parser());
     createDeckWithInclude (datafile, "");
-    DeckConstPtr deck =  parser->parseFile(datafile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckConstPtr deck =  parser->parseFile(datafile.string(), parseContext);
 
     BOOST_CHECK( deck->hasKeyword("START"));
     BOOST_CHECK( deck->hasKeyword("DIMENS"));
@@ -162,7 +163,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithENDINCKeyword_deckReturned) {
     path datafile;
     ParserPtr parser(new Parser());
     createDeckWithInclude (datafile, "ENDINC");
-    DeckConstPtr deck =  parser->parseFile(datafile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckConstPtr deck =  parser->parseFile(datafile.string(), parseContext);
 
     BOOST_CHECK( deck->hasKeyword("START"));
     BOOST_CHECK( !deck->hasKeyword("DIMENS"));
@@ -173,7 +175,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithENDKeyword_deckReturned) {
     path datafile;
     ParserPtr parser(new Parser());
     createDeckWithInclude (datafile, "END");
-    DeckConstPtr deck =  parser->parseFile(datafile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckConstPtr deck =  parser->parseFile(datafile.string(), parseContext);
 
     BOOST_CHECK( deck->hasKeyword("START"));
     BOOST_CHECK( !deck->hasKeyword("DIMENS"));
@@ -184,7 +187,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithPathsKeyword_IncludeExtendsPath) {
     path datafile;
     ParserPtr parser(new Parser());
     createDeckWithInclude (datafile, "");
-    DeckConstPtr deck =  parser->parseFile(datafile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckConstPtr deck =  parser->parseFile(datafile.string(), parseContext);
 
     BOOST_CHECK( deck->hasKeyword("TITLE"));
     BOOST_CHECK( deck->hasKeyword("BOX"));

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -67,9 +67,10 @@ static ParserPtr createWWCTParser() {
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/wwct.data");
     ParserPtr parser = createWWCTParser();
+    Opm::ParseContext parseContext;
     BOOST_CHECK( parser->isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser->isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW( parser->parseFile(singleKeywordFile.string(), ParseContext()) );
+    BOOST_CHECK_NO_THROW( parser->parseFile(singleKeywordFile.string(), parseContext) );
 }
 
 BOOST_AUTO_TEST_CASE(parse_stringWithWWCTKeyword_deckReturned) {
@@ -81,9 +82,10 @@ BOOST_AUTO_TEST_CASE(parse_stringWithWWCTKeyword_deckReturned) {
         "  'WELL-1' 'WELL-2' / -- Ehne mehne muh\n"
         "/\n";
     ParserPtr parser = createWWCTParser();
+    Opm::ParseContext parseContext;
     BOOST_CHECK( parser->isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser->isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseString(wwctString, ParseContext()));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseString(wwctString, parseContext));
 }
 
 BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
@@ -96,15 +98,17 @@ BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
         "/\n";
     std::shared_ptr<std::istream> wwctStream(new std::istringstream(wwctString));
     ParserPtr parser = createWWCTParser();
+    Opm::ParseContext parseContext;
     BOOST_CHECK( parser->isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser->isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseStream(wwctStream, ParseContext()));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseStream(wwctStream, parseContext));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/wwct.data");
     ParserPtr parser = createWWCTParser();
-    DeckPtr deck = parser->parseFile(singleKeywordFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck = parser->parseFile(singleKeywordFile.string(), parseContext);
     BOOST_CHECK(deck->hasKeyword("SUMMARY"));
     BOOST_CHECK(deck->hasKeyword("WWCT"));
 }
@@ -112,7 +116,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_dataIsCorrect) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/wwct.data");
     ParserPtr parser = createWWCTParser();
-    DeckPtr deck =  parser->parseFile(singleKeywordFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string(), parseContext);
     BOOST_CHECK_EQUAL("WELL-1", deck->getKeyword("WWCT" , 0).getRecord(0).getItem(0).get< std::string >(0));
     BOOST_CHECK_EQUAL("WELL-2", deck->getKeyword("WWCT" , 0).getRecord(0).getItem(0).get< std::string >(1));
 }
@@ -159,15 +164,16 @@ static ParserPtr createBPRParser() {
 BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_deckReturned) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/bpr.data");
     ParserPtr parser = createBPRParser();
-
-    BOOST_CHECK_NO_THROW(parser->parseFile(singleKeywordFile.string(), ParseContext()));
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_NO_THROW(parser->parseFile(singleKeywordFile.string(), parseContext));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_DeckhasBRP) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/bpr.data");
 
     ParserPtr parser = createBPRParser();
-    DeckPtr deck =  parser->parseFile(singleKeywordFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string(), parseContext);
 
     BOOST_CHECK_EQUAL(true, deck->hasKeyword("BPR"));
 }
@@ -176,7 +182,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
     boost::filesystem::path singleKeywordFile("testdata/integration_tests/bpr.data");
 
     ParserPtr parser = createBPRParser();
-    DeckPtr deck =  parser->parseFile(singleKeywordFile.string(), ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(singleKeywordFile.string(), parseContext);
 
     const auto& keyword = deck->getKeyword("BPR" , 0);
     BOOST_CHECK_EQUAL(2U, keyword.size());
@@ -198,7 +205,8 @@ BOOST_AUTO_TEST_CASE(parse_fileWithBPRKeyword_dataiscorrect) {
 /***************** Testing non-recognized keywords ********************/
 BOOST_AUTO_TEST_CASE(parse_unknownkeyword_exceptionthrown) {
     ParserPtr parser(new Parser());
-    BOOST_CHECK_THROW( parser->parseFile("testdata/integration_tests/someobscureelements.data", ParseContext()), std::invalid_argument);
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( parser->parseFile("testdata/integration_tests/someobscureelements.data", parseContext), std::invalid_argument);
 }
 
 /*********************Testing truncated (default) records ***************************/
@@ -207,7 +215,8 @@ BOOST_AUTO_TEST_CASE(parse_unknownkeyword_exceptionthrown) {
 // Datafile contains 3 RADFIN4 keywords. One fully specified, one with 2 out of 11 items, and one with no items.
 BOOST_AUTO_TEST_CASE(parse_truncatedrecords_deckFilledWithDefaults) {
     ParserPtr parser(new Parser());
-    DeckPtr deck =  parser->parseFile("testdata/integration_tests/truncated_records.data", ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile("testdata/integration_tests/truncated_records.data", parseContext);
     BOOST_CHECK_EQUAL(3U, deck->size());
     const auto& radfin4_0_full= deck->getKeyword("RADFIN4", 0);
     const auto& radfin4_1_partial= deck->getKeyword("RADFIN4", 1);

--- a/opm/parser/eclipse/IntegrationTests/ParseDATAWithDefault.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseDATAWithDefault.cpp
@@ -53,7 +53,8 @@ ENKRVD\n\
 
 BOOST_AUTO_TEST_CASE( ParseMissingRECORD_THrows) {
     ParserPtr parser(new Parser());
-    BOOST_CHECK_THROW( parser->parseString( dataMissingRecord , ParseContext()) , std::invalid_argument);
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW( parser->parseString( dataMissingRecord , parseContext) , std::invalid_argument);
 }
 
 
@@ -73,7 +74,8 @@ ENKRVD\n\
 
 BOOST_AUTO_TEST_CASE( parse_DATAWithDefult_OK ) {
     ParserPtr parser(new Parser());
-    DeckConstPtr deck = parser->parseString( data , ParseContext());
+    Opm::ParseContext parseContext;
+    DeckConstPtr deck = parser->parseString( data , parseContext);
     const auto& keyword = deck->getKeyword( "ENKRVD" );
     const auto& rec0 = keyword.getRecord(0);
     const auto& rec1 = keyword.getRecord(1);

--- a/opm/parser/eclipse/IntegrationTests/ParseDENSITY.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseDENSITY.cpp
@@ -42,7 +42,8 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(ParseDENSITY) {
     ParserPtr parser(new Parser());
     std::string file("testdata/integration_tests/DENSITY/DENSITY1");
-    DeckPtr deck =  parser->parseFile(file, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(file, parseContext);
     const auto& densityKw = deck->getKeyword("DENSITY" , 0);
 
 

--- a/opm/parser/eclipse/IntegrationTests/ParseEND.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEND.cpp
@@ -40,8 +40,8 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_END_OK ) {
     ParserPtr parser(new Parser());
     std::string fileWithTitleKeyword("testdata/integration_tests/END/END1.txt");
-
-    DeckPtr deck = parser->parseFile(fileWithTitleKeyword, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck = parser->parseFile(fileWithTitleKeyword, parseContext);
 
     BOOST_CHECK_EQUAL(size_t(1), deck->size());
     BOOST_CHECK_EQUAL (true, deck->hasKeyword("OIL"));
@@ -52,8 +52,8 @@ BOOST_AUTO_TEST_CASE( parse_END_OK ) {
 BOOST_AUTO_TEST_CASE( parse_ENDINC_OK ) {
     ParserPtr parser(new Parser());
     std::string fileWithTitleKeyword("testdata/integration_tests/END/ENDINC1.txt");
-
-    DeckPtr deck = parser->parseFile(fileWithTitleKeyword, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck = parser->parseFile(fileWithTitleKeyword, parseContext);
 
     BOOST_CHECK_EQUAL(size_t(1), deck->size());
     BOOST_CHECK_EQUAL (true, deck->hasKeyword("OIL"));

--- a/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseEQUIL.cpp
@@ -61,7 +61,8 @@ BOOST_AUTO_TEST_CASE( parse_EQUIL_MISSING_DIMS ) {
 BOOST_AUTO_TEST_CASE( parse_EQUIL_OK ) {
     ParserPtr parser(new Parser());
     std::string pvtgFile("testdata/integration_tests/EQUIL/EQUIL1");
-    DeckPtr deck =  parser->parseFile(pvtgFile, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(pvtgFile, parseContext);
     const auto& kw1 = deck->getKeyword("EQUIL" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1.size() );
 

--- a/opm/parser/eclipse/IntegrationTests/ParseMULTREGT.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMULTREGT.cpp
@@ -41,7 +41,8 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( parse_MULTREGT_OK ) {
     ParserPtr parser(new Parser());
-    DeckPtr deck =  parser->parseFile("testdata/integration_tests/MULTREGT/MULTREGT", ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile("testdata/integration_tests/MULTREGT/MULTREGT", parseContext);
     BOOST_CHECK_NO_THROW( deck->getKeyword("MULTREGT" , 0); );
 }
 

--- a/opm/parser/eclipse/IntegrationTests/ParseMULTSEGWELL.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMULTSEGWELL.cpp
@@ -39,7 +39,8 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTISEGMENT_ABS ) {
 
     ParserPtr parser(new Parser());
     std::string deckFile("testdata/integration_tests/SCHEDULE/SCHEDULE_MULTISEGMENT_WELL");
-    DeckPtr deck =  parser->parseFile(deckFile, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(deckFile, parseContext);
     // for WELSEGS keyword
     const auto& kw = deck->getKeyword("WELSEGS");
 

--- a/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
@@ -76,12 +76,13 @@ BOOST_AUTO_TEST_CASE( PARSE_SORWMIS)
 ParserPtr parser(new Parser());
 
 // missing miscible keyword
-BOOST_CHECK_THROW (parser->parseString(sorwmisData, ParseContext()), std::invalid_argument );
+Opm::ParseContext parseContext;
+BOOST_CHECK_THROW (parser->parseString(sorwmisData, parseContext), std::invalid_argument );
 
 //too many tables
-BOOST_CHECK_THROW( parser->parseString(miscibleTightData + sorwmisData, ParseContext()), std::invalid_argument);
+BOOST_CHECK_THROW( parser->parseString(miscibleTightData + sorwmisData, parseContext), std::invalid_argument);
 
-DeckPtr deck1 =  parser->parseString(miscibleData + sorwmisData, ParseContext());
+DeckPtr deck1 =  parser->parseString(miscibleData + sorwmisData, parseContext);
 
 const auto& sorwmis = deck1->getKeyword("SORWMIS");
 const auto& miscible = deck1->getKeyword("MISCIBLE");
@@ -113,8 +114,8 @@ BOOST_CHECK_EQUAL(0.8, sorwmisTable1.getMiscibleResidualOilColumn()[2]);
 BOOST_AUTO_TEST_CASE( PARSE_SGCWMIS)
 {
     ParserPtr parser(new Parser());
-
-    DeckPtr deck1 =  parser->parseString(miscibleData + sgcwmisData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck1 =  parser->parseString(miscibleData + sgcwmisData, parseContext);
 
     const auto& sgcwmis = deck1->getKeyword("SGCWMIS");
     const auto& miscible = deck1->getKeyword("MISCIBLE");
@@ -177,18 +178,19 @@ BOOST_AUTO_TEST_CASE(PARSE_MISC)
     ParserPtr parser(new Parser());
 
     // out of range MISC keyword
-    DeckPtr deck1 = parser->parseString(miscOutOfRangeData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck1 = parser->parseString(miscOutOfRangeData, parseContext);
     const auto& item = deck1->getKeyword("MISC").getRecord(0).getItem(0);
     Opm::MiscTable miscTable1(item);
 
 
     // too litle range of MISC keyword
-    DeckPtr deck2 = parser->parseString(miscTooSmallRangeData, ParseContext());
+    DeckPtr deck2 = parser->parseString(miscTooSmallRangeData, parseContext);
     const auto& item2 = deck2->getKeyword("MISC").getRecord(0).getItem(0);
     Opm::MiscTable miscTable2(item2);
 
     // test table input
-    DeckPtr deck3 =  parser->parseString(miscData, ParseContext());
+    DeckPtr deck3 =  parser->parseString(miscData, parseContext);
     const auto& item3 = deck3->getKeyword("MISC").getRecord(0).getItem(0);
     Opm::MiscTable miscTable3(item3);
     BOOST_CHECK_EQUAL(3U, miscTable3.getSolventFractionColumn().size());
@@ -211,7 +213,8 @@ BOOST_AUTO_TEST_CASE(PARSE_PMISC)
     ParserPtr parser(new Parser());
 
     // test table input
-    DeckPtr deck =  parser->parseString(pmiscData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(pmiscData, parseContext);
     Opm::PmiscTable pmiscTable(deck->getKeyword("PMISC").getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(3U, pmiscTable.getOilPhasePressureColumn().size());
     BOOST_CHECK_EQUAL(200*1e5, pmiscTable.getOilPhasePressureColumn()[1]);
@@ -233,7 +236,8 @@ MSFN\n\
 BOOST_AUTO_TEST_CASE(PARSE_MSFN)
 {
 ParserPtr parser(new Parser());
-DeckPtr deck =  parser->parseString(msfnData, ParseContext());
+Opm::ParseContext parseContext;
+DeckPtr deck =  parser->parseString(msfnData, parseContext);
 
 // test table input 1
  Opm::MsfnTable msfnTable1(deck->getKeyword("MSFN").getRecord(0).getItem(0));
@@ -265,7 +269,8 @@ BOOST_AUTO_TEST_CASE(PARSE_TLPMIXPA)
     ParserPtr parser(new Parser());
 
     // test table input
-    DeckPtr deck =  parser->parseString(tlpmixpa, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(tlpmixpa, parseContext);
     Opm::TlpmixpaTable tlpmixpaTable(deck->getKeyword("TLPMIXPA").getRecord(0).getItem(0));
     BOOST_CHECK_EQUAL(3U, tlpmixpaTable.getOilPhasePressureColumn().size());
     BOOST_CHECK_EQUAL(200*1e5, tlpmixpaTable.getOilPhasePressureColumn()[1]);

--- a/opm/parser/eclipse/IntegrationTests/ParsePLYADSS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePLYADSS.cpp
@@ -35,8 +35,9 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( PARSE_PLYADSS_OK) {
     ParserPtr parser(new Parser());
+    Opm::ParseContext parseContext;
     std::string deckFile("testdata/integration_tests/POLYMER/plyadss.data");
-    DeckPtr deck =  parser->parseFile(deckFile, ParseContext());
+    DeckPtr deck =  parser->parseFile(deckFile, parseContext);
     const auto& kw = deck->getKeyword("PLYADSS");
 
     BOOST_CHECK_EQUAL( kw.size() , 11U );

--- a/opm/parser/eclipse/IntegrationTests/ParsePLYDHFLF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePLYDHFLF.cpp
@@ -37,8 +37,9 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( PARSE_PLYDHFLF_OK) {
     ParserPtr parser(new Parser());
+    Opm::ParseContext parseContext;
     std::string deckFile("testdata/integration_tests/POLYMER/plydhflf.data");
-    DeckPtr deck =  parser->parseFile(deckFile, ParseContext());
+    DeckPtr deck =  parser->parseFile(deckFile, parseContext);
     const auto& kw = deck->getKeyword("PLYDHFLF");
     const auto& rec = kw.getRecord(0);
     const auto& item = rec.getItem(0);

--- a/opm/parser/eclipse/IntegrationTests/ParsePLYSHLOG.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePLYSHLOG.cpp
@@ -37,8 +37,9 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( PARSE_PLYSHLOG_OK) {
     ParserPtr parser(new Parser());
+    Opm::ParseContext parseContext;
     std::string deckFile("testdata/integration_tests/POLYMER/plyshlog.data");
-    DeckPtr deck =  parser->parseFile(deckFile, ParseContext());
+    DeckPtr deck =  parser->parseFile(deckFile, parseContext);
     const auto& kw = deck->getKeyword("PLYSHLOG");
     const auto& rec1 = kw.getRecord(0); // reference conditions
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePLYVISC.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePLYVISC.cpp
@@ -37,8 +37,9 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( PARSE_PLYVISC_OK) {
     ParserPtr parser(new Parser());
+    Opm::ParseContext parseContext;
     std::string deckFile("testdata/integration_tests/POLYMER/plyvisc.data");
-    DeckPtr deck =  parser->parseFile(deckFile, ParseContext());
+    DeckPtr deck =  parser->parseFile(deckFile, parseContext);
     const auto& kw = deck->getKeyword("PLYVISC");
     const auto& rec = kw.getRecord(0);
     const auto& item = rec.getItem(0);

--- a/opm/parser/eclipse/IntegrationTests/ParsePORO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePORO.cpp
@@ -39,8 +39,9 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(ParsePOROandPERMX) {
     ParserPtr parser(new Parser());
+    Opm::ParseContext parseContext;
     std::string poroFile("testdata/integration_tests/PORO/PORO1");
-    DeckPtr deck =  parser->parseFile(poroFile, ParseContext());
+    DeckPtr deck =  parser->parseFile(poroFile, parseContext);
     const auto& kw1 = deck->getKeyword("PORO" , 0);
     const auto& kw2 = deck->getKeyword("PERMX" , 0);
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTG.cpp
@@ -64,7 +64,8 @@ PVTG\n\
 
 
 static void check_parser(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(pvtgData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(pvtgData, parseContext);
     const auto& kw1 = deck->getKeyword("PVTG" , 0);
     BOOST_CHECK_EQUAL(5U , kw1.size());
 

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
@@ -68,7 +68,8 @@ PVTO\n\
 
 
 static void check_parser(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(pvtoData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(pvtoData, parseContext);
     const auto& kw1 = deck->getKeyword("PVTO" , 0);
     BOOST_CHECK_EQUAL(5U , kw1.size());
 

--- a/opm/parser/eclipse/IntegrationTests/ParseRSVD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseRSVD.cpp
@@ -40,8 +40,9 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( parse_EQUIL_OK ) {
     ParserPtr parser(new Parser());
+    Opm::ParseContext parseContext;
     std::string pvtgFile("testdata/integration_tests/RSVD/RSVD.txt");
-    DeckPtr deck =  parser->parseFile(pvtgFile, ParseContext());
+    DeckPtr deck =  parser->parseFile(pvtgFile, parseContext);
     const auto& kw1 = deck->getKeyword("RSVD" , 0);
     BOOST_CHECK_EQUAL( 6U , kw1.size() );
 

--- a/opm/parser/eclipse/IntegrationTests/ParseSGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSGOF.cpp
@@ -56,7 +56,8 @@ const char *parserData =
     "    1.0 1.0 0.1 9.0 /\n";
 
 static void check_parser(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(parserData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(parserData, parseContext);
     const auto& kw1 = deck->getKeyword("SGOF");
     BOOST_CHECK_EQUAL(1U , kw1.size());
 
@@ -68,7 +69,8 @@ static void check_parser(ParserPtr parser) {
 }
 
 static void check_SgofTable(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(parserData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(parserData, parseContext);
     Opm::SgofTable sgofTable(deck->getKeyword("SGOF").getRecord(0).getItem(0));
 
     BOOST_CHECK_EQUAL(10U, sgofTable.getSgColumn().size());

--- a/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
@@ -58,7 +58,8 @@ const char *parserData =
     "    1.0 0.0 1.0 0.0 /\n";
 
 static void check_parser(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(parserData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(parserData, parseContext);
     const auto& kw1 = deck->getKeyword("SLGOF");
     BOOST_CHECK_EQUAL(1U , kw1.size());
 
@@ -70,7 +71,8 @@ static void check_parser(ParserPtr parser) {
 }
 
 static void check_SlgofTable(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(parserData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(parserData, parseContext);
     Opm::SlgofTable slgofTable(deck->getKeyword("SLGOF").getRecord(0).getItem(0));
 
     BOOST_CHECK_EQUAL(10U, slgofTable.getSlColumn().size());

--- a/opm/parser/eclipse/IntegrationTests/ParseSWOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSWOF.cpp
@@ -58,7 +58,8 @@ const char *parserData =
     "    1.0  1* 0.1 9.0 /\n";
 
 static void check_parser(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(parserData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(parserData, parseContext);
     const auto& kw1 = deck->getKeyword("SWOF");
     BOOST_CHECK_EQUAL(1U , kw1.size());
 
@@ -70,7 +71,8 @@ static void check_parser(ParserPtr parser) {
 }
 
 static void check_SwofTable(ParserPtr parser) {
-    DeckPtr deck =  parser->parseString(parserData, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseString(parserData, parseContext);
     Opm::SwofTable swofTable(deck->getKeyword("SWOF").getRecord(0).getItem(0));
 
     BOOST_CHECK_EQUAL(10U, swofTable.getSwColumn().size());

--- a/opm/parser/eclipse/IntegrationTests/ParseTITLE.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTITLE.cpp
@@ -42,8 +42,8 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_TITLE_OK ) {
     ParserPtr parser(new Parser());
     std::string fileWithTitleKeyword("testdata/integration_tests/TITLE/TITLE1.txt");
-
-    DeckPtr deck = parser->parseFile(fileWithTitleKeyword, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck = parser->parseFile(fileWithTitleKeyword, parseContext);
 
     BOOST_CHECK_EQUAL(size_t(2), deck->size());
     BOOST_CHECK_EQUAL (true, deck->hasKeyword("TITLE"));

--- a/opm/parser/eclipse/IntegrationTests/ParseTVDP.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTVDP.cpp
@@ -38,7 +38,8 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE(ParseTVDP) {
     ParserPtr parser(new Parser());
     std::string poroFile("testdata/integration_tests/TVDP/TVDP1");
-    DeckPtr deck =  parser->parseFile(poroFile, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(poroFile, parseContext);
 
     BOOST_CHECK_EQUAL( false , deck->hasKeyword("TVDP*"));
     BOOST_CHECK( deck->hasKeyword("TVDPA"));

--- a/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
@@ -44,8 +44,8 @@ BOOST_AUTO_TEST_CASE( parse_VFPPROD_OK ) {
     ParserPtr parser(new Parser());
     std::string file("testdata/integration_tests/VFPPROD/VFPPROD1");
     BOOST_CHECK( parser->isRecognizedKeyword("VFPPROD"));
-
-    DeckPtr deck =  parser->parseFile(file, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(file, parseContext);
 
     const auto& VFPPROD1 = deck->getKeyword("VFPPROD" , 0);
     const auto& BPR = deck->getKeyword("BPR" , 0);

--- a/opm/parser/eclipse/IntegrationTests/ParseWCONHIST.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWCONHIST.cpp
@@ -42,7 +42,8 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_WCHONHIST_OK ) {
     ParserPtr parser(new Parser());
     std::string wconhistFile("testdata/integration_tests/WCONHIST/WCONHIST1");
-    DeckPtr deck =  parser->parseFile(wconhistFile, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(wconhistFile, parseContext);
     const auto& kw1 = deck->getKeyword("WCONHIST" , 0);
     BOOST_CHECK_EQUAL( 3U , kw1.size() );
 

--- a/opm/parser/eclipse/IntegrationTests/ParseWellProbe.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWellProbe.cpp
@@ -52,8 +52,8 @@ BOOST_AUTO_TEST_CASE(ParseWellProbe) {
         "/\n";
     BOOST_CHECK_THROW(parser->parseString(invalidDeckString), std::invalid_argument);
 */
-
-    DeckPtr deck = parser->parseString(validDeckString, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck = parser->parseString(validDeckString, parseContext);
     BOOST_CHECK( !deck->hasKeyword("WELL_PROBE"));
     BOOST_CHECK( deck->hasKeyword("WBHP"));
     BOOST_CHECK( deck->hasKeyword("WOPR"));

--- a/opm/parser/eclipse/IntegrationTests/ParseWellWithWildcards.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWellWithWildcards.cpp
@@ -42,10 +42,11 @@ using namespace Opm;
 BOOST_AUTO_TEST_CASE( parse_WCONPROD_OK ) {
     ParserPtr parser(new Parser());
     std::string wconprodFile("testdata/integration_tests/WellWithWildcards/WCONPROD1");
-    DeckPtr deck =  parser->parseFile(wconprodFile, ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck =  parser->parseFile(wconprodFile, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 30,30,30);
     IOConfigPtr ioConfig;
-    SchedulePtr sched(new Schedule(ParseContext() , grid , deck, ioConfig));
+    SchedulePtr sched(new Schedule(parseContext , grid , deck, ioConfig));
 
     BOOST_CHECK_EQUAL(5U, sched->numWells());
     BOOST_CHECK(sched->hasWell("INJE1"));

--- a/opm/parser/eclipse/IntegrationTests/Polymer.cpp
+++ b/opm/parser/eclipse/IntegrationTests/Polymer.cpp
@@ -37,7 +37,8 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE( parse_polymer_tables ) {
     ParserPtr parser(new Parser());
-    DeckPtr deck = parser->parseFile("testdata/integration_tests/POLYMER/POLY.inc", ParseContext());
+    Opm::ParseContext parseContext;
+    DeckPtr deck = parser->parseFile("testdata/integration_tests/POLYMER/POLY.inc", parseContext);
     Opm::TableManager tables( *deck );
     const TableContainer& plymax = tables.getPlymaxTables();
     const TableContainer& plyrock = tables.getPlyrockTables();

--- a/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -22,8 +22,6 @@
 
 #include <boost/algorithm/string.hpp>
 
-#include <opm/common/OpmLog/LogUtil.hpp>
-#include <opm/common/OpmLog/OpmLog.hpp>
 #include <opm/parser/eclipse/Parser/InputErrorAction.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
@@ -77,11 +75,11 @@ namespace Opm {
     }
 
 
-    void ParseContext::handleError( const std::string& errorKey , const std::string& msg) const {
+    void ParseContext::handleError( const std::string& errorKey , const std::string& msg) {
         InputError::Action action = get( errorKey );
 
         if (action == InputError::WARN)
-            OpmLog::addMessage(Log::MessageType::Warning , msg);
+            m_messageContainer.warning(msg);
         else if (action == InputError::THROW_EXCEPTION)
             throw std::invalid_argument(errorKey + ": " + msg);
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -80,7 +80,7 @@ namespace Opm {
     public:
         ParseContext();
         ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
-        void handleError( const std::string& errorKey , const std::string& msg) const;
+        void handleError( const std::string& errorKey , const std::string& msg);
         bool hasKey(const std::string& key) const;
         void updateKey(const std::string& key , InputError::Action action);
         void update(InputError::Action action);

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -47,7 +47,7 @@ namespace Opm {
 
 
     struct ParserState {
-        const ParseContext& parseContext;
+        ParseContext& parseContext;
         Deck * deck;
         boost::filesystem::path dataFile;
         boost::filesystem::path rootPath;
@@ -70,7 +70,7 @@ namespace Opm {
             rootPath = parent.rootPath;
         }
 
-        ParserState(const ParseContext& __parseContext)
+        ParserState(ParseContext& __parseContext)
             : parseContext( __parseContext ),
               deck( new Deck() ),
               pathMap( std::make_shared< std::map< std::string, std::string > >() ),
@@ -222,7 +222,7 @@ namespace Opm {
      is retained in the current implementation.
      */
 
-    Deck * Parser::newDeckFromFile(const std::string &dataFileName, const ParseContext& parseContext) const {
+    Deck * Parser::newDeckFromFile(const std::string &dataFileName, ParseContext& parseContext) const {
         std::shared_ptr<ParserState> parserState = std::make_shared<ParserState>(parseContext);
         parserState->openRootFile( dataFileName );
         parseState(parserState);
@@ -231,7 +231,7 @@ namespace Opm {
         return parserState->deck;
     }
 
-    Deck * Parser::newDeckFromString(const std::string &data, const ParseContext& parseContext) const {
+    Deck * Parser::newDeckFromString(const std::string &data, ParseContext& parseContext) const {
         std::shared_ptr<ParserState> parserState = std::make_shared<ParserState>(parseContext);
         parserState->openString( data );
 
@@ -242,15 +242,15 @@ namespace Opm {
     }
 
 
-    DeckPtr Parser::parseFile(const std::string &dataFileName, const ParseContext& parseContext) const {
+    DeckPtr Parser::parseFile(const std::string &dataFileName, ParseContext& parseContext) const {
         return std::shared_ptr<Deck>( newDeckFromFile( dataFileName , parseContext));
     }
 
-    DeckPtr Parser::parseString(const std::string &data, const ParseContext& parseContext) const {
+    DeckPtr Parser::parseString(const std::string &data, ParseContext& parseContext) const {
         return std::shared_ptr<Deck>( newDeckFromString( data , parseContext));
     }
 
-    DeckPtr Parser::parseStream(std::shared_ptr<std::istream> inputStream, const ParseContext& parseContext) const {
+    DeckPtr Parser::parseStream(std::shared_ptr<std::istream> inputStream, ParseContext& parseContext) const {
         std::shared_ptr<ParserState> parserState = std::make_shared<ParserState>(parseContext);
         parserState->openStream( inputStream );
 

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -56,12 +56,12 @@ namespace Opm {
         static std::string stripComments(const std::string& inputString);
 
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
-        std::shared_ptr< Deck > parseFile(const std::string &dataFile, const ParseContext& parseContext) const;
-        std::shared_ptr< Deck > parseString(const std::string &data, const ParseContext& parseContext) const;
-        std::shared_ptr< Deck > parseStream(std::shared_ptr<std::istream> inputStream , const ParseContext& parseContext) const;
+        std::shared_ptr< Deck > parseFile(const std::string &dataFile, ParseContext& parseContext) const;
+        std::shared_ptr< Deck > parseString(const std::string &data, ParseContext& parseContext) const;
+        std::shared_ptr< Deck > parseStream(std::shared_ptr<std::istream> inputStream , ParseContext& parseContext) const;
 
-        Deck * newDeckFromFile(const std::string &dataFileName, const ParseContext& parseContext) const;
-        Deck * newDeckFromString(const std::string &dataFileName, const ParseContext& parseContext) const;
+        Deck * newDeckFromFile(const std::string &dataFileName, ParseContext& parseContext) const;
+        Deck * newDeckFromString(const std::string &dataFileName, ParseContext& parseContext) const;
 
         std::shared_ptr< Deck > parseFile(const std::string &dataFile, bool strict = true) const;
         std::shared_ptr< Deck > parseString(const std::string &data, bool strict = true) const;

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -506,7 +506,7 @@ namespace Opm {
         return m_deckNames.end();
     }
 
-    DeckKeyword ParserKeyword::parse(const ParseContext& parseContext , RawKeywordPtr rawKeyword) const {
+    DeckKeyword ParserKeyword::parse(ParseContext& parseContext , RawKeywordPtr rawKeyword) const {
         if (rawKeyword->isFinished()) {
             DeckKeyword keyword( rawKeyword->getKeywordName() );
             keyword.setLocation(rawKeyword->getFilename(), rawKeyword->getLineNR());

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -95,7 +95,7 @@ namespace Opm {
         SectionNameSet::const_iterator validSectionNamesBegin() const;
         SectionNameSet::const_iterator validSectionNamesEnd() const;
 
-        DeckKeyword parse(const ParseContext& parseContext , std::shared_ptr< RawKeyword > rawKeyword) const;
+        DeckKeyword parse(ParseContext& parseContext , std::shared_ptr< RawKeyword > rawKeyword) const;
         enum ParserKeywordSizeEnum getSizeType() const;
         const std::pair<std::string,std::string>& getSizeDefinitionPair() const;
         bool isDataKeyword() const;

--- a/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -116,7 +116,7 @@ namespace Opm {
         }
     }
 
-    DeckRecord ParserRecord::parse(const ParseContext& parseContext , RawRecord& rawRecord ) const {
+    DeckRecord ParserRecord::parse(ParseContext& parseContext , RawRecord& rawRecord ) const {
         DeckRecord deckRecord( size() + 20 );
         for (size_t i = 0; i < size(); i++) {
             auto parserItem = get(i);

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -40,7 +40,7 @@ namespace Opm {
         void addDataItem(std::shared_ptr< const ParserItem > item);
         std::shared_ptr< const ParserItem > get(size_t index) const;
         std::shared_ptr< const ParserItem > get(const std::string& itemName) const;
-        DeckRecord parse( const ParseContext&, RawRecord& ) const;
+        DeckRecord parse(ParseContext&, RawRecord& ) const;
         bool isDataRecord() const;
         bool equal(const ParserRecord& other) const;
         bool hasDimension() const;

--- a/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
@@ -31,7 +31,8 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeValid) {
     boost::filesystem::path inputFilePath("testdata/parser/includeValid.data");
 
     Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseFile(inputFilePath.string() , Opm::ParseContext());
+    Opm::ParseContext parseContext;
+    Opm::DeckConstPtr deck = parser->parseFile(inputFilePath.string() , parseContext);
 
     BOOST_CHECK_EQUAL(true , deck->hasKeyword("OIL"));
     BOOST_CHECK_EQUAL(false , deck->hasKeyword("WATER"));
@@ -41,7 +42,8 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeInvalid) {
     boost::filesystem::path inputFilePath("testdata/parser/includeInvalid.data");
 
     Opm::ParserPtr parser(new Opm::Parser());
-    BOOST_CHECK_THROW(parser->parseFile(inputFilePath.string() , Opm::ParseContext()), std::runtime_error);
+    Opm::ParseContext parseContext;
+    BOOST_CHECK_THROW(parser->parseFile(inputFilePath.string() , parseContext), std::runtime_error);
 }
 
 BOOST_AUTO_TEST_CASE(ParserKeyword_includeWrongCase) {
@@ -50,25 +52,26 @@ BOOST_AUTO_TEST_CASE(ParserKeyword_includeWrongCase) {
     boost::filesystem::path inputFile3Path("testdata/parser/includeWrongCase3.data");
 
     Opm::ParserPtr parser(new Opm::Parser());
+    Opm::ParseContext parseContext;
 
 #if HAVE_CASE_SENSITIVE_FILESYSTEM
     // so far, we expect the files which are included to exhibit
     // exactly the same spelling as their names on disk. Eclipse seems
     // to be a bit more relaxed when it comes to this, so we might
     // have to change the current behavior one not-so-fine day...
-    BOOST_CHECK_THROW(parser->parseFile(inputFile1Path.string(), Opm::ParseContext()), std::runtime_error);
-    BOOST_CHECK_THROW(parser->parseFile(inputFile2Path.string(), Opm::ParseContext()), std::runtime_error);
-    BOOST_CHECK_THROW(parser->parseFile(inputFile3Path.string(), Opm::ParseContext()), std::runtime_error);
+    BOOST_CHECK_THROW(parser->parseFile(inputFile1Path.string(), parseContext), std::runtime_error);
+    BOOST_CHECK_THROW(parser->parseFile(inputFile2Path.string(), parseContext), std::runtime_error);
+    BOOST_CHECK_THROW(parser->parseFile(inputFile3Path.string(), parseContext), std::runtime_error);
 #else
     // for case-insensitive filesystems, the include statement will
     // always work regardless of how the capitalization of the
     // included files is wrong...
-    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile1Path.string(), Opm::ParseContext())->hasKeyword("OIL"));
-    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile1Path.string(), Opm::ParseContext())->hasKeyword("WATER"));
-    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile2Path.string(), Opm::ParseContext())->hasKeyword("OIL"));
-    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile2Path.string(), Opm::ParseContext())->hasKeyword("WATER"));
-    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile3Path.string(), Opm::ParseContext())->hasKeyword("OIL"));
-    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile3Path.string(), Opm::ParseContext())->hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile1Path.string(), parseContext)->hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile1Path.string(), parseContext)->hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile2Path.string(), parseContext)->hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile2Path.string(), parseContext)->hasKeyword("WATER"));
+    BOOST_CHECK_EQUAL(true, parser->parseFile(inputFile3Path.string(), parseContext)->hasKeyword("OIL"));
+    BOOST_CHECK_EQUAL(false, parser->parseFile(inputFile3Path.string(), parseContext)->hasKeyword("WATER"));
 #endif
 }
 

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -289,6 +289,7 @@ BOOST_AUTO_TEST_CASE( quoted_comments ) {
 
 BOOST_AUTO_TEST_CASE( PATHS_has_global_scope ) {
     Parser parser;
-    parser.newDeckFromFile( "testdata/parser/PATHSInInclude.data", ParseContext() );
-    BOOST_CHECK_THROW( parser.newDeckFromFile( "testdata/parser/PATHSInIncludeInvalid.data", ParseContext() ), std::runtime_error );
+    ParseContext parseContext;
+    parser.newDeckFromFile( "testdata/parser/PATHSInInclude.data", parseContext );
+    BOOST_CHECK_THROW( parser.newDeckFromFile( "testdata/parser/PATHSInIncludeInvalid.data", parseContext ), std::runtime_error );
 }

--- a/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
+++ b/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
@@ -41,7 +41,8 @@ std::shared_ptr<const Deck> createCOMPSEGSDeck() {
         "/\n";
 
     Parser parser;
-    DeckConstPtr deck(parser.parseString(deckData, ParseContext()));
+    ParseContext parseContext;
+    DeckConstPtr deck(parser.parseString(deckData, parseContext));
     return deck;
 }
 

--- a/opm/parser/eclipse/python/c_inter/cparser.cc
+++ b/opm/parser/eclipse/python/c_inter/cparser.cc
@@ -7,7 +7,7 @@
 
 extern "C" {
 
-    Opm::Deck * parser_parse_file(const Opm::Parser * parser , const char * file , const Opm::ParseContext * parse_mode) {
+    Opm::Deck * parser_parse_file(const Opm::Parser * parser , const char * file , Opm::ParseContext * parse_mode) {
         return parser->newDeckFromFile( file , *parse_mode );
     }
 


### PR DESCRIPTION
This PR is the first step to replace OpmLog with MessageContainer in opm-parser. 
Due to the implementation of new ParseContext, lots of argument of ``const  ParseContext`` is replaced with ``ParseContext``.  If you have any new or effective way to avoid this transition, please feel free to make comments.