### PR TITLE
changed: do not prototype boost::filesystem::path

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -25,14 +25,9 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <boost/filesystem.hpp>
 
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
-
-namespace boost {
-    namespace filesystem {
-        class path;
-    }
-}
 
 namespace Json {
     class JsonObject;


### PR DESCRIPTION
this breaks with g++ 4.8 used in redhat builds.

/usr/include/boost148/boost/filesystem/v3/path.hpp:710:24 error: 'path'
is already declared in this scope.

Seems g++-4.8 has a bug; you cannot prototype symbols which are included from a different namespace. Boost (atleast 1.48) imports either boost::filesystem2::path or boost::filesystem3::path with a 'using' statement. This took me forever to track. This is the best I can do. The cost is small imo.