### PR TITLE
avoid reserved names for guard macros

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _FACEDIR_
-#define _FACEDIR_
+#ifndef OPM_FACEDIR_HPP
+#define OPM_FACEDIR_HPP
 
 #include <string>
 

--- a/opm/parser/eclipse/EclipseState/Grid/MinpvMode.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MinpvMode.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _MINPVMODE_
-#define _MINPVMODE_
+#ifndef OPM_MINPVMODE_HPP
+#define OPM_MINPVMODE_HPP
 
 #include <string>
 

--- a/opm/parser/eclipse/EclipseState/Grid/PinchMode.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/PinchMode.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#ifndef _PINCHMODE_
-#define _PINCHMODE_
+#ifndef OPM_PINCHMODE_HPP
+#define OPM_PINCHMODE_HPP
 
 #include <string>
 

--- a/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef _COLUMN_SCHEMA_HPP_
-#define _COLUMN_SCHEMA_HPP_
+#ifndef OPM_COLUMN_SCHEMA_HPP
+#define OPM_COLUMN_SCHEMA_HPP
 
 #include <string>
 #include <vector>

--- a/opm/parser/eclipse/EclipseState/Tables/TableColumn.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableColumn.hpp
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef _TABLE_COLUMN_HPP_
-#define _TABLE_COLUMN_HPP_
+#ifndef OPM_TABLE_COLUMN_HPP
+#define OPM_TABLE_COLUMN_HPP
 
 #include <string>
 #include <vector>

--- a/opm/parser/eclipse/EclipseState/Tables/TableEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableEnums.hpp
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef _TABLE_ENUMS_HPP_
-#define _TABLE_ENUMS_HPP_
+#ifndef OPM_TABLE_ENUMS_HPP
+#define OPM_TABLE_ENUMS_HPP
 
 namespace Opm {
     namespace Table {

--- a/opm/parser/eclipse/EclipseState/Tables/TableIndex.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableIndex.hpp
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef _TABLE_INDEX_HPP_
-#define _TABLE_INDEX_HPP_
+#ifndef OPM_TABLE_INDEX_HPP
+#define OPM_TABLE_INDEX_HPP
 
 #include <cstddef>
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef _TABLE_SCHEMA_HPP_
-#define _TABLE_SCHEMA_HPP_
+#ifndef OPM_TABLE_SCHEMA_HPP
+#define OPM_TABLE_SCHEMA_HPP
 
 #include <string>
 #include <vector>

--- a/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _ORDERED_MAP_
-#define _ORDERED_MAP_
+#ifndef OPM_ORDERED_MAP_HPP
+#define OPM_ORDERED_MAP_HPP
 
 #include <unordered_map>
 #include <vector>

--- a/opm/parser/eclipse/EclipseState/Util/RecordVector.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/RecordVector.hpp
@@ -18,8 +18,8 @@
  */
 
 
-#ifndef _RECORD_VECTOR_
-#define _RECORD_VECTOR_
+#ifndef OPM_RECORD_VECTOR_HPP
+#define OPM_RECORD_VECTOR_HPP
 
 #include <vector>
 #include <stdexcept>

--- a/opm/parser/eclipse/EclipseState/Util/Value.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/Value.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef _VALUE_
-#define _VALUE_
+#ifndef OPM_VALUE_HPP
+#define OPM_VALUE_HPP
 
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
just like for macros that start and end with `__`, `clang++ -Weverything` likes to complain about macros which start and end with a single underscore. This is basically the same issue as Ensembles/ert#1048