### PR TITLE
ReadValueToken correctly parses numbers

### DIFF
--- a/opm/parser/eclipse/RawDeck/tests/StarTokenTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/StarTokenTests.cpp
@@ -100,8 +100,21 @@ BOOST_AUTO_TEST_CASE( ContainsStar_WithStar_ReturnsTrue ) {
 
 BOOST_AUTO_TEST_CASE( readValueToken_basic_validity_tests ) {
     BOOST_CHECK_THROW( Opm::readValueToken<int>( std::string( "3.3" ) ), std::invalid_argument );
+    BOOST_CHECK_EQUAL( 3, Opm::readValueToken<int>( std::string( "3" ) ) );
+    BOOST_CHECK_EQUAL( 3, Opm::readValueToken<int>( std::string( "+3" ) ) );
+    BOOST_CHECK_EQUAL( -3, Opm::readValueToken<int>( std::string( "-3" ) ) );
     BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "truls" ) ), std::invalid_argument );
-    BOOST_CHECK_EQUAL( "3.3", Opm::readValueToken<std::string>( std::string( "3.3" ) ) );
+    BOOST_CHECK_EQUAL( 0, Opm::readValueToken<double>( std::string( "0" ) ) );
+    BOOST_CHECK_EQUAL( 0, Opm::readValueToken<double>( std::string( "0.0" ) ) );
+    BOOST_CHECK_EQUAL( 0, Opm::readValueToken<double>( std::string( "+0.0" ) ) );
+    BOOST_CHECK_EQUAL( 0, Opm::readValueToken<double>( std::string( "-0.0" ) ) );
+    BOOST_CHECK_EQUAL( 0, Opm::readValueToken<double>( std::string( ".0" ) ) );
+    BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "1.0.0" ) ), std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "1g0" ) ), std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "1.23h" ) ), std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "+1.23h" ) ), std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::readValueToken<double>( std::string( "-1.23h" ) ), std::invalid_argument );
+    BOOST_CHECK_EQUAL( 3.3, Opm::readValueToken<double>( std::string( "3.3" ) ) );
     BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3e0" ) ), 1e-6 );
     BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3d0" ) ), 1e-6 );
     BOOST_CHECK_CLOSE( 3.3, Opm::readValueToken<double>( std::string( "3.3E0" ) ), 1e-6 );


### PR DESCRIPTION
Changes the implementation of numbers parsing from std::atoi/f to
std::strtod/l. These support setting the optional end-of-string pointer
which are used to determine if a parsing was successful or not. This has
the nice side effect of *greatly* simplifying the logic, at the expense
of some C-style details.

Tests added to verify that the different edge cases are handled
properly.

Fixes issue https://github.com/OPM/opm-parser/issues/740