### PR TITLE
Remove MessageContainer from ParseContext + storage type change

### DIFF
--- a/opm/parser/eclipse/Parser/MessageContainer.cpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.cpp
@@ -132,6 +132,15 @@ namespace Opm {
         );
     }
 
+    void MessageContainer::add( const Message& msg ) {
+        this->m_messages.push_back( msg );
+    }
+
+    void MessageContainer::add( Message&& msg ) {
+        this->m_messages.push_back( std::move( msg ) );
+    }
+
+
     std::vector<Message>::const_iterator MessageContainer::begin() const
     {
         return m_messages.begin();

--- a/opm/parser/eclipse/Parser/MessageContainer.cpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.cpp
@@ -141,14 +141,11 @@ namespace Opm {
     }
 
 
-    std::vector<Message>::const_iterator MessageContainer::begin() const
-    {
+    MessageContainer::const_iterator MessageContainer::begin() const {
         return m_messages.begin();
     }
 
-
-    std::vector<Message>::const_iterator MessageContainer::end() const
-    {
+    MessageContainer::const_iterator MessageContainer::end() const {
         return m_messages.end();
     }
 

--- a/opm/parser/eclipse/Parser/MessageContainer.cpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.cpp
@@ -24,10 +24,17 @@
 
 namespace Opm {
 
+    Location::Location( const std::string& fn, size_t ln ) :
+        filename( fn ), lineno( ln )
+    {
+        if( ln == 0 )
+            throw std::invalid_argument( "Invalid line number 0 for file '"
+                                         + fn + "'" );
+    }
 
     void MessageContainer::error( const std::string& msg,
                                   const std::string& filename,
-                                  const int lineno ) {
+                                  const size_t lineno ) {
         m_messages.emplace_back(
             Message { Message::Error, msg, Location { filename, lineno } }
         );
@@ -41,7 +48,7 @@ namespace Opm {
 
     void MessageContainer::bug( const std::string& msg,
                                 const std::string& filename,
-                                const int lineno ) {
+                                const size_t lineno ) {
         m_messages.emplace_back(
             Message { Message::Bug, msg, { filename, lineno } }
         );
@@ -55,7 +62,7 @@ namespace Opm {
 
     void MessageContainer::warning( const std::string& msg,
                                     const std::string& filename,
-                                    const int lineno ) {
+                                    const size_t lineno ) {
         m_messages.emplace_back( Message {
                 Message::Warning, msg, { filename, lineno }
             }
@@ -73,7 +80,7 @@ namespace Opm {
 
     void MessageContainer::info( const std::string& msg,
                                  const std::string& filename,
-                                 const int lineno ) {
+                                 const size_t lineno ) {
         m_messages.emplace_back(
             Message { Message::Info, msg, { filename, lineno } }
         );
@@ -87,7 +94,7 @@ namespace Opm {
 
     void MessageContainer::debug( const std::string& msg,
                                   const std::string& filename,
-                                  const int lineno ) {
+                                  const size_t lineno ) {
         m_messages.emplace_back(
             Message { Message::Debug, msg, { filename, lineno } }
         );
@@ -101,7 +108,7 @@ namespace Opm {
 
     void MessageContainer::problem( const std::string& msg,
                                     const std::string& filename,
-                                    const int lineno ) {
+                                    const size_t lineno ) {
         m_messages.emplace_back(
             Message { Message::Problem, msg, { filename, lineno } }
         );

--- a/opm/parser/eclipse/Parser/MessageContainer.cpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.cpp
@@ -28,35 +28,28 @@ namespace Opm {
     void MessageContainer::error( const std::string& msg,
                                   const std::string& filename,
                                   const int lineno ) {
-        m_messages.emplace_back( Message {
-            MessageType::MessageTypeEnum::Error, msg,
-            { filename, lineno } }
+        m_messages.emplace_back(
+            Message { Message::Error, msg, Location { filename, lineno } }
         );
     }
 
 
     void MessageContainer::error( const std::string& msg ) {
-        m_messages.emplace_back(
-            Message { MessageType::MessageTypeEnum::Error, msg, {} }
-        );
+        m_messages.emplace_back( Message { Message::Error, msg, {} } );
     }
 
 
     void MessageContainer::bug( const std::string& msg,
                                 const std::string& filename,
                                 const int lineno ) {
-        m_messages.emplace_back( Message {
-                MessageType::MessageTypeEnum::Bug, msg,
-                { filename, lineno }
-            }
+        m_messages.emplace_back(
+            Message { Message::Bug, msg, { filename, lineno } }
         );
     }
 
 
     void MessageContainer::bug( const std::string& msg ) {
-        m_messages.emplace_back(
-            Message { MessageType::MessageTypeEnum::Bug, msg,{} }
-        );
+        m_messages.emplace_back( Message { Message::Bug, msg, {} } );
     }
 
 
@@ -64,8 +57,7 @@ namespace Opm {
                                     const std::string& filename,
                                     const int lineno ) {
         m_messages.emplace_back( Message {
-                MessageType::MessageTypeEnum::Warning, msg,
-                { filename, lineno }
+                Message::Warning, msg, { filename, lineno }
             }
         );
     }
@@ -73,7 +65,7 @@ namespace Opm {
 
     void MessageContainer::warning( const std::string& msg ) {
         m_messages.emplace_back(
-            Message { MessageType::MessageTypeEnum::Warning, msg,{} }
+            Message { Message::Warning, msg,{} }
         );
     }
 
@@ -82,54 +74,42 @@ namespace Opm {
     void MessageContainer::info( const std::string& msg,
                                  const std::string& filename,
                                  const int lineno ) {
-        m_messages.emplace_back( Message {
-                MessageType::MessageTypeEnum::Info, msg,
-                { filename, lineno }
-            }
+        m_messages.emplace_back(
+            Message { Message::Info, msg, { filename, lineno } }
         );
     }
 
 
     void MessageContainer::info( const std::string& msg ) {
-        m_messages.emplace_back(
-            Message { MessageType::MessageTypeEnum::Info, msg,{} }
-        );
+        m_messages.emplace_back( Message { Message::Info, msg, {} } );
     }
 
 
     void MessageContainer::debug( const std::string& msg,
                                   const std::string& filename,
                                   const int lineno ) {
-        m_messages.emplace_back( Message {
-                MessageType::MessageTypeEnum::Debug, msg,
-                { filename, lineno }
-            }
+        m_messages.emplace_back(
+            Message { Message::Debug, msg, { filename, lineno } }
         );
     }
 
 
     void MessageContainer::debug( const std::string& msg ) {
-        m_messages.emplace_back(
-            Message { MessageType::MessageTypeEnum::Debug, msg,{} }
-        );
+        m_messages.emplace_back( Message { Message::Debug, msg, {} } );
     }
 
 
     void MessageContainer::problem( const std::string& msg,
                                     const std::string& filename,
                                     const int lineno ) {
-        m_messages.emplace_back( Message {
-                MessageType::MessageTypeEnum::Problem, msg,
-                { filename, lineno }
-            }
+        m_messages.emplace_back(
+            Message { Message::Problem, msg, { filename, lineno } }
         );
     }
 
 
     void MessageContainer::problem( const std::string& msg ) {
-        m_messages.emplace_back(
-            Message { MessageType::MessageTypeEnum::Problem, msg, {} }
-        );
+        m_messages.emplace_back( Message { Message::Problem, msg, {} } );
     }
 
     void MessageContainer::add( const Message& msg ) {

--- a/opm/parser/eclipse/Parser/MessageContainer.cpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.cpp
@@ -25,85 +25,112 @@
 namespace Opm {
 
 
-    void MessageContainer::error(const std::string& msg, const std::string& filename, const int lineno)
-    {
-        std::unique_ptr<Location> loc(new Location{filename, lineno});
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Error, msg, std::move(loc)});
+    void MessageContainer::error( const std::string& msg,
+                                  const std::string& filename,
+                                  const int lineno ) {
+        m_messages.emplace_back( Message {
+            MessageType::MessageTypeEnum::Error, msg,
+            { filename, lineno } }
+        );
     }
 
 
-    void MessageContainer::error(const std::string& msg)
-    {
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Error, msg, nullptr});
+    void MessageContainer::error( const std::string& msg ) {
+        m_messages.emplace_back(
+            Message { MessageType::MessageTypeEnum::Error, msg, {} }
+        );
     }
 
 
-    void MessageContainer::bug(const std::string& msg, const std::string& filename, const int lineno)
-    {
-        std::unique_ptr<Location> loc(new Location{filename, lineno});
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Bug, msg, std::move(loc)});
+    void MessageContainer::bug( const std::string& msg,
+                                const std::string& filename,
+                                const int lineno ) {
+        m_messages.emplace_back( Message {
+                MessageType::MessageTypeEnum::Bug, msg,
+                { filename, lineno }
+            }
+        );
     }
 
 
-    void MessageContainer::bug(const std::string& msg)
-    {
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Bug, msg, nullptr});
+    void MessageContainer::bug( const std::string& msg ) {
+        m_messages.emplace_back(
+            Message { MessageType::MessageTypeEnum::Bug, msg,{} }
+        );
     }
 
 
-    void MessageContainer::warning(const std::string& msg, const std::string& filename, const int lineno)
-    {
-        std::unique_ptr<Location> loc(new Location{filename, lineno});
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Warning, msg, std::move(loc)});
+    void MessageContainer::warning( const std::string& msg,
+                                    const std::string& filename,
+                                    const int lineno ) {
+        m_messages.emplace_back( Message {
+                MessageType::MessageTypeEnum::Warning, msg,
+                { filename, lineno }
+            }
+        );
     }
 
 
-    void MessageContainer::warning(const std::string& msg)
-    {
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Warning, msg, nullptr});
+    void MessageContainer::warning( const std::string& msg ) {
+        m_messages.emplace_back(
+            Message { MessageType::MessageTypeEnum::Warning, msg,{} }
+        );
     }
 
 
 
-    void MessageContainer::info(const std::string& msg, const std::string& filename, const int lineno)
-    {
-        std::unique_ptr<Location> loc(new Location{filename, lineno});
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Info, msg, std::move(loc)});
+    void MessageContainer::info( const std::string& msg,
+                                 const std::string& filename,
+                                 const int lineno ) {
+        m_messages.emplace_back( Message {
+                MessageType::MessageTypeEnum::Info, msg,
+                { filename, lineno }
+            }
+        );
     }
 
 
-    void MessageContainer::info(const std::string& msg)
-    {
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Info, msg, nullptr});
+    void MessageContainer::info( const std::string& msg ) {
+        m_messages.emplace_back(
+            Message { MessageType::MessageTypeEnum::Info, msg,{} }
+        );
     }
 
 
-    void MessageContainer::debug(const std::string& msg, const std::string& filename, const int lineno)
-    {
-        std::unique_ptr<Location> loc(new Location{filename, lineno});
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Debug, msg, std::move(loc)});
+    void MessageContainer::debug( const std::string& msg,
+                                  const std::string& filename,
+                                  const int lineno ) {
+        m_messages.emplace_back( Message {
+                MessageType::MessageTypeEnum::Debug, msg,
+                { filename, lineno }
+            }
+        );
     }
 
 
-    void MessageContainer::debug(const std::string& msg)
-    {
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Debug, msg, nullptr});
+    void MessageContainer::debug( const std::string& msg ) {
+        m_messages.emplace_back(
+            Message { MessageType::MessageTypeEnum::Debug, msg,{} }
+        );
     }
 
 
-    void MessageContainer::problem(const std::string& msg, const std::string& filename, const int lineno)
-    {
-        std::unique_ptr<Location> loc(new Location{filename, lineno});
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Problem, msg, std::move(loc)});
+    void MessageContainer::problem( const std::string& msg,
+                                    const std::string& filename,
+                                    const int lineno ) {
+        m_messages.emplace_back( Message {
+                MessageType::MessageTypeEnum::Problem, msg,
+                { filename, lineno }
+            }
+        );
     }
 
 
-    void MessageContainer::problem(const std::string& msg)
-    {
-        m_messages.emplace_back(Message{MessageType::MessageTypeEnum::Problem, msg, nullptr});
+    void MessageContainer::problem( const std::string& msg ) {
+        m_messages.emplace_back(
+            Message { MessageType::MessageTypeEnum::Problem, msg, {} }
+        );
     }
-
-
 
     std::vector<Message>::const_iterator MessageContainer::begin() const
     {

--- a/opm/parser/eclipse/Parser/MessageContainer.hpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.hpp
@@ -28,14 +28,13 @@ namespace Opm {
 
     struct Location {
         Location() = default;
-        Location( const std::string& fn, int ln ) :
-            filename( fn ), lineno( ln ) {}
+        Location( const std::string&, size_t );
 
         std::string filename;
-        int lineno = -1;
+        size_t lineno = 0;
 
         explicit operator bool() const {
-            return lineno > 0;
+            return lineno != 0;
         }
     };
 
@@ -68,22 +67,22 @@ namespace Opm {
 
         using const_iterator = std::vector< Message >::const_iterator;
 
-        void error(const std::string& msg, const std::string& filename, const int lineno);
+        void error(const std::string& msg, const std::string& filename, const size_t lineno);
         void error(const std::string& msg);
 
-        void bug(const std::string& msg, const std::string& filename, const int lineno);
+        void bug(const std::string& msg, const std::string& filename, const size_t lineno);
         void bug(const std::string& msg);
 
-        void warning(const std::string& msg, const std::string& filename, const int lineno);
+        void warning(const std::string& msg, const std::string& filename, const size_t lineno);
         void warning(const std::string& msg);
 
-        void info(const std::string& msg, const std::string& filename, const int lineno);
+        void info(const std::string& msg, const std::string& filename, const size_t lineno);
         void info(const std::string& msg);
 
-        void debug(const std::string& msg, const std::string& filename, const int lineno);
+        void debug(const std::string& msg, const std::string& filename, const size_t lineno);
         void debug(const std::string& msg);
 
-        void problem(const std::string& msg, const std::string& filename, const int lineno);
+        void problem(const std::string& msg, const std::string& filename, const size_t lineno);
         void problem(const std::string& msg);
 
         void add( const Message& );

--- a/opm/parser/eclipse/Parser/MessageContainer.hpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.hpp
@@ -29,6 +29,9 @@ namespace Opm {
     namespace MessageType {
 
         enum MessageTypeEnum {
+
+    struct Message {
+        enum type {
             Debug     = 1,
             Info      = 2,
             Warning   = 3,
@@ -41,15 +44,22 @@ namespace Opm {
 
 
     struct Location {
+        Location() = default;
+        Location( const std::string& s, int l ) : filename( s ), lineno( l ) {}
+
         std::string filename;
-        int lineno;
+        int lineno = -1;
+
+        explicit operator bool() const {
+            return lineno > 0;
+        }
     };
 
 
     struct Message {
         MessageType::MessageTypeEnum mtype;
         std::string message;
-        std::unique_ptr<Location> location;
+        Location location;
     };
 
 

--- a/opm/parser/eclipse/Parser/MessageContainer.hpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.hpp
@@ -26,9 +26,18 @@
 
 namespace Opm {
 
-    namespace MessageType {
+    struct Location {
+        Location() = default;
+        Location( const std::string& fn, int ln ) :
+            filename( fn ), lineno( ln ) {}
 
-        enum MessageTypeEnum {
+        std::string filename;
+        int lineno = -1;
+
+        explicit operator bool() const {
+            return lineno > 0;
+        }
+    };
 
     struct Message {
         enum type {
@@ -40,24 +49,14 @@ namespace Opm {
             Bug       = 6
         };
 
-    } // namespace MessageType
+        Message( type mt, const std::string& msg, Location&& loc ) :
+            mtype( mt ), message( msg ), location( std::move( loc ) ) {}
+
+        Message( type mt, const std::string& msg ) :
+            mtype( mt ), message( msg ) {}
 
 
-    struct Location {
-        Location() = default;
-        Location( const std::string& s, int l ) : filename( s ), lineno( l ) {}
-
-        std::string filename;
-        int lineno = -1;
-
-        explicit operator bool() const {
-            return lineno > 0;
-        }
-    };
-
-
-    struct Message {
-        MessageType::MessageTypeEnum mtype;
+        type mtype;
         std::string message;
         Location location;
     };

--- a/opm/parser/eclipse/Parser/MessageContainer.hpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.hpp
@@ -84,6 +84,9 @@ namespace Opm {
         void problem(const std::string& msg, const std::string& filename, const int lineno);
         void problem(const std::string& msg);
 
+        void add( const Message& );
+        void add( Message&& );
+
         std::vector<Message>::const_iterator begin() const;
         std::vector<Message>::const_iterator end() const;
     private:

--- a/opm/parser/eclipse/Parser/MessageContainer.hpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.hpp
@@ -66,6 +66,9 @@ namespace Opm {
     ///Message container is used to replace OpmLog functionalities.
     class MessageContainer {
     public:
+
+        using const_iterator = std::vector< Message >::const_iterator;
+
         void error(const std::string& msg, const std::string& filename, const int lineno);
         void error(const std::string& msg);
 
@@ -87,8 +90,8 @@ namespace Opm {
         void add( const Message& );
         void add( Message&& );
 
-        std::vector<Message>::const_iterator begin() const;
-        std::vector<Message>::const_iterator end() const;
+        const_iterator begin() const;
+        const_iterator end() const;
     private:
         std::vector<Message> m_messages;
     };

--- a/opm/parser/eclipse/Parser/MessageContainer.hpp
+++ b/opm/parser/eclipse/Parser/MessageContainer.hpp
@@ -20,8 +20,6 @@
 #ifndef MESSAGECONTAINER_H
 #define MESSAGECONTAINER_H
 
-#endif // OPM_MESSAGECONTAINER_HEADER_INCLUDED
-
 #include <string>
 #include <vector>
 #include <memory>
@@ -83,3 +81,5 @@ namespace Opm {
     };
 
 } // namespace Opm
+
+#endif // OPM_MESSAGECONTAINER_HEADER_INCLUDED

--- a/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -77,13 +77,19 @@ namespace Opm {
     }
 
 
-    void ParseContext::handleError( const std::string& errorKey , const std::string& msg) const {
+    Message::type ParseContext::handleError(
+            const std::string& errorKey,
+            const std::string& msg ) const {
+
         InputError::Action action = get( errorKey );
 
         if (action == InputError::WARN)
-            OpmLog::addMessage(Log::MessageType::Warning , msg);
+            return Message::Warning;
+
         else if (action == InputError::THROW_EXCEPTION)
             throw std::invalid_argument(errorKey + ": " + msg);
+
+        return Message::Debug;
 
     }
 
@@ -95,19 +101,6 @@ namespace Opm {
     std::map<std::string,InputError::Action>::const_iterator ParseContext::end() const {
         return m_errorContexts.end();
     }
-
-
-    const MessageContainer& ParseContext::getMessageContainer() const
-    {
-        return m_messageContainer;
-    }
-
-
-    MessageContainer& ParseContext::getMessageContainer()
-    {
-        return m_messageContainer;
-    }
-
 
     bool ParseContext::hasKey(const std::string& key) const {
         if (m_errorContexts.find( key ) == m_errorContexts.end())

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -80,7 +80,7 @@ namespace Opm {
     public:
         ParseContext();
         ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
-        void handleError( const std::string& errorKey , const std::string& msg) const;
+        Message::type handleError( const std::string& errorKey, const std::string& msg ) const;
         bool hasKey(const std::string& key) const;
         void updateKey(const std::string& key , InputError::Action action);
         void update(InputError::Action action);
@@ -88,8 +88,6 @@ namespace Opm {
         InputError::Action get(const std::string& key) const;
         std::map<std::string,InputError::Action>::const_iterator begin() const;
         std::map<std::string,InputError::Action>::const_iterator end() const;
-        const MessageContainer& getMessageContainer() const;
-        MessageContainer& getMessageContainer();
         /*
           When the key is added it is inserted in 'strict mode',
           i.e. with the value 'InputError::THROW_EXCEPTION. If you
@@ -199,7 +197,6 @@ namespace Opm {
         void envUpdate( const std::string& envVariable , InputError::Action action );
         void patternUpdate( const std::string& pattern , InputError::Action action);
         std::map<std::string , InputError::Action> m_errorContexts;
-        MessageContainer m_messageContainer;
 }; }
 
 

--- a/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
+++ b/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
@@ -60,4 +60,5 @@ BOOST_AUTO_TEST_CASE(LocationImplicitConversion) {
 
     BOOST_CHECK( !mc.begin()->location );
     BOOST_CHECK( (mc.begin() + 1)->location );
+    BOOST_CHECK_THROW( mc.info( "msg", "filename", 0 ), std::invalid_argument );
 }

--- a/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
+++ b/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
@@ -34,8 +34,8 @@ BOOST_AUTO_TEST_CASE(TestIterator) {
     msgContainer.bug("This is a bug.", "dummy.log", 20);
     {       
         BOOST_CHECK_EQUAL("This is an error.", msgContainer.begin()->message);
-        BOOST_CHECK_EQUAL("dummy.log", (msgContainer.end()-1)->location->filename);
-        BOOST_CHECK_EQUAL(20, (msgContainer.end()-1)->location->lineno);
+        BOOST_CHECK_EQUAL("dummy.log", (msgContainer.end()-1)->location.filename);
+        BOOST_CHECK_EQUAL(20, (msgContainer.end()-1)->location.lineno);
     }
     
     MessageContainer msgList;

--- a/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
+++ b/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
@@ -51,6 +51,13 @@ BOOST_AUTO_TEST_CASE(TestIterator) {
         BOOST_CHECK_EQUAL(msg.message, msgString[i]);
         i++;
     }
+}
 
+BOOST_AUTO_TEST_CASE(LocationImplicitConversion) {
+    MessageContainer mc;
+    mc.warning( "Warning" );
+    mc.info( "Info", "filename", 10 );
 
+    BOOST_CHECK( !mc.begin()->location );
+    BOOST_CHECK( (mc.begin() + 1)->location );
 }


### PR DESCRIPTION
As a step towards (re)making `ParseContext` a read-only configuration object, remove `MessageContainer` from parse context. The patch set also changes Messages to auto-only storage, deprecating `unique_ptr`s.