### PR TITLE
Jenkins reboot

### DIFF
--- a/jenkins/README.md
+++ b/jenkins/README.md
@@ -1,0 +1,21 @@
+# opm-parser jenkins build scripts:
+
+**build-opm-parser.sh**:
+This is a helper script which contains a function for building,
+testing and cloning opm-parser and its dependencies.
+
+**build.sh**:
+This script will build dependencies, then build opm-parser and execute its tests.
+It is intended for post-merge builds of the master branch.
+
+**build-pr.sh**:
+This script will build dependencies, then build opm-parser and execute its tests.
+It inspects the $ghbPrBuildComment environmental variable to obtain a pull request
+to use for for ert and opm-common (defaults to master)
+and then builds $sha1 of opm-parser.
+
+It is intended for pre-merge builds of pull requests.
+
+You specify a given pull request to use for opm-common through the trigger.
+The trigger line needs to contain ert=&lt;pull request number&gt; and/or
+opm-common=&lt;pull request number&gt;.

--- a/jenkins/build-opm-parser.sh
+++ b/jenkins/build-opm-parser.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+function build_opm_parser {
+  # Build ERT
+  pushd .
+  mkdir -p $WORKSPACE/deps/ert
+  cd $WORKSPACE/deps/ert
+  git init .
+  git remote add origin https://github.com/Ensembles/ert
+  git fetch origin $ERT:branch_to_build
+  test $? -eq 0 || exit 1
+  git checkout branch_to_build
+  popd
+
+  pushd .
+  mkdir -p serial/build-ert
+  cd serial/build-ert
+  cmake $WORKSPACE/deps/ert/devel -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install
+  make install
+  popd
+
+  # Build opm-common
+  pushd .
+  mkdir -p $WORKSPACE/deps/opm-common
+  cd $WORKSPACE/deps/opm-common
+  git init .
+  git remote add origin https://github.com/OPM/opm-common
+  git fetch origin $OPM_COMMON_REVISION:branch_to_build
+  test $? -eq 0 || exit 1
+  git checkout branch_to_build
+  popd
+  source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
+
+  pushd .
+  mkdir serial/build-opm-common
+  cd serial/build-opm-common
+  build_module "-DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install" 0 $WORKSPACE/deps/opm-common
+  popd
+
+  # Build opm-parser
+  git checkout $OPM_PARSER_REVISION
+  pushd .
+  mkdir serial/build-opm-parser
+  cd serial/build-opm-parser
+  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install" 1 $WORKSPACE
+  test $? -eq 0 || exit 1
+  popd
+}

--- a/jenkins/build-pr.sh
+++ b/jenkins/build-pr.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+source `dirname $0`/build-opm-parser.sh
+
+ERT_REVISION=master
+OPM_COMMON_REVISION=master
+OPM_PARSER_REVISION=$sha1
+
+if grep -q "ert=" <<< $ghprbCommentBody
+then
+  ERT_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*ert=([0-9]+).*/\1/g'`/merge
+fi
+if grep -q "opm-common=" <<< $ghprbCommentBody
+then
+  OPM_COMMON_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-common=([0-9]+).*/\1/g'`/merge
+fi
+
+echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$OPM_PARSER_REVISION"
+
+build_opm_parser
+test $? -eq 0 || exit 1
+
+cp serial/build-opm-parser/testoutput.xml .

--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+source `dirname $0`/build-opm-parser.sh
+
+ERT_REVISION=master
+OPM_COMMON_REVISION=master
+OPM_PARSER_REVISION=master
+
+build_opm_parser
+test $? -eq 0 || exit 1
+
+cp serial/build-opm-parser/testoutput.xml .


### PR DESCRIPTION
This is the Jenkins build scripts for this module, ref https://github.com/OPM/opm-common/pull/102

These files here serve the following purposes:
- README.md - simple instruction on how to use/setup on Jenkins.
- build.sh - Script intended for post-merge builds on Jenkins.
- build-pr.sh - Script intended for pre-merge pull request builds on Jenkins (through a trigger).
- build-opm-parser.sh - Shared code between the two build modes.

I have included ERT for my own convenience, although there is no trigger support to build against a PR there. Whether this is wanted or not I leave up to others to decide (trigger support is easily added if you want to take it all the way).

Basically, the pre-merge builds works through a trigger. Authorized persons can comment on a pull request to have Jenkins build it. This trigger is of the form
'jenkins build this [opm-common=&lt;<pr number&gt>] please'

where the bit in brackets is optional.

Note that the Jenkins jobs are NOT yet added. The post-merge script is not easily tested before things are merged, but you can try the pre-merge build from the command line:

from the top of the source tree (with this branch) use

WORKSPACE=`pwd` ghbprbCommentBody="jenkins build this opm-common=102 please" sha1='pull/743/merge' jenkins/build-pr.sh

this will build ert, then opm-common with pull request 102, then opm-parser with this pull request.