### PR TITLE
Added fields to IOConfig so parameters can be removed from EclipseWriter

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -47,7 +47,11 @@ namespace Opm {
         m_FMTIN(false),
         m_FMTOUT(false),
         m_eclipse_input_path(input_path),
-        m_ignore_RPTSCHED_RESTART(false){
+        m_ignore_RPTSCHED_RESTART(false),
+        m_deck_filename(""),
+        m_output_enabled(true),
+        m_output_dir(".")
+    {
     }
 
     bool IOConfig::getWriteEGRIDFile() const {
@@ -443,6 +447,30 @@ namespace Opm {
 
     int IOConfig::getFirstRFTStep() const {
         return m_first_rft_step;
+    }
+
+    std::string IOConfig::getDeckFileName() {
+        return m_deck_filename;
+    }
+
+    void IOConfig::setDeckFileName(const std::string& deckFileName){
+        m_deck_filename = deckFileName;
+    }
+
+    bool IOConfig::getOutputEnabled(){
+        return m_output_enabled;
+    }
+
+    void IOConfig::setOutputEnabled(bool enabled){
+        m_output_enabled = enabled;
+    }
+
+    std::string IOConfig::getOutputDir() {
+        return m_output_dir;
+    }
+
+    void IOConfig::setOutputDir(const std::string& outputDir) {
+        m_output_dir = outputDir;
     }
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -158,6 +158,14 @@ namespace Opm {
 
         std::string getRestartFileName(const std::string& restart_base, int report_step, bool output) const;
 
+        std::string getDeckFileName();
+        void setDeckFileName(const std::string& deckFileName);
+
+        bool getOutputEnabled();
+        void setOutputEnabled(bool enabled);
+
+        std::string getOutputDir();
+        void setOutputDir(const std::string& outputDir);
 
     private:
 
@@ -182,7 +190,9 @@ namespace Opm {
         bool            m_ignore_RPTSCHED_RESTART;
         int             m_first_restart_step;
         int             m_first_rft_step;
-
+        std::string     m_deck_filename;
+        bool            m_output_enabled;
+        std::string     m_output_dir;
 
         struct restartConfig {
             /*

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -460,6 +460,31 @@ BOOST_AUTO_TEST_CASE(IOConfigTest) {
     ioConfigPtr4->handleRunspecSection(runspecSection4);
 
     BOOST_CHECK_EQUAL(false, ioConfigPtr4->getWriteEGRIDFile());
+
+    IOConfigPtr ioConfigPtr5;
+    BOOST_CHECK_NO_THROW(ioConfigPtr5 = std::make_shared<IOConfig>());
+
+    BOOST_CHECK_EQUAL("", ioConfigPtr5->getDeckFileName());
+
+    std::string testString = "testString";
+    ioConfigPtr5->setDeckFileName(testString);
+    BOOST_CHECK_EQUAL(testString, ioConfigPtr5->getDeckFileName());
+
+    IOConfigPtr ioConfigPtr6;
+    BOOST_CHECK_NO_THROW(ioConfigPtr6 = std::make_shared<IOConfig>());
+
+    BOOST_CHECK_EQUAL(true, ioConfigPtr6->getOutputEnabled());
+    ioConfigPtr6->setOutputEnabled(false);
+    BOOST_CHECK_EQUAL(false, ioConfigPtr6->getOutputEnabled());
+
+    IOConfigPtr ioConfigPtr7;
+    BOOST_CHECK_NO_THROW(ioConfigPtr7 = std::make_shared<IOConfig>());
+
+    BOOST_CHECK_EQUAL(".", ioConfigPtr7->getOutputDir());
+    std::string testDir = "testDir";
+    ioConfigPtr7->setOutputDir(testDir);
+    BOOST_CHECK_EQUAL(testDir, ioConfigPtr7->getOutputDir());
+
 }
 
 


### PR DESCRIPTION
std::string     m_deck_filename;
bool            m_output_enabled;
std::string     m_output_dir;

Prerequisite for later PR in opm-output