### PR TITLE
Rawkeyword iterator

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -375,7 +375,7 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
                     }
                 }
                 else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::include) {
-                    auto& firstRecord = parserState->rawKeyword->getRecord(0);
+                    auto& firstRecord = parserState->rawKeyword->getFirstRecord( );
                     std::string includeFileAsString = readValueToken<std::string>(firstRecord.getItem(0));
                     boost::filesystem::path includeFile = getIncludeFilePath(*parserState, includeFileAsString);
                     std::shared_ptr<ParserState> newParserState = parserState->includeState( includeFile );

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -511,17 +511,19 @@ namespace Opm {
             DeckKeyword keyword( rawKeyword->getKeywordName() );
             keyword.setLocation(rawKeyword->getFilename(), rawKeyword->getLineNR());
             keyword.setDataKeyword( isDataKeyword() );
-
-            for (size_t i = 0; i < rawKeyword->size(); i++) {
-                auto& rawRecord = rawKeyword->getRecord(i);
-                if(m_records.size() > 0) {
-                    keyword.addRecord( getRecord( i )->parse( parseContext, rawRecord ) );
-                }
-                else {
-                    if(rawRecord.size() > 0) {
-                        throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
-                    }
-                }
+	    {
+		size_t record_nr = 0;
+		for (auto& rawRecord : *rawKeyword) {
+		    if(m_records.size() > 0) {
+			keyword.addRecord( getRecord( record_nr )->parse( parseContext, rawRecord ) );
+		    }
+		    else {
+			if(rawRecord.size() > 0) {
+			    throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
+			}
+		    }
+		    record_nr++;
+		}
             }
             return keyword;
         } else

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -106,14 +106,8 @@ namespace Opm {
     }
 
 
-    RawRecord& RawKeyword::getRecord(size_t index) {
-        if( index >= this->m_records.size() )
-            throw std::out_of_range(
-                "Error: looking up record " + std::to_string( index )
-                + ", but RawKeyword has only "
-                + std::to_string( this->m_records.size() ) + " records." );
-
-        return *std::next( this->m_records.begin(), index );
+    const RawRecord& RawKeyword::getFirstRecord() const {
+        return *m_records.begin();
     }
 
     bool RawKeyword::isKeywordPrefix(const std::string& line, std::string& keywordName) {

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -172,6 +172,15 @@ namespace Opm {
         return this->m_records.end();
     }
 
+    RawKeyword::iterator RawKeyword::begin() {
+        return this->m_records.begin();
+    }
+
+    RawKeyword::iterator RawKeyword::end() {
+        return this->m_records.end();
+    }
+
+
     Raw::KeywordSizeEnum RawKeyword::getSizeType() const {
         return m_sizeType;
     }

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -45,7 +45,11 @@ namespace Opm {
         void addRawRecordString(const std::string& partialRecordString);
         size_t size() const;
         Raw::KeywordSizeEnum getSizeType() const;
-        RawRecord& getRecord( size_t index );
+
+        // Special case method only for inspecting INCLUDE keywords;
+        // the general getRecords functionality should use the
+        // iterator interface.
+        const RawRecord& getFirstRecord( ) const;
 
         static bool isKeywordPrefix(const std::string& line, std::string& keywordName);
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -58,9 +58,13 @@ namespace Opm {
         size_t getLineNR() const;
 
         using const_iterator = std::list< RawRecord >::const_iterator;
+        using iterator = std::list< RawRecord >::iterator;
 
         const_iterator begin() const;
         const_iterator end() const;
+        iterator begin();
+        iterator end();
+
 
     private:
         Raw::KeywordSizeEnum m_sizeType;

--- a/opm/parser/eclipse/RawDeck/tests/RawKeywordTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/RawKeywordTests.cpp
@@ -88,11 +88,6 @@ BOOST_AUTO_TEST_CASE(addRecord_singleRecord_recordAdded) {
     BOOST_CHECK_EQUAL(1U, keyword.size());
 }
 
-BOOST_AUTO_TEST_CASE(getRecord_outOfRange_throws) {
-    RawKeyword keyword("TEST", Raw::SLASH_TERMINATED , "FILE" , 10U);
-    keyword.addRawRecordString("test 1 3 4 /");
-    BOOST_CHECK_THROW(keyword.getRecord(1), std::out_of_range);
-}
 
 
 
@@ -141,10 +136,6 @@ BOOST_AUTO_TEST_CASE(isFinished_FixedsizeMulti) {
     BOOST_CHECK(  !keyword.isFinished() );
     keyword.addRawRecordString("1 2 3 3 /");
     BOOST_CHECK(  keyword.isFinished() );
-
-    const auto& record = keyword.getRecord(3);
-    BOOST_CHECK_EQUAL( 4U , record.size() );
-
 }
 
 BOOST_AUTO_TEST_CASE(isTableCollection) {


### PR DESCRIPTION
Using range based for instead of `getRecord( )`when iterating over `RawRecords`.

The `std::next( )` based solution chocked when meeting a keyword with O(400000) records.