### PR TITLE
Refactoring of internal parsing

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -203,4 +203,12 @@ namespace Opm {
         m_dataFile = dataFile;
     }
 
+    Deck::iterator Deck::begin() {
+        return this->keywordList.begin();
+    }
+
+    Deck::iterator Deck::end() {
+        return this->keywordList.end();
+    }
+
 }

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -117,6 +117,8 @@ namespace Opm {
             using DeckView::begin;
             using DeckView::end;
 
+            using iterator = std::vector< DeckKeyword >::iterator;
+
             Deck();
             void addKeyword( DeckKeyword&& keyword );
             void addKeyword( const DeckKeyword& keyword );
@@ -132,6 +134,9 @@ namespace Opm {
 
             const std::string getDataFile() const;
             void setDataFile(const std::string& dataFile);
+
+            iterator begin();
+            iterator end();
 
         private:
             Deck( std::vector< DeckKeyword >&& );

--- a/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -212,7 +212,8 @@ namespace Opm {
     }
 
     const std::vector< double >& DeckItemT< double >::assertSIData() const {
-        if( this->dimensions.size() <= 0 )
+        const auto dim_size = dimensions.size();
+        if( dim_size <= 0 )
             throw std::invalid_argument("No dimension has been set for item:" + this->name() + " can not ask for SI data");
 
         // we already converted this item to SI?
@@ -222,10 +223,11 @@ namespace Opm {
          * This is an unobservable state change - SIData is lazily converted to
          * SI units, so externally the object still behaves as const
          */
-        this->SIdata.resize( this->size() );
+        const auto size = this->size();
+        this->SIdata.resize( size );
 
-        for( size_t index = 0; index < this->size(); index++ ) {
-            const auto dimIndex = ( index % dimensions.size() );
+        for( size_t index = 0; index < size; index++ ) {
+            const auto dimIndex = index % dim_size;
             this->SIdata[ index ] = this->dimensions[ dimIndex ]
                                           ->convertRawToSi( this->get( index ) );
         }

--- a/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
@@ -100,7 +100,7 @@ BOOST_AUTO_TEST_CASE(get_byNameNonExisting_throws) {
 BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
     ParserStringItemPtr itemString(new ParserStringItem(std::string("STRINGITEM1")));
     ParserRecordPtr record1(new ParserRecord());
-    RawRecord rawRecord( " ' VALUE ' /" );
+    RawRecord rawRecord( " ' VALUE ' " );
     ParseContext parseContext;
     record1->addItem( itemString );
 

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -234,7 +234,8 @@ namespace Opm {
     template< typename T >
     void GridProperty< T >::loadFromDeckKeyword( const DeckKeyword& deckKeyword ) {
         const auto& deckItem = getDeckItem(deckKeyword);
-        for (size_t dataPointIdx = 0; dataPointIdx < deckItem.size(); ++dataPointIdx) {
+        const auto size = deckItem.size();
+        for (size_t dataPointIdx = 0; dataPointIdx < size; ++dataPointIdx) {
             if (!deckItem.defaultApplied(dataPointIdx))
                 setDataPoint(dataPointIdx, dataPointIdx, deckItem);
         }

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -94,11 +94,11 @@ BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
         "WWCT\n"
         "  'WELL-1' 'WELL-2' / -- Rumpelstilzchen\n"
         "/\n";
-    std::shared_ptr<std::istream> wwctStream(new std::istringstream(wwctString));
+    std::unique_ptr<std::istream> wwctStream(new std::istringstream(wwctString));
     ParserPtr parser = createWWCTParser();
     BOOST_CHECK( parser->isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser->isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseStream(wwctStream, ParseContext()));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseStream(std::move(wwctStream), ParseContext()));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -94,11 +94,10 @@ BOOST_AUTO_TEST_CASE(parse_streamWithWWCTKeyword_deckReturned) {
         "WWCT\n"
         "  'WELL-1' 'WELL-2' / -- Rumpelstilzchen\n"
         "/\n";
-    std::unique_ptr<std::istream> wwctStream(new std::istringstream(wwctString));
     ParserPtr parser = createWWCTParser();
     BOOST_CHECK( parser->isRecognizedKeyword("WWCT"));
     BOOST_CHECK( parser->isRecognizedKeyword("SUMMARY"));
-    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseStream(std::move(wwctStream), ParseContext()));
+    BOOST_CHECK_NO_THROW(DeckPtr deck =  parser->parseString( wwctString, ParseContext()));
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckHasWWCT) {

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -614,14 +614,14 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
 
 
     void Parser::applyUnitsToDeck(Deck& deck) const {
-        for (size_t index=0; index < deck.size(); ++index) {
-            auto& deckKeyword = deck.getKeyword( index );
-            if (isRecognizedKeyword( deckKeyword.name())) {
-                const auto* parserKeyword = getParserKeywordFromDeckName( deckKeyword.name() );
-                if (parserKeyword->hasDimension()) {
-                    parserKeyword->applyUnitsToDeck(deck , deckKeyword);
-                }
-            }
+        for( auto& deckKeyword : deck ) {
+
+            if( !isRecognizedKeyword( deckKeyword.name() ) ) continue;
+
+            const auto* parserKeyword = getParserKeywordFromDeckName( deckKeyword.name() );
+            if( !parserKeyword->hasDimension() ) continue;
+
+            parserKeyword->applyUnitsToDeck(deck , deckKeyword);
         }
     }
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -647,7 +647,7 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
                         return true;
                     }
                 }
-                parserState->rawKeyword->addRawRecordString(line.string());
+                parserState->rawKeyword->addRawRecordString(line);
             }
 
             if (parserState->rawKeyword

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -330,25 +330,25 @@ void Parser::addParserKeyword(const Json::JsonObject& jsonKeyword) {
 }
 
 
-const ParserKeyword* Parser::getKeyword(const std::string& name ) const {
+const ParserKeyword* Parser::getKeyword( const std::string& name ) const {
     auto iter = m_deckParserKeywords.find( name );
+
     if (iter == m_deckParserKeywords.end())
-        throw std::invalid_argument("Keyword not found");
-    else
-        return iter->second;
+        throw std::invalid_argument( "Keyword '" + name + "' not found" );
+
+    return iter->second;
 }
 
 const ParserKeyword* Parser::getParserKeywordFromDeckName(const std::string& deckKeywordName) const {
-    if (m_deckParserKeywords.count(deckKeywordName)) {
+    if( m_deckParserKeywords.count( deckKeywordName ) )
         return m_deckParserKeywords.at(deckKeywordName);
-    } else {
-        const auto* wildCardKeyword = matchingKeyword( deckKeywordName );
 
-        if (wildCardKeyword)
-            return wildCardKeyword;
-        else
-            throw std::invalid_argument("Do not have parser keyword for parsing: " + deckKeywordName);
-    }
+    const auto* wildCardKeyword = matchingKeyword( deckKeywordName );
+
+    if ( !wildCardKeyword )
+        throw std::invalid_argument("Do not have parser keyword for parsing: " + deckKeywordName);
+
+    return wildCardKeyword;
 }
 
 std::vector<std::string> Parser::getAllDeckNames () const {

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -527,12 +527,6 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
 
 
 
-    static inline std::string& doSpecialHandlingForTitleKeyword(std::string& line, std::shared_ptr<ParserState> parserState) {
-        if ((parserState->rawKeyword != NULL) && (parserState->rawKeyword->getKeywordName() == "TITLE"))
-                line = line.append("/");
-        return line;
-    }
-
     template< typename Itr >
     static inline Itr trim_left( Itr begin, Itr end ) {
 
@@ -583,7 +577,6 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
             liner = trim( liner  ); // Removing garbage (eg. \r)
 
             auto line = liner.string();
-            doSpecialHandlingForTitleKeyword(line, parserState);
             std::string keywordString;
             parserState->line()++;
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -396,10 +396,6 @@ namespace Opm {
         return (m_wildCardKeywords.count(internalKeywordName) > 0);
     }
 
-    bool Parser::isRecognizedKeyword(const std::string& name ) const {
-        return this->isRecognizedKeyword( string_view( name ) );
-    }
-
     bool Parser::isRecognizedKeyword(const string_view& name ) const {
         if( !ParserKeyword::validDeckName( name ) )
             return false;
@@ -446,10 +442,6 @@ void Parser::addParserKeyword(const Json::JsonObject& jsonKeyword) {
 
 
 const ParserKeyword* Parser::getKeyword( const std::string& name ) const {
-    return getParserKeywordFromDeckName( string_view( name ) );
-}
-
-const ParserKeyword* Parser::getParserKeywordFromDeckName( const std::string& name ) const {
     return getParserKeywordFromDeckName( string_view( name ) );
 }
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -99,19 +99,16 @@ namespace Opm {
     template< typename Itr >
     static inline Itr trim_left( Itr begin, Itr end ) {
 
-        const auto ws = []( char ch ) { return std::isspace( ch ); };
-        return std::find_if_not( begin, end, ws );
+        return std::find_if_not( begin, end, RawConsts::is_separator );
     }
 
     template< typename Itr >
     static inline Itr trim_right( Itr begin, Itr end ) {
 
-        const auto ws = []( char ch ) { return std::isspace( ch ); };
-
         std::reverse_iterator< Itr > rbegin( end );
         std::reverse_iterator< Itr > rend( begin );
 
-        return std::find_if_not( rbegin, rend, ws ).base();
+        return std::find_if_not( rbegin, rend, RawConsts::is_separator ).base();
     }
 
     static inline string_view trim( string_view str ) {

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -313,6 +313,10 @@ void ParserState::loadFile(const boost::filesystem::path& inputFile) {
     std::fread( &buffer[ 0 ], 1, buffer.size() - 1, fp );
     buffer.back() = '\n';
 
+    if( std::ferror( fp ) )
+        throw std::runtime_error( "Error when reading input file '"
+                                + inputFileCanonical.string() + "'" );
+
     this->input_stack.push( clean( buffer ), inputFileCanonical );
 }
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -56,7 +56,7 @@ inline Itr find_comment( Itr begin, Itr end ) {
 }
 
 template< typename Itr, typename Term >
-inline Itr strip_after( Itr begin, Itr end, Term terminator ) {
+inline Itr find_terminator( Itr begin, Itr end, Term terminator ) {
 
     auto pos = terminator( begin, end );
 
@@ -72,7 +72,7 @@ inline Itr strip_after( Itr begin, Itr end, Term terminator ) {
     // Quotes are not balanced - probably an error?!
     if( qend == end ) return end;
 
-    return strip_after( qend + 1, end, terminator );
+    return find_terminator( qend + 1, end, terminator );
 }
 
 /**
@@ -86,7 +86,7 @@ inline Itr strip_after( Itr begin, Itr end, Term terminator ) {
     ABC "-- Not balanced quote?  =>  ABC "-- Not balanced quote?
 */
 static inline string_view strip_comments( string_view str ) {
-    return { str.begin(), strip_after( str.begin(), str.end(),
+    return { str.begin(), find_terminator( str.begin(), str.end(),
             find_comment< string_view::const_iterator > ) };
 }
 
@@ -119,7 +119,7 @@ inline string_view strip_slash( string_view view ) {
 
     auto begin = view.begin();
     auto end = view.end();
-    auto slash = strip_after( begin, end, term );
+    auto slash = find_terminator( begin, end, term );
 
     /* we want to preserve terminating slashes */
     if( slash != end ) ++slash;
@@ -555,7 +555,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
      * strip_comment is the actual (internal) implementation
      */
     std::string Parser::stripComments( const std::string& str ) {
-        return { str.begin(), strip_after( str.begin(), str.end(),
+        return { str.begin(), find_terminator( str.begin(), str.end(),
                 find_comment< std::string::const_iterator > ) };
     }
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -43,8 +43,10 @@
 
 namespace Opm {
 
+namespace {
+
     template< typename Itr >
-    static inline Itr find_comment( Itr begin, Itr end ) {
+    inline Itr find_comment( Itr begin, Itr end ) {
 
         auto itr = std::find( begin, end, '-' );
         for( ; itr != end; itr = std::find( itr + 1, end, '-' ) )
@@ -54,7 +56,7 @@ namespace Opm {
     }
 
     template< typename Itr, typename Term >
-    static inline Itr strip_after( Itr begin, Itr end, Term terminator ) {
+    inline Itr strip_after( Itr begin, Itr end, Term terminator ) {
 
         auto pos = terminator( begin, end );
 
@@ -79,31 +81,14 @@ namespace Opm {
        the source string to remain alive. The function handles quoting with
        single quotes and double quotes:
 
-         ABC --Comment                =>  ABC
-         ABC '--Comment1' --Comment2  =>  ABC '--Comment1'
-         ABC "-- Not balanced quote?  =>  ABC "-- Not balanced quote?
-    */
-    static inline string_view strip_comments( string_view str ) {
-        return { str.begin(), strip_after( str.begin(), str.end(),
-                find_comment< string_view::const_iterator > ) };
-    }
-
-    /* stripComments only exists so that the unit tests can verify it.
-     * strip_comment is the actual (internal) implementation
-     */
-    std::string Parser::stripComments( const std::string& str ) {
-        return { str.begin(), strip_after( str.begin(), str.end(),
-                find_comment< std::string::const_iterator > ) };
-    }
-
-    template< typename Itr >
-    static inline Itr trim_left( Itr begin, Itr end ) {
+template< typename Itr >
+inline Itr trim_left( Itr begin, Itr end ) {
 
         return std::find_if_not( begin, end, RawConsts::is_separator );
     }
 
     template< typename Itr >
-    static inline Itr trim_right( Itr begin, Itr end ) {
+    inline Itr trim_right( Itr begin, Itr end ) {
 
         std::reverse_iterator< Itr > rbegin( end );
         std::reverse_iterator< Itr > rend( begin );
@@ -111,13 +96,13 @@ namespace Opm {
         return std::find_if_not( rbegin, rend, RawConsts::is_separator ).base();
     }
 
-    static inline string_view trim( string_view str ) {
+    inline string_view trim( string_view str ) {
         auto fst = trim_left( str.begin(), str.end() );
         auto lst = trim_right( fst, str.end() );
         return { fst, lst };
     }
 
-    static inline string_view strip_slash( string_view view ) {
+    inline string_view strip_slash( string_view view ) {
         using itr = string_view::const_iterator;
         const auto term = []( itr begin, itr end ) {
             return std::find( begin, end, '/' );
@@ -133,7 +118,7 @@ namespace Opm {
         return { begin, slash };
     }
 
-    static inline bool getline( string_view& input, string_view& line ) {
+    inline bool getline( string_view& input, string_view& line ) {
         if( input.empty() ) return false;
 
         auto end = std::find( input.begin(), input.end(), '\n' );
@@ -149,7 +134,7 @@ namespace Opm {
      * including stripping comments, removing leading/trailing whitespaces and
      * everything after (terminating) slashes
      */
-    static inline std::string clean( const std::string& str ) {
+    inline std::string clean( const std::string& str ) {
         std::string dst;
         dst.reserve( str.size() );
 
@@ -328,7 +313,7 @@ namespace Opm {
         parseContext.handleError( errorKey , msg.str() );
     }
 
-    static boost::filesystem::path getIncludeFilePath(ParserState& parserState, std::string path)
+    boost::filesystem::path getIncludeFilePath(ParserState& parserState, std::string path)
     {
         const std::string pathKeywordPrefix("$");
         const std::string validPathNameCharacters("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_");
@@ -527,6 +512,16 @@ namespace Opm {
         return true;
     }
 
+}
+
+
+    /* stripComments only exists so that the unit tests can verify it.
+     * strip_comment is the actual (internal) implementation
+     */
+    std::string Parser::stripComments( const std::string& str ) {
+        return { str.begin(), strip_after( str.begin(), str.end(),
+                find_comment< std::string::const_iterator > ) };
+    }
 
     Parser::Parser(bool addDefault) {
         if (addDefault)

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -543,22 +543,22 @@ namespace Opm {
      */
 
     Deck * Parser::newDeckFromFile(const std::string &dataFileName, const ParseContext& parseContext) const {
-        std::shared_ptr<ParserState> parserState = std::make_shared<ParserState>(parseContext);
-        parserState->openRootFile( dataFileName );
-        parseState( *parserState, *this );
-        applyUnitsToDeck(*parserState->deck);
+        ParserState parserState( parseContext );
+        parserState.openRootFile( dataFileName );
+        parseState( parserState, *this );
+        applyUnitsToDeck( *parserState.deck );
 
-        return parserState->deck;
+        return parserState.deck;
     }
 
     Deck * Parser::newDeckFromString(const std::string &data, const ParseContext& parseContext) const {
-        std::shared_ptr<ParserState> parserState = std::make_shared<ParserState>(parseContext);
-        parserState->loadString( data );
+        ParserState parserState( parseContext );
+        parserState.loadString( data );
 
-        parseState( *parserState, *this );
-        applyUnitsToDeck(*parserState->deck);
+        parseState( parserState, *this );
+        applyUnitsToDeck( *parserState.deck );
 
-        return parserState->deck;
+        return parserState.deck;
     }
 
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -427,9 +427,7 @@ bool tryParseKeyword( ParserState& parserState, const Parser& parser ) {
     while( !parserState.done() ) {
         auto line = parserState.getline();
 
-        // skip empty lines
-        if (line.size() == 0)
-            continue;
+        if( line.empty() ) continue;
 
         std::string keywordString;
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -365,54 +365,55 @@ std::vector<std::string> Parser::getAllDeckNames () const {
 bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
     bool stopParsing = false;
 
-    if (parserState->inputstream) {
-        while (true) {
-            bool streamOK = tryParseKeyword(parserState);
-            if (parserState->rawKeyword) {
-                if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::end) {
-                    stopParsing = true;
-                    break;
-                }
-                else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::endinclude) {
-                    break;
-                }
-                else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::paths) {
-                    for( const auto& record : *parserState->rawKeyword ) {
-                            std::string pathName = readValueToken<std::string>(record.getItem(0));
-                            std::string pathValue = readValueToken<std::string>(record.getItem(1));
-                            parserState->pathMap->insert(std::pair<std::string, std::string>(pathName, pathValue));
-                    }
-                }
-                else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::include) {
-                    auto& firstRecord = parserState->rawKeyword->getFirstRecord( );
-                    std::string includeFileAsString = readValueToken<std::string>(firstRecord.getItem(0));
-                    boost::filesystem::path includeFile = getIncludeFilePath(*parserState, includeFileAsString);
-                    std::shared_ptr<ParserState> newParserState = parserState->includeState( includeFile );
+    if( !parserState->inputstream )
+        throw std::invalid_argument("Failed to open file: " + parserState->dataFile.string());
 
-
-                    stopParsing = parseState(newParserState);
-                    if (stopParsing) break;
-                } else {
-
-                    if (isRecognizedKeyword(parserState->rawKeyword->getKeywordName())) {
-                            const auto* parserKeyword = getParserKeywordFromDeckName(parserState->rawKeyword->getKeywordName());
-                            parserState->deck->addKeyword( parserKeyword->parse(parserState->parseContext , parserState->rawKeyword ) );
-                        } else {
-                            DeckKeyword deckKeyword(parserState->rawKeyword->getKeywordName(), false);
-                            const std::string msg = "The keyword " + parserState->rawKeyword->getKeywordName() + " is not recognized";
-                            deckKeyword.setLocation(parserState->rawKeyword->getFilename(),
-                                                     parserState->rawKeyword->getLineNR());
-                            parserState->deck->addKeyword( std::move( deckKeyword ) );
-                            parserState->deck->getMessageContainer().warning(parserState->dataFile.string(), msg, parserState->lineNR);
-                        }
-                    }
-                    parserState->rawKeyword.reset();
-                }
-                if (!streamOK)
-                    break;
+    while (true) {
+        bool streamOK = tryParseKeyword(parserState);
+        if (parserState->rawKeyword) {
+            if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::end) {
+                stopParsing = true;
+                break;
             }
-        } else
-            throw std::invalid_argument("Failed to open file: " + parserState->dataFile.string());
+            else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::endinclude) {
+                break;
+            }
+            else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::paths) {
+                for( const auto& record : *parserState->rawKeyword ) {
+                        std::string pathName = readValueToken<std::string>(record.getItem(0));
+                        std::string pathValue = readValueToken<std::string>(record.getItem(1));
+                        parserState->pathMap->insert(std::pair<std::string, std::string>(pathName, pathValue));
+                }
+            }
+            else if (parserState->rawKeyword->getKeywordName() == Opm::RawConsts::include) {
+                auto& firstRecord = parserState->rawKeyword->getFirstRecord( );
+                std::string includeFileAsString = readValueToken<std::string>(firstRecord.getItem(0));
+                boost::filesystem::path includeFile = getIncludeFilePath(*parserState, includeFileAsString);
+                std::shared_ptr<ParserState> newParserState = parserState->includeState( includeFile );
+
+
+                stopParsing = parseState(newParserState);
+                if (stopParsing) break;
+            } else {
+
+                if (isRecognizedKeyword(parserState->rawKeyword->getKeywordName())) {
+                        const auto* parserKeyword = getParserKeywordFromDeckName(parserState->rawKeyword->getKeywordName());
+                        parserState->deck->addKeyword( parserKeyword->parse(parserState->parseContext , parserState->rawKeyword ) );
+                    } else {
+                        DeckKeyword deckKeyword(parserState->rawKeyword->getKeywordName(), false);
+                        const std::string msg = "The keyword " + parserState->rawKeyword->getKeywordName() + " is not recognized";
+                        deckKeyword.setLocation(parserState->rawKeyword->getFilename(),
+                                                    parserState->rawKeyword->getLineNR());
+                        parserState->deck->addKeyword( std::move( deckKeyword ) );
+                        parserState->deck->getMessageContainer().warning(parserState->dataFile.string(), msg, parserState->lineNR);
+                    }
+                }
+                parserState->rawKeyword.reset();
+            }
+            if (!streamOK)
+                break;
+        }
+
         return stopParsing;
     }
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -448,39 +448,48 @@ bool Parser::parseState(std::shared_ptr<ParserState> parserState) const {
 
         const auto* parserKeyword = getParserKeywordFromDeckName( keywordString );
 
-        if (parserKeyword->getSizeType() == SLASH_TERMINATED || parserKeyword->getSizeType() == UNKNOWN) {
-            Raw::KeywordSizeEnum rawSizeType;
-            if (parserKeyword->getSizeType() == SLASH_TERMINATED)
-                rawSizeType = Raw::SLASH_TERMINATED;
-            else
-                rawSizeType = Raw::UNKNOWN;
+        if( parserKeyword->getSizeType() == SLASH_TERMINATED || parserKeyword->getSizeType() == UNKNOWN) {
 
-            return RawKeywordPtr(new RawKeyword(keywordString , rawSizeType , parserState->dataFile.string(), parserState->lineNR));
-        } else {
-            size_t targetSize;
+            const auto rawSizeType = parserKeyword->getSizeType() == SLASH_TERMINATED
+                                   ? Raw::SLASH_TERMINATED
+                                   : Raw::UNKNOWN;
 
-            if (parserKeyword->hasFixedSize())
-                targetSize = parserKeyword->getFixedSize();
-            else {
-                const std::pair<std::string, std::string> sizeKeyword = parserKeyword->getSizeDefinitionPair();
-                const Deck * deck = parserState->deck;
-                if (deck->hasKeyword(sizeKeyword.first)) {
-                    const auto& sizeDefinitionKeyword = deck->getKeyword(sizeKeyword.first);
-                    const auto& record = sizeDefinitionKeyword.getRecord(0);
-                    targetSize = record.getItem( sizeKeyword.second ).get< int >( 0 );
-                } else {
-                    std::string msg = "Expected the kewyord: " + sizeKeyword.first + " to infer the number of records in: " + keywordString;
-                    parserState->parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msg );
-
-                    auto keyword = getKeyword( sizeKeyword.first );
-                    auto record = keyword->getRecord(0);
-                    auto int_item = std::dynamic_pointer_cast<const ParserIntItem>( record->get( sizeKeyword.second ) );
-
-                    targetSize = int_item->getDefault( );
-                }
-            }
-            return RawKeywordPtr(new RawKeyword(keywordString, parserState->dataFile.string() , parserState->lineNR , targetSize , parserKeyword->isTableCollection()));
+            return std::make_shared< RawKeyword >( keywordString, rawSizeType,
+                                                   parserState->dataFile.string(),
+                                                   parserState->lineNR );
         }
+
+        if( parserKeyword->hasFixedSize() ) {
+            return std::make_shared< RawKeyword >( keywordString, parserState->dataFile.string(),
+                                                   parserState->lineNR, parserKeyword->getFixedSize(),
+                                                   parserKeyword->isTableCollection() );
+        }
+
+        const auto& sizeKeyword = parserKeyword->getSizeDefinitionPair();
+        const auto* deck = parserState->deck;
+
+        if( deck->hasKeyword(sizeKeyword.first ) ) {
+            const auto& sizeDefinitionKeyword = deck->getKeyword(sizeKeyword.first);
+            const auto& record = sizeDefinitionKeyword.getRecord(0);
+            const auto targetSize = record.getItem( sizeKeyword.second ).get< int >( 0 );
+            return std::make_shared< RawKeyword >( keywordString, parserState->dataFile.string(),
+                                                   parserState->lineNR, targetSize,
+                                                   parserKeyword->isTableCollection() );
+        }
+
+        std::string msg = "Expected the kewyord: " + sizeKeyword.first
+                        + " to infer the number of records in: " + keywordString;
+
+        parserState->parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msg );
+
+        const auto* keyword = getKeyword( sizeKeyword.first );
+        const auto record = keyword->getRecord(0);
+        const auto int_item = std::dynamic_pointer_cast<const ParserIntItem>( record->get( sizeKeyword.second ) );
+
+        const auto targetSize = int_item->getDefault( );
+        return std::make_shared< RawKeyword >( keywordString, parserState->dataFile.string(),
+                                               parserState->lineNR, targetSize,
+                                               parserKeyword->isTableCollection() );
     }
 
 

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -133,9 +133,13 @@ inline bool getline( string_view& input, string_view& line ) {
     auto end = std::find( input.begin(), input.end(), '\n' );
 
     line = string_view( input.begin(), end );
-    const auto mod = end == input.end() ? 0 : 1;
-    input = string_view( end + mod, input.end() );
+    input = string_view( end + 1, input.end() );
     return true;
+
+    /* we know that we always append a newline onto the input string, so we can
+     * safely assume that end+1 will either be end-of-input (i.e. empty range)
+     * or the start of the next line
+     */
 }
 
 /*
@@ -154,7 +158,7 @@ inline std::string clean( const std::string& str ) {
         //if( line.begin() == line.end() ) continue;
 
         dst.append( line.begin(), line.end() );
-        dst.append( 1, '\n' );
+        dst.push_back( '\n' );
     }
 
     return dst;
@@ -249,7 +253,7 @@ ParserState::ParserState(const ParseContext& __parseContext)
 {}
 
 void ParserState::loadString(const std::string& input) {
-    this->input_stack.push( clean( input ) );
+    this->input_stack.push( clean( input + "\n" ) );
 }
 
 void ParserState::loadFile(const boost::filesystem::path& inputFile) {
@@ -282,9 +286,10 @@ void ParserState::loadFile(const boost::filesystem::path& inputFile) {
     auto* fp = ufp.get();
     std::string buffer;
     std::fseek( fp, 0, SEEK_END );
-    buffer.resize( std::ftell( fp ) );
+    buffer.resize( std::ftell( fp ) + 1 );
     std::rewind( fp );
-    std::fread( &buffer[ 0 ], 1, buffer.size(), fp );
+    std::fread( &buffer[ 0 ], 1, buffer.size() - 1, fp );
+    buffer.back() = '\n';
 
     this->input_stack.push( clean( buffer ), inputFileCanonical );
 }

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -114,9 +114,7 @@ namespace Opm {
         bool hasWildCardKeyword(const std::string& keyword) const;
         const ParserKeyword* matchingKeyword(const string_view& keyword) const;
 
-        bool tryParseKeyword(std::shared_ptr<ParserState> parserState) const;
         bool parseState(std::shared_ptr<ParserState> parserState) const;
-        std::shared_ptr< RawKeyword > createRawKeyword(const string_view& keywordString, std::shared_ptr<ParserState> parserState) const;
         void addDefaultKeywords();
     };
 

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -28,6 +28,7 @@
 #include <boost/filesystem.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
 
 namespace Json {
     class JsonObject;
@@ -38,7 +39,6 @@ namespace Opm {
     class Deck;
     class ParseContext;
     class RawKeyword;
-    class string_view;
     struct ParserState;
 
     /// The hub of the parsing process.
@@ -69,6 +69,7 @@ namespace Opm {
 
         bool isRecognizedKeyword( const string_view& deckKeywordName) const;
         bool isRecognizedKeyword( const std::string& deckKeywordName) const;
+        const ParserKeyword* getParserKeywordFromDeckName(const string_view& deckKeywordName) const;
         const ParserKeyword* getParserKeywordFromDeckName(const std::string& deckKeywordName) const;
         std::vector<std::string> getAllDeckNames () const;
 
@@ -105,12 +106,12 @@ namespace Opm {
 
     private:
         // associative map of the parser internal name and the corresponding ParserKeyword object
-        std::map<std::string, std::unique_ptr< const ParserKeyword > > m_internalParserKeywords;
+        std::map< string_view, std::unique_ptr< const ParserKeyword > > m_internalParserKeywords;
         // associative map of deck names and the corresponding ParserKeyword object
-        std::map<std::string, const ParserKeyword* > m_deckParserKeywords;
+        std::map< string_view, const ParserKeyword* > m_deckParserKeywords;
         // associative map of the parser internal names and the corresponding
         // ParserKeyword object for keywords which match a regular expression
-        std::map<std::string, const ParserKeyword* > m_wildCardKeywords;
+        std::map< string_view, const ParserKeyword* > m_wildCardKeywords;
 
         bool hasWildCardKeyword(const std::string& keyword) const;
         const ParserKeyword* matchingKeyword(const string_view& keyword) const;

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -118,7 +118,7 @@ namespace Opm {
 
         bool tryParseKeyword(std::shared_ptr<ParserState> parserState) const;
         bool parseState(std::shared_ptr<ParserState> parserState) const;
-        std::shared_ptr< RawKeyword > createRawKeyword(const std::string& keywordString, std::shared_ptr<ParserState> parserState) const;
+        std::shared_ptr< RawKeyword > createRawKeyword(const string_view& keywordString, std::shared_ptr<ParserState> parserState) const;
         void addDefaultKeywords();
     };
 

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -68,9 +68,7 @@ namespace Opm {
         const ParserKeyword* getKeyword(const std::string& name) const;
 
         bool isRecognizedKeyword( const string_view& deckKeywordName) const;
-        bool isRecognizedKeyword( const std::string& deckKeywordName) const;
         const ParserKeyword* getParserKeywordFromDeckName(const string_view& deckKeywordName) const;
-        const ParserKeyword* getParserKeywordFromDeckName(const std::string& deckKeywordName) const;
         std::vector<std::string> getAllDeckNames () const;
 
         void loadKeywords(const Json::JsonObject& jsonKeywords);

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -39,7 +39,6 @@ namespace Opm {
     class Deck;
     class ParseContext;
     class RawKeyword;
-    struct ParserState;
 
     /// The hub of the parsing process.
     /// An input file in the eclipse data format is specified, several steps of parsing is performed
@@ -114,7 +113,6 @@ namespace Opm {
         bool hasWildCardKeyword(const std::string& keyword) const;
         const ParserKeyword* matchingKeyword(const string_view& keyword) const;
 
-        bool parseState(std::shared_ptr<ParserState> parserState) const;
         void addDefaultKeywords();
     };
 

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -38,6 +38,7 @@ namespace Opm {
     class Deck;
     class ParseContext;
     class RawKeyword;
+    class string_view;
     struct ParserState;
 
     /// The hub of the parsing process.
@@ -66,6 +67,7 @@ namespace Opm {
         void addParserKeyword(std::unique_ptr< const ParserKeyword >&& parserKeyword);
         const ParserKeyword* getKeyword(const std::string& name) const;
 
+        bool isRecognizedKeyword( const string_view& deckKeywordName) const;
         bool isRecognizedKeyword( const std::string& deckKeywordName) const;
         const ParserKeyword* getParserKeywordFromDeckName(const std::string& deckKeywordName) const;
         std::vector<std::string> getAllDeckNames () const;
@@ -111,7 +113,7 @@ namespace Opm {
         std::map<std::string, const ParserKeyword* > m_wildCardKeywords;
 
         bool hasWildCardKeyword(const std::string& keyword) const;
-        const ParserKeyword* matchingKeyword(const std::string& keyword) const;
+        const ParserKeyword* matchingKeyword(const string_view& keyword) const;
 
         bool tryParseKeyword(std::shared_ptr<ParserState> parserState) const;
         bool parseState(std::shared_ptr<ParserState> parserState) const;

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -53,7 +53,7 @@ namespace Opm {
         /// The starting point of the parsing process. The supplied file is parsed, and the resulting Deck is returned.
         std::shared_ptr< Deck > parseFile(const std::string &dataFile, const ParseContext& parseContext) const;
         std::shared_ptr< Deck > parseString(const std::string &data, const ParseContext& parseContext) const;
-        std::shared_ptr< Deck > parseStream(std::shared_ptr<std::istream> inputStream , const ParseContext& parseContext) const;
+        std::shared_ptr< Deck > parseStream(std::unique_ptr<std::istream>&& inputStream , const ParseContext& parseContext) const;
 
         Deck * newDeckFromFile(const std::string &dataFileName, const ParseContext& parseContext) const;
         Deck * newDeckFromString(const std::string &dataFileName, const ParseContext& parseContext) const;

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -60,7 +60,6 @@ namespace Opm {
 
         std::shared_ptr< Deck > parseFile(const std::string &dataFile, bool strict = true) const;
         std::shared_ptr< Deck > parseString(const std::string &data, bool strict = true) const;
-        std::shared_ptr< Deck > parseStream(std::shared_ptr<std::istream> inputStream , bool strict = true) const;
 
         /// Method to add ParserKeyword instances, these holding type and size information about the keywords and their data.
         void addParserKeyword(const Json::JsonObject& jsonKeyword);

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -575,40 +575,36 @@ namespace Opm {
         // compare the deck names. we don't care about the ordering of the strings.
         if (m_deckNames != other.m_deckNames)
             return false;
-        {
-            if ((m_name == other.m_name) &&
-                (m_matchRegexString == other.m_matchRegexString) &&
-                (m_keywordSizeType == other.m_keywordSizeType) &&
-                (isDataKeyword() == other.isDataKeyword()) &&
-                (m_isTableCollection == other.m_isTableCollection)) {
 
-                bool equal_ = false;
-                switch (m_keywordSizeType) {
-                case FIXED:
-                    if (m_fixedSize == other.m_fixedSize)
-                        equal_ = true;
-                    break;
-                case OTHER_KEYWORD_IN_DECK:
-                    if ((m_sizeDefinitionPair.first == other.m_sizeDefinitionPair.first) &&
-                        (m_sizeDefinitionPair.second == other.m_sizeDefinitionPair.second))
-                        equal_ = true;
-                    break;
-                default:
-                    equal_ = true;
-                    break;
-                }
-
-                for (size_t recordIndex = 0; recordIndex < m_records.size(); recordIndex++) {
-                    std::shared_ptr<ParserRecord> record = getRecord(recordIndex);
-                    std::shared_ptr<ParserRecord> other_record = other.getRecord(recordIndex);
-
-                    equal_ = equal_ && record->equal( *other_record );
-                }
-
-                return equal_;
-            } else
+        if(    m_name != other.m_name
+            || m_matchRegexString != other.m_matchRegexString
+            || m_keywordSizeType != other.m_keywordSizeType
+            || isDataKeyword() != other.isDataKeyword()
+            || m_isTableCollection != other.m_isTableCollection )
                 return false;
+
+        switch( m_keywordSizeType ) {
+            case FIXED:
+                if( m_fixedSize != other.m_fixedSize )
+                    return false;
+                break;
+
+            case OTHER_KEYWORD_IN_DECK:
+                if(  m_sizeDefinitionPair.first != other.m_sizeDefinitionPair.first
+                  || m_sizeDefinitionPair.second != other.m_sizeDefinitionPair.second )
+                    return false;
+                break;
+
+            default:
+                break;
         }
+
+        for( size_t i = 0; i < m_records.size(); i++ ) {
+            if( !getRecord( i )->equal( *other.getRecord( i ) ) )
+                    return false;
+        }
+
+        return true;
     }
 
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -231,10 +231,6 @@ namespace Opm {
         return { str.begin(), str.begin() + 9 };
     }
 
-    bool ParserKeyword::validDeckName( const std::string& name) {
-        return validDeckName( string_view( name ) );
-    }
-
     bool ParserKeyword::validDeckName( const string_view& name) {
 
         if( !validNameStart( name ) )
@@ -544,22 +540,6 @@ namespace Opm {
                       << "\n"
                       << "Ignoring expression!\n";
         }
-    }
-
-    bool ParserKeyword::matches(const std::string& deckKeywordName) const {
-        if (!validDeckName(deckKeywordName))
-            return false;
-        else if (m_deckNames.count(deckKeywordName) > 0)
-            return true;
-        else if (hasMatchRegex()) {
-#ifdef HAVE_REGEX
-            return std::regex_match(deckKeywordName, m_matchRegex);
-#else
-            return boost::regex_match(deckKeywordName, m_matchRegex);
-#endif
-        }
-
-        return false;
     }
 
     bool ParserKeyword::matches(const string_view& name ) const {

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -212,22 +212,13 @@ namespace Opm {
         return true;
     }
 
-    bool ParserKeyword::validInternalName(const std::string& name) {
-        if (name.length() < 2)
-            return false;
-        else if (!std::isalpha(name[0]))
-            return false;
+    bool ParserKeyword::validInternalName( const std::string& name ) {
+        if( name.length() < 2 ) return false;
+        if( !std::isalpha( name[0] ) ) return false;
 
-        for (size_t i = 1; i < name.length(); i++) {
-            char c = name[i];
-            if (!isalnum(c) &&
-                c != '_')
-            {
-                return false;
-            }
-        }
+        const auto ok = []( char c ) { return std::isalnum( c ) || c == '_'; };
 
-        return true;
+        return std::all_of( name.begin() + 1, name.end(), ok );
     }
 
     std::string ParserKeyword::getDeckName(const std::string& rawString)

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -220,7 +220,7 @@ namespace Opm {
         return std::all_of( name.begin() + 1, name.end(), ok );
     }
 
-    std::string ParserKeyword::getDeckName( const string_view& str ) {
+    string_view ParserKeyword::getDeckName( const string_view& str ) {
 
         auto first_sep = std::find_if( str.begin(), str.end(), RawConsts::is_separator );
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -486,27 +486,23 @@ namespace Opm {
     }
 
     DeckKeyword ParserKeyword::parse(const ParseContext& parseContext , RawKeywordPtr rawKeyword) const {
-        if (rawKeyword->isFinished()) {
-            DeckKeyword keyword( rawKeyword->getKeywordName() );
-            keyword.setLocation(rawKeyword->getFilename(), rawKeyword->getLineNR());
-            keyword.setDataKeyword( isDataKeyword() );
-	    {
-		size_t record_nr = 0;
-		for (auto& rawRecord : *rawKeyword) {
-		    if(m_records.size() > 0) {
-			keyword.addRecord( getRecord( record_nr )->parse( parseContext, rawRecord ) );
-		    }
-		    else {
-			if(rawRecord.size() > 0) {
-			    throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
-			}
-		    }
-		    record_nr++;
-		}
-            }
-            return keyword;
-        } else
+        if( !rawKeyword->isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword->getKeywordName());
+
+        DeckKeyword keyword( rawKeyword->getKeywordName() );
+        keyword.setLocation( rawKeyword->getFilename(), rawKeyword->getLineNR() );
+        keyword.setDataKeyword( isDataKeyword() );
+
+        size_t record_nr = 0;
+        for( auto& rawRecord : *rawKeyword ) {
+            if( m_records.size() == 0 && rawRecord.size() > 0 )
+                throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
+
+            keyword.addRecord( getRecord( record_nr )->parse( parseContext, rawRecord ) );
+            record_nr++;
+        }
+
+        return keyword;
     }
 
     size_t ParserKeyword::getFixedSize() const {

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -31,9 +31,8 @@
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParserStringItem.hpp>
+#include <opm/parser/eclipse/RawDeck/RawConsts.hpp>
 #include <opm/parser/eclipse/RawDeck/RawKeyword.hpp>
-
-#include <boost/algorithm/string.hpp>
 
 namespace Opm {
 
@@ -221,15 +220,15 @@ namespace Opm {
         return std::all_of( name.begin() + 1, name.end(), ok );
     }
 
-    std::string ParserKeyword::getDeckName(const std::string& rawString)
-    {
+    std::string ParserKeyword::getDeckName(const std::string& str ) {
+
+        auto first_sep = std::find_if( str.begin(), str.end(), RawConsts::is_separator );
+
         // only look at the first 8 characters (at most)
-        std::string result = rawString.substr(0, 8);
+        if( std::distance( str.begin(), first_sep ) < 9 )
+            return { str.begin(), first_sep };
 
-        // remove any white space
-        boost::algorithm::trim(result);
-
-        return result;
+        return { str.begin(), str.begin() + 9 };
     }
 
     static inline std::string uppercase( std::string str ) {

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -248,17 +248,11 @@ namespace Opm {
         if (!validNameStart(upperCaseName))
             return false;
 
-        for (size_t i = 1; i < upperCaseName.length(); i++) {
-            char c = upperCaseName[i];
-            if (!isalnum(c) &&
-                c != '-' &&
-                c != '_' &&
-                c != '+')
-            {
-                return false;
-            }
-        }
-        return true;
+        const auto valid = []( char c ) {
+            return std::isalnum( c ) || c == '-' || c == '_' || c == '+';
+        };
+
+        return std::all_of( name.begin() + 1, name.end(), valid );
     }
 
     bool ParserKeyword::hasMultipleDeckNames() const {

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -201,7 +201,7 @@ namespace Opm {
     }
 
 
-    bool ParserKeyword::validNameStart(const std::string& name) {
+    bool ParserKeyword::validNameStart( const string_view& name) {
         if (name.length() > ParserConst::maxKeywordLength)
             return false;
 
@@ -220,7 +220,7 @@ namespace Opm {
         return std::all_of( name.begin() + 1, name.end(), ok );
     }
 
-    std::string ParserKeyword::getDeckName(const std::string& str ) {
+    std::string ParserKeyword::getDeckName( const string_view& str ) {
 
         auto first_sep = std::find_if( str.begin(), str.end(), RawConsts::is_separator );
 
@@ -231,7 +231,11 @@ namespace Opm {
         return { str.begin(), str.begin() + 9 };
     }
 
-    bool ParserKeyword::validDeckName(const std::string& name) {
+    bool ParserKeyword::validDeckName( const std::string& name) {
+        return validDeckName( string_view( name ) );
+    }
+
+    bool ParserKeyword::validDeckName( const string_view& name) {
 
         if( !validNameStart( name ) )
             return false;
@@ -552,6 +556,24 @@ namespace Opm {
             return std::regex_match(deckKeywordName, m_matchRegex);
 #else
             return boost::regex_match(deckKeywordName, m_matchRegex);
+#endif
+        }
+
+        return false;
+    }
+
+    bool ParserKeyword::matches(const string_view& name ) const {
+        if (!validDeckName(name ))
+            return false;
+
+        else if( m_deckNames.count( name.string() ) )
+            return true;
+
+        else if (hasMatchRegex()) {
+#ifdef HAVE_REGEX
+            return std::regex_match( name.begin(), name.end(), m_matchRegex);
+#else
+            return boost::regex_match( name.begin(), name.end(), m_matchRegex);
 #endif
         }
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -231,21 +231,9 @@ namespace Opm {
         return { str.begin(), str.begin() + 9 };
     }
 
-    static inline std::string uppercase( std::string str ) {
-        /* the cctype toupper etc. are often implemented as macros, so its
-         * unreliable with std algorithms. Hand-rolling map instead
-         */
-        for( auto& c : str ) c = toupper( c );
-        return str;
-    }
-
     bool ParserKeyword::validDeckName(const std::string& name) {
-        // make the keyword string ALL_UPPERCASE because Eclipse seems
-        // to be case-insensitive (although this is one of its
-        // undocumented features...)
-        auto upperCaseName = uppercase( name );
 
-        if (!validNameStart(upperCaseName))
+        if( !validNameStart( name ) )
             return false;
 
         const auto valid = []( char c ) {
@@ -258,7 +246,6 @@ namespace Opm {
     bool ParserKeyword::hasMultipleDeckNames() const {
         return m_deckNames.size() > 1;
     }
-
 
     void ParserKeyword::initDeckNames(const Json::JsonObject& jsonObject) {
         if (!jsonObject.has_item("deck_names"))

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -82,15 +82,10 @@ namespace Opm {
     }
 
     bool ParserKeyword::hasDimension() const {
-        if (m_records.size() > 0) {
-            bool hasDim = false;
-            for (auto& record : m_records) {
-                if (record->hasDimension())
-                    hasDim = true;
-            }
-            return hasDim;
-        } else
-            return false;
+        for( const auto& record : m_records )
+            if( record->hasDimension() ) return true;
+
+        return false;
     }
 
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -66,11 +66,9 @@ namespace Opm {
 
         static string_view getDeckName(const string_view& rawString);
         static bool validInternalName(const std::string& name);
-        static bool validDeckName(const std::string& name);
         static bool validDeckName(const string_view& name);
         bool hasMatchRegex() const;
         void setMatchRegex(const std::string& deckNameRegexp);
-        bool matches(const std::string& deckKeywordName) const;
         bool matches(const string_view& ) const;
         bool hasDimension() const;
         void addRecord(std::shared_ptr<ParserRecord> record);

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -64,7 +64,7 @@ namespace Opm {
         typedef std::set<std::string> SectionNameSet;
 
 
-        static std::string getDeckName(const string_view& rawString);
+        static string_view getDeckName(const string_view& rawString);
         static bool validInternalName(const std::string& name);
         static bool validDeckName(const std::string& name);
         static bool validDeckName(const string_view& name);

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -43,6 +43,7 @@ namespace Opm {
     class ParserDoubleItem;
     class ParserRecord;
     class RawKeyword;
+    class string_view;
 
     class ParserKeyword {
     public:
@@ -63,12 +64,14 @@ namespace Opm {
         typedef std::set<std::string> SectionNameSet;
 
 
-        static std::string getDeckName(const std::string& rawString);
+        static std::string getDeckName(const string_view& rawString);
         static bool validInternalName(const std::string& name);
         static bool validDeckName(const std::string& name);
+        static bool validDeckName(const string_view& name);
         bool hasMatchRegex() const;
         void setMatchRegex(const std::string& deckNameRegexp);
         bool matches(const std::string& deckKeywordName) const;
+        bool matches(const string_view& ) const;
         bool hasDimension() const;
         void addRecord(std::shared_ptr<ParserRecord> record);
         void addDataRecord(std::shared_ptr<ParserRecord> record);
@@ -122,7 +125,7 @@ namespace Opm {
         bool m_isTableCollection;
         std::string m_Description;
 
-        static bool validNameStart(const std::string& name);
+        static bool validNameStart(const string_view& name);
         void initDeckNames( const Json::JsonObject& jsonConfig );
         void initSectionNames( const Json::JsonObject& jsonConfig );
         void initMatchRegex( const Json::JsonObject& jsonObject );

--- a/opm/parser/eclipse/Parser/tests/ParserItemTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserItemTests.cpp
@@ -93,7 +93,7 @@ BOOST_AUTO_TEST_CASE(Initialize_Default_String) {
 BOOST_AUTO_TEST_CASE(scan_PreMatureTerminator_defaultUsed) {
     ParserIntItem itemInt(std::string("ITEM2"), 123);
 
-    RawRecord rawRecord1( "/" );
+    RawRecord rawRecord1( "" );
     const auto defaulted = itemInt.scan(rawRecord1);
 
     BOOST_CHECK(defaulted.defaultApplied(0));
@@ -315,7 +315,7 @@ BOOST_AUTO_TEST_CASE(Scan_All_CorrectIntSetInDeckItem) {
     ParserItemSizeEnum sizeType = ALL;
     ParserIntItem itemInt("ITEM", sizeType);
 
-    RawRecord rawRecord( "100 443 10*77 10*1 25/" );
+    RawRecord rawRecord( "100 443 10*77 10*1 25" );
     const auto deckIntItem = itemInt.scan(rawRecord);
     BOOST_CHECK_EQUAL(23U, deckIntItem.size());
     BOOST_CHECK_EQUAL(77, deckIntItem.get< int >(3));
@@ -327,7 +327,7 @@ BOOST_AUTO_TEST_CASE(Scan_All_WithDefaults) {
     ParserItemSizeEnum sizeType = ALL;
     ParserIntItem itemInt("ITEM", sizeType);
 
-    RawRecord rawRecord( "100 10* 10*1 25/" );
+    RawRecord rawRecord( "100 10* 10*1 25" );
     const auto deckIntItem = itemInt.scan(rawRecord);
     BOOST_CHECK_EQUAL(22U, deckIntItem.size());
     BOOST_CHECK(!deckIntItem.defaultApplied(0));
@@ -341,7 +341,7 @@ BOOST_AUTO_TEST_CASE(Scan_All_WithDefaults) {
 BOOST_AUTO_TEST_CASE(Scan_SINGLE_CorrectIntSetInDeckItem) {
     ParserIntItem itemInt(std::string("ITEM2"));
 
-    RawRecord rawRecord("100 44.3 'Heisann' /" );
+    RawRecord rawRecord("100 44.3 'Heisann'" );
     const auto deckIntItem = itemInt.scan(rawRecord);
     BOOST_CHECK_EQUAL(100, deckIntItem.get< int >(0));
 }
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(Scan_SeveralInts_CorrectIntsSetInDeckItem) {
     ParserIntItem itemInt2(std::string("ITEM2"));
     ParserIntItem itemInt3(std::string("ITEM3"));
 
-    RawRecord rawRecord( "100 443 338932 222.33 'Heisann' /" );
+    RawRecord rawRecord( "100 443 338932 222.33 'Heisann' " );
     const auto deckIntItem1 = itemInt1.scan(rawRecord);
     BOOST_CHECK_EQUAL(100, deckIntItem1.get< int >(0));
 
@@ -370,7 +370,7 @@ BOOST_AUTO_TEST_CASE(Scan_Multiplier_CorrectIntsSetInDeckItem) {
     ParserItemSizeEnum sizeType = ALL;
     ParserIntItem itemInt("ITEM2", sizeType);
 
-    RawRecord rawRecord( "3*4 /" );
+    RawRecord rawRecord( "3*4 " );
     const auto deckIntItem = itemInt.scan(rawRecord);
     BOOST_CHECK_EQUAL(4, deckIntItem.get< int >(0));
     BOOST_CHECK_EQUAL(4, deckIntItem.get< int >(1));
@@ -381,7 +381,7 @@ BOOST_AUTO_TEST_CASE(Scan_StarNoMultiplier_ExceptionThrown) {
     ParserItemSizeEnum sizeType = SINGLE;
     ParserIntItem itemInt("ITEM2", sizeType , 100);
 
-    RawRecord rawRecord( "*45 /" );
+    RawRecord rawRecord( "*45 " );
     BOOST_CHECK_THROW(itemInt.scan(rawRecord), std::invalid_argument);
 }
 
@@ -389,7 +389,7 @@ BOOST_AUTO_TEST_CASE(Scan_MultipleItems_CorrectIntsSetInDeckItem) {
     ParserIntItem itemInt1(std::string("ITEM1"));
     ParserIntItem itemInt2(std::string("ITEM2"));
 
-    RawRecord rawRecord( "10 20 /" );
+    RawRecord rawRecord( "10 20" );
     const auto deckIntItem1 = itemInt1.scan(rawRecord);
     const auto deckIntItem2 = itemInt2.scan(rawRecord);
 
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(Scan_MultipleDefault_CorrectIntsSetInDeckItem) {
     ParserIntItem itemInt1("ITEM1", 10);
     ParserIntItem itemInt2("ITEM2", 20);
 
-    RawRecord rawRecord( "* * /" );
+    RawRecord rawRecord( "* * " );
     const auto deckIntItem1 = itemInt1.scan(rawRecord);
     const auto deckIntItem2 = itemInt2.scan(rawRecord);
 
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE(Scan_MultipleWithMultiplier_CorrectIntsSetInDeckItem) {
     ParserIntItem itemInt1("ITEM1", 10);
     ParserIntItem itemInt2("ITEM2", 20);
 
-    RawRecord rawRecord( "2*30/" );
+    RawRecord rawRecord( "2*30" );
     const auto deckIntItem1 = itemInt1.scan(rawRecord);
     const auto deckIntItem2 = itemInt2.scan(rawRecord);
 
@@ -424,14 +424,14 @@ BOOST_AUTO_TEST_CASE(Scan_MultipleWithMultiplier_CorrectIntsSetInDeckItem) {
 BOOST_AUTO_TEST_CASE(Scan_MalformedMultiplier_Throw) {
     ParserIntItem itemInt1("ITEM1" , 10);
 
-    RawRecord rawRecord( "2.10*30/" );
+    RawRecord rawRecord( "2.10*30" );
     BOOST_CHECK_THROW(itemInt1.scan(rawRecord), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_CASE(Scan_MalformedMultiplierChar_Throw) {
     ParserIntItem itemInt1("ITEM1", 10);
 
-    RawRecord rawRecord( "210X30/" );
+    RawRecord rawRecord( "210X30" );
     BOOST_CHECK_THROW(itemInt1.scan(rawRecord), std::invalid_argument);
 }
 
@@ -439,7 +439,7 @@ BOOST_AUTO_TEST_CASE(Scan_MultipleWithMultiplierDefault_CorrectIntsSetInDeckItem
     ParserIntItem itemInt1("ITEM1", 10);
     ParserIntItem itemInt2("ITEM2", 20);
 
-    RawRecord rawRecord( "2*/" );
+    RawRecord rawRecord( "2*" );
     const auto deckIntItem1 = itemInt1.scan(rawRecord);
     const auto deckIntItem2 = itemInt2.scan(rawRecord);
 
@@ -501,24 +501,24 @@ BOOST_AUTO_TEST_CASE(InitializeStringItem_FromJsonObject_withDefaultInvalid_thro
 
 BOOST_AUTO_TEST_CASE(init_defaultvalue_defaultset) {
     ParserStringItem itemString(std::string("ITEM1") , "DEFAULT");
-    RawRecord rawRecord( "'1*'/" );
+    RawRecord rawRecord( "'1*'" );
     BOOST_CHECK_EQUAL("1*", itemString.scan( rawRecord ).get< std::string >(0) );
 
-    RawRecord rawRecord1( "13*/" );
+    RawRecord rawRecord1( "13*" );
     BOOST_CHECK_EQUAL("DEFAULT" , itemString.scan( rawRecord1 ).get< std::string >(0) );
 
-    RawRecord rawRecord2( "*/" );
+    RawRecord rawRecord2( "*" );
     BOOST_CHECK_EQUAL("DEFAULT", itemString.scan( rawRecord2 ).get< std::string >(0) );
 
     ParserStringItem itemStringDefaultChanged("ITEM2", "SPECIAL");
-    RawRecord rawRecord3( "*/" );
+    RawRecord rawRecord3( "*" );
     BOOST_CHECK_EQUAL("SPECIAL", itemStringDefaultChanged.scan( rawRecord3 ).get< std::string >(0) );
 }
 
 BOOST_AUTO_TEST_CASE(scan_all_valuesCorrect) {
     ParserItemSizeEnum sizeType = ALL;
     ParserStringItem itemString("ITEMWITHMANY", sizeType);
-    RawRecord rawRecord( "'WELL1' FISK BANAN 3*X OPPLEGG_FOR_DATAANALYSE 'Foo$*!% BAR' /" );
+    RawRecord rawRecord( "'WELL1' FISK BANAN 3*X OPPLEGG_FOR_DATAANALYSE 'Foo$*!% BAR' " );
     const auto deckItem = itemString.scan(rawRecord);
     BOOST_CHECK_EQUAL(8U, deckItem.size());
 
@@ -535,7 +535,7 @@ BOOST_AUTO_TEST_CASE(scan_all_valuesCorrect) {
 BOOST_AUTO_TEST_CASE(scan_all_withdefaults) {
     ParserItemSizeEnum sizeType = ALL;
     ParserIntItem itemString("ITEMWITHMANY", sizeType);
-    RawRecord rawRecord( "10*1 10* 10*2 /" );
+    RawRecord rawRecord( "10*1 10* 10*2 " );
     const auto deckItem = itemString.scan(rawRecord);
 
     BOOST_CHECK_EQUAL(30U, deckItem.size());
@@ -558,7 +558,7 @@ BOOST_AUTO_TEST_CASE(scan_all_withdefaults) {
 
 BOOST_AUTO_TEST_CASE(scan_single_dataCorrect) {
     ParserStringItem itemString(std::string("ITEM1"));
-    RawRecord rawRecord( "'WELL1' 'WELL2' /" );
+    RawRecord rawRecord( "'WELL1' 'WELL2'" );
     const auto deckItem = itemString.scan(rawRecord);
     BOOST_CHECK_EQUAL(1U, deckItem.size());
     BOOST_CHECK_EQUAL("WELL1", deckItem.get< std::string >(0));
@@ -576,7 +576,7 @@ BOOST_AUTO_TEST_CASE(scan_singleWithMixedRecord_dataCorrect) {
 
 /******************String and int**********************/
 BOOST_AUTO_TEST_CASE(scan_intsAndStrings_dataCorrect) {
-    RawRecord rawRecord( "'WELL1' 2 2 2*3 /" );
+    RawRecord rawRecord( "'WELL1' 2 2 2*3" );
 
     ParserItemSizeEnum sizeTypeItemBoxed = ALL;
 

--- a/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
@@ -127,15 +127,14 @@ static ParserRecordPtr createSimpleParserRecord() {
 
 BOOST_AUTO_TEST_CASE(parse_validRecord_noThrow) {
     ParserRecordPtr record = createSimpleParserRecord();
-    RawRecord rawRecord( "100 443 /" );
     ParseContext parseContext;
-    rawRecord.dump();
-    BOOST_CHECK_NO_THROW(record->parse(parseContext , rawRecord));
+    RawRecord raw( string_view( "100 443" ) );
+    BOOST_CHECK_NO_THROW(record->parse(parseContext, raw ) );
 }
 
 BOOST_AUTO_TEST_CASE(parse_validRecord_deckRecordCreated) {
     ParserRecordPtr record = createSimpleParserRecord();
-    RawRecord rawRecord(  "100 443 /" );
+    RawRecord rawRecord( string_view( "100 443" ) );
     ParseContext parseContext;
     const auto deckRecord = record->parse(parseContext , rawRecord);
     BOOST_CHECK_EQUAL(2U, deckRecord.size());
@@ -168,7 +167,7 @@ static ParserRecordPtr createMixedParserRecord() {
 
 BOOST_AUTO_TEST_CASE(parse_validMixedRecord_noThrow) {
     ParserRecordPtr record = createMixedParserRecord();
-    RawRecord rawRecord(  "1 2 10.0 20.0 4 90.0 /" );
+    RawRecord rawRecord( string_view( "1 2 10.0 20.0 4 90.0") );
     ParseContext parseContext;
     BOOST_CHECK_NO_THROW(record->parse(parseContext , rawRecord));
 }
@@ -217,7 +216,7 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
     // according to the RM, this is invalid ("an asterisk by itself is not sufficient"),
     // but it seems to appear in the wild. Thus, we interpret this as "1*"...
     {
-        RawRecord rawRecord( "* /" );
+        RawRecord rawRecord( "* " );
         const auto deckStringItem = itemString->scan(rawRecord);
         const auto deckIntItem = itemInt->scan(rawRecord);
         const auto deckDoubleItem = itemDouble->scan(rawRecord);
@@ -232,7 +231,7 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
     }
 
     {
-        RawRecord rawRecord( "/" );
+        RawRecord rawRecord( "" );
         const auto deckStringItem = itemString->scan(rawRecord);
         const auto deckIntItem = itemInt->scan(rawRecord);
         const auto deckDoubleItem = itemDouble->scan(rawRecord);
@@ -248,7 +247,7 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
 
 
     {
-        RawRecord rawRecord( "TRYGVE 10 2.9 /" );
+        RawRecord rawRecord( "TRYGVE 10 2.9 " );
 
         // let the raw record be "consumed" by the items. Note that the scan() method
         // modifies the rawRecord object!
@@ -267,7 +266,7 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
 
     // again this is invalid according to the RM, but it is used anyway in the wild...
     {
-        RawRecord rawRecord( "* * * /" );
+        RawRecord rawRecord( "* * *" );
         const auto deckStringItem = itemString->scan(rawRecord);
         const auto deckIntItem = itemInt->scan(rawRecord);
         const auto deckDoubleItem = itemDouble->scan(rawRecord);
@@ -282,7 +281,7 @@ BOOST_AUTO_TEST_CASE(ParseWithDefault_defaultAppliedCorrectInDeck) {
     }
 
     {
-        RawRecord rawRecord(  "3* /" );
+        RawRecord rawRecord(  "3*" );
         const auto deckStringItem = itemString->scan(rawRecord);
         const auto deckIntItem = itemInt->scan(rawRecord);
         const auto deckDoubleItem = itemDouble->scan(rawRecord);
@@ -309,13 +308,13 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooManyItems_Throws) {
     parserRecord->addItem(itemK);
 
 
-    RawRecord rawRecord(  "3 3 3 /" );
+    RawRecord rawRecord(  "3 3 3 " );
     BOOST_CHECK_NO_THROW(parserRecord->parse(parseContext , rawRecord));
 
-    RawRecord rawRecordOneExtra(  "3 3 3 4 /" );
+    RawRecord rawRecordOneExtra(  "3 3 3 4 " );
     BOOST_CHECK_THROW(parserRecord->parse(parseContext , rawRecordOneExtra), std::invalid_argument);
 
-    RawRecord rawRecordForgotRecordTerminator(  "3 3 3 \n 4 4 4 /" );
+    RawRecord rawRecordForgotRecordTerminator(  "3 3 3 \n 4 4 4 " );
     BOOST_CHECK_THROW(parserRecord->parse(parseContext , rawRecordForgotRecordTerminator), std::invalid_argument);
 
 }

--- a/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
@@ -331,7 +331,7 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooFewItems) {
     parserRecord->addItem(itemK);
 
     ParseContext parseContext;
-    RawRecord rawRecord(  "3 3  /" );
+    RawRecord rawRecord(  "3 3  " );
     // no default specified for the third item, record can be parsed just fine but trying
     // to access the data will raise an exception...
     BOOST_CHECK_NO_THROW(parserRecord->parse(parseContext , rawRecord));

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -36,7 +36,7 @@ namespace Opm {
         const unsigned int maxKeywordLength = 8;
 
         static inline bool is_separator( char ch ) {
-            return ch == '\t' || ch == ' ';
+            return ch == '\t' || ch == ' ' || ch == '\n';
         }
 
         static inline bool is_quote( char ch ) {

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -20,7 +20,6 @@
 #ifndef RAWCONSTS_HPP
 #define	RAWCONSTS_HPP
 
-#include <cctype>
 #include <string>
 
 namespace Opm {
@@ -37,7 +36,7 @@ namespace Opm {
         const unsigned int maxKeywordLength = 8;
 
         static inline bool is_separator( char ch ) {
-            return std::isspace( ch );
+            return ' ' == ch || '\n' == ch || '\t' == ch;
         }
 
         static inline bool is_quote( char ch ) {

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -36,7 +36,7 @@ namespace Opm {
         const unsigned int maxKeywordLength = 8;
 
         static inline bool is_separator( char ch ) {
-            return ' ' == ch || '\n' == ch || '\t' == ch;
+            return ' ' == ch || '\n' == ch || '\t' == ch || '\r' == ch;
         }
 
         static inline bool is_quote( char ch ) {

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -20,6 +20,7 @@
 #ifndef RAWCONSTS_HPP
 #define	RAWCONSTS_HPP
 
+#include <cctype>
 #include <string>
 
 namespace Opm {
@@ -36,7 +37,7 @@ namespace Opm {
         const unsigned int maxKeywordLength = 8;
 
         static inline bool is_separator( char ch ) {
-            return ch == '\t' || ch == ' ' || ch == '\n';
+            return std::isspace( ch );
         }
 
         static inline bool is_quote( char ch ) {

--- a/opm/parser/eclipse/RawDeck/RawConsts.hpp
+++ b/opm/parser/eclipse/RawDeck/RawConsts.hpp
@@ -38,6 +38,10 @@ namespace Opm {
         static inline bool is_separator( char ch ) {
             return ch == '\t' || ch == ' ';
         }
+
+        static inline bool is_quote( char ch ) {
+            return ch == quote || ch == '"';
+        }
     }
 }
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -99,7 +99,9 @@ namespace Opm {
 
         if( m_isFinished ) return;
 
-        if( RawRecord::isTerminatedRecordString( partialRecordString ) ) {
+        if( this->getKeywordName() == "TITLE"
+            || RawRecord::isTerminatedRecordString( partialRecordString ) ) {
+
             m_records.emplace_back( std::move( m_partialRecordString ), m_filename, m_name );
             m_partialRecordString.clear();
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -119,7 +119,7 @@ namespace Opm {
         return str;
     }
 
-    bool RawKeyword::isKeywordPrefix(const std::string& line, std::string& keyword ) {
+    bool RawKeyword::isKeywordPrefix(const string_view& line, std::string& keyword ) {
         // make the keyword string ALL_UPPERCASE because Eclipse seems
         // to be case-insensitive (although this is one of its
         // undocumented features...)

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -37,12 +37,6 @@ namespace Opm {
             throw std::invalid_argument("Error - invalid sizetype on input");
     }
 
-
-    RawKeyword::RawKeyword(const std::string& name, Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR) :
-        RawKeyword( string_view( name ), sizeType, filename, lineNR ) {}
-    RawKeyword::RawKeyword(const std::string& name , const std::string& filename, size_t lineNR , size_t inputSize, bool isTableCollection ) :
-        RawKeyword(string_view( name ), filename, lineNR, inputSize, isTableCollection ) {}
-
     RawKeyword::RawKeyword(const string_view& name , const std::string& filename, size_t lineNR , size_t inputSize, bool isTableCollection ) {
         commonInit(name.string(),filename,lineNR);
         if (isTableCollection) {
@@ -118,10 +112,6 @@ namespace Opm {
             if( m_sizeType == Raw::FIXED && m_records.size() == m_fixedSize )
                 m_isFinished = true;
         }
-    }
-
-    void RawKeyword::addRawRecordString(const std::string& rec ) {
-        addRawRecordString( string_view( rec ) );
     }
 
     const RawRecord& RawKeyword::getFirstRecord() const {

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -27,17 +27,22 @@
 namespace Opm {
 
 
-    RawKeyword::RawKeyword(const std::string& name, Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR) {
+    RawKeyword::RawKeyword(const string_view& name, Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR) {
         if (sizeType == Raw::SLASH_TERMINATED || sizeType == Raw::UNKNOWN) {
-            commonInit(name,filename,lineNR);
+            commonInit(name.string(),filename,lineNR);
             m_sizeType = sizeType;
         } else
             throw std::invalid_argument("Error - invalid sizetype on input");
     }
 
 
-    RawKeyword::RawKeyword(const std::string& name , const std::string& filename, size_t lineNR , size_t inputSize, bool isTableCollection ) {
-        commonInit(name,filename,lineNR);
+    RawKeyword::RawKeyword(const std::string& name, Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR) :
+        RawKeyword( string_view( name ), sizeType, filename, lineNR ) {}
+    RawKeyword::RawKeyword(const std::string& name , const std::string& filename, size_t lineNR , size_t inputSize, bool isTableCollection ) :
+        RawKeyword(string_view( name ), filename, lineNR, inputSize, isTableCollection ) {}
+
+    RawKeyword::RawKeyword(const string_view& name , const std::string& filename, size_t lineNR , size_t inputSize, bool isTableCollection ) {
+        commonInit(name.string(),filename,lineNR);
         if (isTableCollection) {
             m_sizeType = Raw::TABLE_COLLECTION;
             m_numTables = inputSize;
@@ -125,7 +130,7 @@ namespace Opm {
         // make the keyword string ALL_UPPERCASE because Eclipse seems
         // to be case-insensitive (although this is one of its
         // undocumented features...)
-        keyword = uppercase( ParserKeyword::getDeckName( line ) );
+        keyword = uppercase( ParserKeyword::getDeckName( line ).string() );
 
         return isValidKeyword( keyword );
     }

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -81,27 +81,30 @@ namespace Opm {
     void RawKeyword::addRawRecordString(const std::string& partialRecordString) {
         m_partialRecordString += " " + partialRecordString;
 
-        if (m_sizeType != Raw::FIXED && isTerminator( m_partialRecordString )) {
+
+        if( m_sizeType != Raw::FIXED && isTerminator( m_partialRecordString ) ) {
             if (m_sizeType == Raw::TABLE_COLLECTION) {
                 m_currentNumTables += 1;
                 if (m_currentNumTables == m_numTables) {
                     m_isFinished = true;
                     m_partialRecordString.clear();
+                    return;
                 }
-            } else if (m_sizeType != Raw::UNKNOWN) {
+            } else if( m_sizeType != Raw::UNKNOWN ) {
                 m_isFinished = true;
                 m_partialRecordString.clear();
+                return;
             }
         }
 
-        if (!m_isFinished) {
-            if (RawRecord::isTerminatedRecordString(partialRecordString)) {
-                m_records.emplace_back( std::move( m_partialRecordString ), m_filename, m_name );
-                m_partialRecordString.clear();
+        if( m_isFinished ) return;
 
-                if (m_sizeType == Raw::FIXED && (m_records.size() == m_fixedSize))
-                    m_isFinished = true;
-            }
+        if( RawRecord::isTerminatedRecordString( partialRecordString ) ) {
+            m_records.emplace_back( std::move( m_partialRecordString ), m_filename, m_name );
+            m_partialRecordString.clear();
+
+            if( m_sizeType == Raw::FIXED && m_records.size() == m_fixedSize )
+                m_isFinished = true;
         }
     }
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -113,12 +113,19 @@ namespace Opm {
         return *m_records.begin();
     }
 
-    bool RawKeyword::isKeywordPrefix(const std::string& line, std::string& keywordName) {
+    static inline std::string uppercase( std::string&& str ) {
+        std::transform( str.begin(), str.end(), str.begin(),
+            []( char c ) { return std::toupper( c ); } );
+        return str;
+    }
+
+    bool RawKeyword::isKeywordPrefix(const std::string& line, std::string& keyword ) {
         // make the keyword string ALL_UPPERCASE because Eclipse seems
         // to be case-insensitive (although this is one of its
         // undocumented features...)
-        keywordName = boost::to_upper_copy(ParserKeyword::getDeckName(line));
-        return isValidKeyword(keywordName);
+        keyword = uppercase( ParserKeyword::getDeckName( line ) );
+
+        return isValidKeyword( keyword );
     }
 
     bool RawKeyword::isValidKeyword(const std::string& keywordCandidate) {

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -43,13 +43,8 @@ namespace Opm {
         RawKeyword(const string_view& name , Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR);
         RawKeyword(const string_view& name , const std::string& filename, size_t lineNR , size_t inputSize , bool isTableCollection = false);
 
-        RawKeyword(const std::string& name , Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR);
-        RawKeyword(const std::string& name , const std::string& filename, size_t lineNR , size_t inputSize , bool isTableCollection = false);
-
         const std::string& getKeywordName() const;
         void addRawRecordString( const string_view& );
-        /* The string overload exists for testing only */
-        void addRawRecordString( const std::string& );
         size_t size() const;
         Raw::KeywordSizeEnum getSizeType() const;
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -30,6 +30,7 @@
 namespace Opm {
 
     class RawRecord;
+    class string_view;
 
     /// Class representing a RawKeyword, meaning both the actual keyword phrase, and the records,
     /// represented as a list of RawRecord objects.
@@ -51,7 +52,7 @@ namespace Opm {
         // iterator interface.
         const RawRecord& getFirstRecord( ) const;
 
-        static bool isKeywordPrefix(const std::string& line, std::string& keywordName);
+        static bool isKeywordPrefix(const string_view& line, std::string& keywordName);
 
         bool isPartialRecordStringEmpty() const;
         bool isFinished() const;

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -26,6 +26,7 @@
 #include <list>
 
 #include <opm/parser/eclipse/RawDeck/RawEnums.hpp>
+#include <opm/parser/eclipse/Utility/Stringview.hpp>
 
 namespace Opm {
 
@@ -46,7 +47,9 @@ namespace Opm {
         RawKeyword(const std::string& name , const std::string& filename, size_t lineNR , size_t inputSize , bool isTableCollection = false);
 
         const std::string& getKeywordName() const;
-        void addRawRecordString(const std::string& partialRecordString);
+        void addRawRecordString( const string_view& );
+        /* The string overload exists for testing only */
+        void addRawRecordString( const std::string& );
         size_t size() const;
         Raw::KeywordSizeEnum getSizeType() const;
 
@@ -82,7 +85,7 @@ namespace Opm {
         size_t m_currentNumTables;
         std::string m_name;
         std::list< RawRecord > m_records;
-        std::string m_partialRecordString;
+        string_view m_partialRecordString;
 
         size_t m_lineNR;
         std::string m_filename;

--- a/opm/parser/eclipse/RawDeck/RawKeyword.hpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.hpp
@@ -39,6 +39,9 @@ namespace Opm {
 
     class RawKeyword {
     public:
+        RawKeyword(const string_view& name , Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR);
+        RawKeyword(const string_view& name , const std::string& filename, size_t lineNR , size_t inputSize , bool isTableCollection = false);
+
         RawKeyword(const std::string& name , Raw::KeywordSizeEnum sizeType , const std::string& filename, size_t lineNR);
         RawKeyword(const std::string& name , const std::string& filename, size_t lineNR , size_t inputSize , bool isTableCollection = false);
 

--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -33,16 +33,15 @@ using namespace std;
 
 namespace Opm {
 
-    static inline std::string::const_iterator first_nonspace (
-            std::string::const_iterator begin,
-            std::string::const_iterator end ) {
+    template< typename Itr >
+    static inline Itr first_nonspace( Itr begin, Itr end ) {
         return std::find_if_not( begin, end, RawConsts::is_separator );
     }
 
-    static std::deque< string_view > splitSingleRecordString( const string_view& record ) {
+    static std::deque< string_view > splitSingleRecordString( const string_view& line ) {
 
         std::deque< string_view > dst;
-        string_view record( rec );
+        string_view record( line );
 
         for( auto current = first_nonspace( record.begin(), record.end() );
                 current != record.end();

--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -65,15 +65,16 @@ namespace Opm {
         return std::find( begin, rec.end(), RawConsts::slash );
     }
 
-    static inline std::string::const_iterator first_nonspace (
-            std::string::const_iterator begin,
-            std::string::const_iterator end ) {
+    static inline const char* first_nonspace (
+            const char* begin,
+            const char* end ) {
         return std::find_if_not( begin, end, RawConsts::is_separator );
     }
 
-    static std::deque< string_view > splitSingleRecordString( const std::string& record ) {
+    static std::deque< string_view > splitSingleRecordString( const std::string& rec ) {
 
         std::deque< string_view > dst;
+        string_view record( rec );
 
         for( auto current = first_nonspace( record.begin(), record.end() );
                 current != record.end();
@@ -149,8 +150,7 @@ namespace Opm {
 
     void RawRecord::push_front(std::string tok ) {
         this->expanded_items.push_back( tok );
-        string_view record { this->expanded_items.back().begin(), this->expanded_items.back().end() };
-        this->m_recordItems.push_front( record );
+        this->m_recordItems.emplace_front( this->expanded_items.back() );
     }
 
     void RawRecord::dump() const {

--- a/opm/parser/eclipse/RawDeck/RawRecord.cpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.cpp
@@ -123,8 +123,4 @@ namespace Opm {
     bool RawRecord::isTerminatedRecordString( const string_view& str ) {
         return str.back() == RawConsts::slash;
     }
-
-    bool RawRecord::isTerminatedRecordString( const std::string& str ) {
-        return isTerminatedRecordString( string_view( str ) );
-    }
 }

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -47,7 +47,6 @@ namespace Opm {
         const std::string& getKeywordName() const;
 
         static bool isTerminatedRecordString( const string_view& );
-        static bool isTerminatedRecordString( const std::string& );
 
        void dump() const;
 

--- a/opm/parser/eclipse/RawDeck/RawRecord.hpp
+++ b/opm/parser/eclipse/RawDeck/RawRecord.hpp
@@ -35,23 +35,24 @@ namespace Opm {
 
     class RawRecord {
     public:
-        RawRecord(std::string&&, const std::string& fileName = "", const std::string& keywordName = "");
+        RawRecord( const string_view&, const std::string& fileName = "", const std::string& keywordName = "");
 
         inline string_view pop_front();
         void push_front(std::string token);
         inline size_t size() const;
 
-        const std::string& getRecordString() const;
+        std::string getRecordString() const;
         inline string_view getItem(size_t index) const;
         const std::string& getFileName() const;
         const std::string& getKeywordName() const;
 
-        static bool isTerminatedRecordString(const std::string& candidateRecordString);
+        static bool isTerminatedRecordString( const string_view& );
+        static bool isTerminatedRecordString( const std::string& );
 
        void dump() const;
 
     private:
-        std::string m_sanitizedRecordString;
+        string_view m_sanitizedRecordString;
         std::deque< string_view > m_recordItems;
         std::list< std::string > expanded_items;
         const std::string m_fileName;

--- a/opm/parser/eclipse/RawDeck/StarToken.cpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.cpp
@@ -78,19 +78,10 @@ namespace Opm {
 
         if( view.empty() ) throw std::invalid_argument( "Empty input string" );
 
-        const auto width = std::numeric_limits< int >::digits10 + 1;
-        std::array< char, width + 1 > buffer {};
-
-        if( view.size() > width ) throw std::invalid_argument(
-            "Maximum 'int' length is " + std::to_string( width )
-        );
-
-        std::copy( view.begin(), view.end(), buffer.begin() );
-
         char* end;
-        auto value = std::strtol( buffer.data(), &end, 10 );
+        auto value = std::strtol( view.begin(), &end, 10 );
 
-        if( std::distance( buffer.data(), end ) != int( view.size() ) )
+        if( std::distance( view.begin(), (const char*)end ) != int( view.size() ) )
             throw std::invalid_argument( "Expected integer, got '" + view + "'" );
 
         return value;
@@ -104,24 +95,25 @@ namespace Opm {
     double readValueToken< double >( string_view view ) {
         if( view.empty() ) throw std::invalid_argument( "Empty input string" );
 
-        const auto width = 64;
-        std::array< char, width > buffer {};
-
-        if( view.size() > width ) throw std::invalid_argument(
-            "Maximum 'double' length is " + std::to_string( width )
-        );
-
-        std::copy( view.begin(), view.end(), buffer.begin() );
-
         char* end;
-        auto value = std::strtod( buffer.data(), &end );
-        if( std::distance( buffer.data(), end ) == int( view.size() ) )
+        auto value = std::strtod( view.begin(), &end );
+        if( std::distance( view.begin(), (const char*) end ) == int( view.size() ) )
             return value;
 
         // Eclipse supports Fortran syntax for specifying exponents of floating point
         // numbers ('D' and 'E', e.g., 1.234d5) while C++ only supports the 'e' (e.g.,
         // 1.234e5). the quick fix is to replace 'D' by 'E' and 'd' by 'e' before trying
         // to convert the string into a floating point value.
+
+        const auto width = 64;
+
+        if( view.size() > width ) throw std::invalid_argument(
+            "Maximum 'double' length is " + std::to_string( width )
+        );
+
+        std::array< char, width > buffer {};
+        std::copy( view.begin(), view.end(), buffer.begin() );
+
 
         auto fortran = std::find_if( buffer.begin(), buffer.end(), fortran_float );
         if( fortran != buffer.end() )

--- a/opm/parser/eclipse/RawDeck/StarToken.cpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.cpp
@@ -31,12 +31,6 @@
 
 namespace Opm {
 
-    bool isStarToken(const std::string& token,
-                           std::string& countString,
-                           std::string& valueString) {
-        return isStarToken( string_view( token ), countString, valueString );
-    }
-
     bool isStarToken(const string_view& token,
                            std::string& countString,
                            std::string& valueString) {

--- a/opm/parser/eclipse/RawDeck/StarToken.hpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.hpp
@@ -29,19 +29,11 @@ namespace Opm {
                            std::string& countString,
                            std::string& valueString);
 
-    bool isStarToken(const std::string& token,
-                           std::string& countString,
-                           std::string& valueString);
-
     template <class T>
     T readValueToken( string_view );
 
 class StarToken {
 public:
-    StarToken(const std::string& token) :
-        StarToken( string_view( token ) )
-    {}
-
     StarToken(const string_view& token)
     {
         if (!isStarToken(token, m_countString, m_valueString))

--- a/opm/parser/eclipse/RawDeck/tests/RawRecordTests.cpp
+++ b/opm/parser/eclipse/RawDeck/tests/RawRecordTests.cpp
@@ -24,7 +24,7 @@
 
 
 BOOST_AUTO_TEST_CASE(RawRecordGetRecordsCorrectElementsReturned) {
-    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20                                       /"));
+    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20                                       "));
 
     BOOST_CHECK_EQUAL((unsigned) 4, record->size());
 
@@ -42,13 +42,11 @@ BOOST_AUTO_TEST_CASE(RawRecordIsCompleteRecordCompleteRecordReturnsTrue) {
 BOOST_AUTO_TEST_CASE(RawRecordIsCompleteRecordInCompleteRecordReturnsFalse) {
     bool isComplete = Opm::RawRecord::isTerminatedRecordString("'NODIR '  'REVERS'  1  20                                       ");
     BOOST_CHECK_EQUAL(false, isComplete);
-    isComplete = Opm::RawRecord::isTerminatedRecordString("'NODIR '  'REVERS  1  20 /");
-    BOOST_CHECK_EQUAL(false, isComplete);
 }
 
 BOOST_AUTO_TEST_CASE(Rawrecord_OperatorThis_OK) {
-    Opm::RawRecord record(" 'NODIR '  'REVERS'  1  20  /");
-    Opm::RawRecordPtr recordPtr(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20  /"));
+    Opm::RawRecord record(" 'NODIR '  'REVERS'  1  20  ");
+    Opm::RawRecordPtr recordPtr(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20  "));
 
     BOOST_CHECK_EQUAL("'NODIR '", record.getItem(0));
     BOOST_CHECK_EQUAL("'REVERS'", record.getItem(1));
@@ -61,7 +59,7 @@ BOOST_AUTO_TEST_CASE(Rawrecord_OperatorThis_OK) {
 }
 
 BOOST_AUTO_TEST_CASE(Rawrecord_PushFront_OK) {
-    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20  /"));
+    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20  "));
     record->push_front("String2");
     record->push_front("String1");
 
@@ -71,7 +69,7 @@ BOOST_AUTO_TEST_CASE(Rawrecord_PushFront_OK) {
 }
 
 BOOST_AUTO_TEST_CASE(Rawrecord_size_OK) {
-    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20  /"));
+    Opm::RawRecordPtr record(new Opm::RawRecord(" 'NODIR '  'REVERS'  1  20  "));
 
     BOOST_CHECK_EQUAL(4U, record->size());
     record->push_front("String2");
@@ -80,17 +78,17 @@ BOOST_AUTO_TEST_CASE(Rawrecord_size_OK) {
 }
 
 BOOST_AUTO_TEST_CASE(Rawrecord_sizeEmpty_OK) {
-    Opm::RawRecordPtr record(new Opm::RawRecord("/"));
+    Opm::RawRecordPtr record(new Opm::RawRecord(""));
     BOOST_CHECK_EQUAL(0U, record->size());
 }
 
 BOOST_AUTO_TEST_CASE(Rawrecord_spaceOnlyEmpty_OK) {
-    Opm::RawRecordPtr record(new Opm::RawRecord("   /"));
+    Opm::RawRecordPtr record(new Opm::RawRecord("   "));
     BOOST_CHECK_EQUAL(0U, record->size());
 }
 
 BOOST_AUTO_TEST_CASE(Rawrecord_noFileAndKeywordGiven_EmptyStringUsed) {
-    Opm::RawRecordPtr record(new Opm::RawRecord("32 33  /"));
+    Opm::RawRecordPtr record(new Opm::RawRecord("32 33  "));
     BOOST_CHECK_EQUAL("", record->getKeywordName());
     BOOST_CHECK_EQUAL("", record->getFileName());
 }
@@ -98,7 +96,7 @@ BOOST_AUTO_TEST_CASE(Rawrecord_noFileAndKeywordGiven_EmptyStringUsed) {
 BOOST_AUTO_TEST_CASE(Rawrecord_FileAndKeywordGiven_CorrectStringsReturned) {
     const std::string fileName = "/this/is/it";
     const std::string keywordName = "KEYWD";
-    Opm::RawRecordPtr record(new Opm::RawRecord("32 33  /", fileName, keywordName));
+    Opm::RawRecordPtr record(new Opm::RawRecord("32 33  ", fileName, keywordName));
     BOOST_CHECK_EQUAL(keywordName, record->getKeywordName());
     BOOST_CHECK_EQUAL(fileName, record->getFileName());
 }

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -54,6 +54,7 @@ namespace Opm {
             inline string_view( const_iterator, size_t );
             inline string_view( const std::string& );
             inline string_view( const std::string&, size_t );
+            inline string_view( const char* );
 
             inline const_iterator begin() const;
             inline const_iterator end() const;
@@ -164,6 +165,10 @@ namespace Opm {
 
     inline string_view::string_view( const std::string& str, size_t count ) :
         string_view( str.data(), count )
+    {}
+
+    inline string_view::string_view( const char* str ) :
+        string_view( str, str + std::strlen( str ) + 1 )
     {}
 
     inline string_view::const_iterator string_view::begin() const {

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -47,11 +47,13 @@ namespace Opm {
      */
     class string_view {
         public:
-            using const_iterator = std::string::const_iterator;
+            using const_iterator = const char*;
 
             inline string_view() = default;
+            inline string_view( const_iterator, const_iterator );
+            inline string_view( const_iterator, size_t );
             inline string_view( const std::string& );
-            inline string_view( std::string::const_iterator, std::string::const_iterator );
+            inline string_view( const std::string&, size_t );
 
             inline const_iterator begin() const;
             inline const_iterator end() const;
@@ -81,8 +83,8 @@ namespace Opm {
             inline std::string substr( size_t from, size_t to ) const;
 
         private:
-            const_iterator fst;
-            const_iterator lst;
+            const_iterator fst = nullptr;
+            const_iterator lst = nullptr;
     };
 
     /*
@@ -144,15 +146,24 @@ namespace Opm {
 
     // Member functions of string_view.
 
-    inline string_view::string_view( std::string::const_iterator begin,
-                              std::string::const_iterator end ) :
+    inline string_view::string_view( const_iterator begin,
+                                     const_iterator end ) :
         fst( begin ),
         lst( end )
     {}
 
+    inline string_view::string_view( const_iterator begin,
+                                     size_t count ) :
+        fst( begin ),
+        lst( begin + count )
+    {}
+
     inline string_view::string_view( const std::string& str ) :
-        fst( str.begin() ),
-        lst( str.end() )
+        string_view( str.data(), str.size() )
+    {}
+
+    inline string_view::string_view( const std::string& str, size_t count ) :
+        string_view( str.data(), count )
     {}
 
     inline string_view::const_iterator string_view::begin() const {

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -20,6 +20,7 @@
 #ifndef OPM_UTILITY_SUBSTRING_HPP
 #define OPM_UTILITY_SUBSTRING_HPP
 
+#include <algorithm>
 #include <cstring>
 #include <iosfwd>
 #include <stdexcept>
@@ -56,6 +57,8 @@ namespace Opm {
             inline const_iterator end() const;
 
             inline char operator[]( size_t ) const;
+            inline bool operator<( const string_view& ) const;
+            inline bool operator==( const string_view& ) const;
 
             inline bool empty() const;
             inline size_t size() const;
@@ -159,6 +162,15 @@ namespace Opm {
 
     inline char string_view::operator[]( size_t i ) const {
         return *(this->begin() + i);
+    }
+
+    inline bool string_view::operator<( const string_view& rhs ) const {
+        return std::lexicographical_compare( this->begin(), this->end(),
+                                             rhs.begin(), rhs.end() );
+    }
+
+    inline bool string_view::operator==( const string_view& rhs ) const {
+        return std::equal( this->begin(), this->end(), rhs.begin() );
     }
 
     inline bool string_view::empty() const {

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -168,7 +168,7 @@ namespace Opm {
     {}
 
     inline string_view::string_view( const char* str ) :
-        string_view( str, str + std::strlen( str ) + 1 )
+        string_view( str, str + std::strlen( str ) )
     {}
 
     inline string_view::const_iterator string_view::begin() const {

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -56,6 +56,9 @@ namespace Opm {
             inline const_iterator begin() const;
             inline const_iterator end() const;
 
+            inline char front() const;
+            inline char back() const;
+
             inline char operator[]( size_t ) const;
             inline bool operator<( const string_view& ) const;
             inline bool operator==( const string_view& ) const;
@@ -158,6 +161,14 @@ namespace Opm {
 
     inline string_view::const_iterator string_view::end() const {
         return this->lst;
+    }
+
+    inline char string_view::front() const {
+        return *this->fst;
+    }
+
+    inline char string_view::back() const {
+        return *(this->lst - 1);
     }
 
     inline char string_view::operator[]( size_t i ) const {

--- a/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
@@ -36,6 +36,15 @@ BOOST_AUTO_TEST_CASE(viewOperatorAt) {
         BOOST_CHECK_EQUAL( view[ i ], srcstr[ i ] );
 }
 
+BOOST_AUTO_TEST_CASE(viewFrontBack) {
+    std::string srcstr = "lorem ipsum";
+    string_view view( srcstr );
+
+    BOOST_CHECK_EQUAL( view.front(), 'l' );
+    BOOST_CHECK_EQUAL( view.back(), 'm' );
+}
+
+
 BOOST_AUTO_TEST_CASE(viewSubstr) {
     std::string srcstr = "lorem ipsum";
     string_view view( srcstr.begin(), srcstr.end() );

--- a/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
@@ -13,7 +13,7 @@ using namespace Opm;
 
 BOOST_AUTO_TEST_CASE(fullStringView) {
     std::string srcstr = "lorem ipsum";
-    string_view view( srcstr.begin(), srcstr.end() );
+    string_view view( srcstr );
 
     BOOST_CHECK_EQUAL_COLLECTIONS(
             srcstr.begin(), srcstr.end(),
@@ -22,15 +22,18 @@ BOOST_AUTO_TEST_CASE(fullStringView) {
 
 BOOST_AUTO_TEST_CASE(viewCorrectSize) {
     std::string srcstr = "lorem ipsum";
-    string_view view( srcstr.begin(), srcstr.begin() + 5 );
 
+    string_view full( srcstr );
+    BOOST_CHECK_EQUAL( srcstr.size(), full.size() );
+
+    string_view view( srcstr, 5 );
     BOOST_CHECK_EQUAL( 5, view.size() );
     BOOST_CHECK_EQUAL( 5, view.length() );
 }
 
 BOOST_AUTO_TEST_CASE(viewOperatorAt) {
     std::string srcstr = "lorem ipsum";
-    string_view view( srcstr.begin(), srcstr.end() );
+    string_view view( srcstr );
 
     for( size_t i = 0; i < view.size(); ++i )
         BOOST_CHECK_EQUAL( view[ i ], srcstr[ i ] );
@@ -47,7 +50,7 @@ BOOST_AUTO_TEST_CASE(viewFrontBack) {
 
 BOOST_AUTO_TEST_CASE(viewSubstr) {
     std::string srcstr = "lorem ipsum";
-    string_view view( srcstr.begin(), srcstr.end() );
+    string_view view( srcstr );
 
     BOOST_CHECK_NO_THROW( view.string() );
     BOOST_CHECK_EQUAL( srcstr, view.string() );
@@ -64,7 +67,7 @@ BOOST_AUTO_TEST_CASE(viewSubstr) {
 
 BOOST_AUTO_TEST_CASE(viewStream) {
     std::string srcstr = "lorem ipsum";
-    string_view view( srcstr.begin(), srcstr.end() );
+    string_view view( srcstr );
 
     std::stringstream str;
     str << view;
@@ -75,7 +78,7 @@ BOOST_AUTO_TEST_CASE(viewStream) {
 BOOST_AUTO_TEST_CASE(equalityOperators) {
     std::string srcstr = "lorem ipsum";
     std::string diffstr = "lorem";
-    string_view view( srcstr.begin(), srcstr.end() );
+    string_view view( srcstr );
 
     BOOST_CHECK_EQUAL( srcstr, view );
     BOOST_CHECK_NE( diffstr, view );
@@ -96,8 +99,8 @@ BOOST_AUTO_TEST_CASE(plusOperator) {
     std::string ws = " ";
     std::string rhs = "ipsum";
 
-    string_view lhs_view( lhs.begin(), lhs.end() );
-    string_view rhs_view( rhs.begin(), rhs.end() );
+    string_view lhs_view( lhs );
+    string_view rhs_view( rhs );
 
     BOOST_CHECK_EQUAL( total, lhs_view + ws + rhs_view );
     BOOST_CHECK_EQUAL( lhs + ws, lhs_view + ws );


### PR DESCRIPTION
A somewhat large patch set of smaller incremental updates (for ease of review) designed to simplify the structure of the internal parsing, remove some redundant code and enable new optimisations. I've tried to keep every commit tiny and single-purpose. A few highlights:

* `string_view` uses char* internally instead of `std::string::const_iterator`
* streams removed in favour of reading the whole file at once and work with it in memory
* `RawRecord`s no longer copy memory, but stores offsets into the buffered file
* Simplified control flow of several helper functions
* The input file is immediately stripped for comments and other things to ignore - this reduces special casing and simplifies actual parsing
* Various performance benefits (I measure ~15%)

Except for speedups, no side effects of this effort should be visible for other projects.