### PR TITLE
Fixes support for BOXed ACTNUM

### DIFF
--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -101,7 +101,8 @@ namespace Opm {
 
     static std::vector< GridProperties< int >::SupportedKeywordInfo >
     makeSupportedIntKeywords() {
-        return {GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" ),
+        return {GridProperties< int >::SupportedKeywordInfo( "ACTNUM" , 1, "1" ),
+                GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" ),
                 GridProperties< int >::SupportedKeywordInfo( "IMBNUM" , 1, "1" ),
                 GridProperties< int >::SupportedKeywordInfo( "PVTNUM" , 1, "1" ),
                 GridProperties< int >::SupportedKeywordInfo( "EQLNUM" , 1, "1" ),

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -57,6 +57,10 @@ namespace Opm {
         m_eclipseGrid(       std::make_shared<EclipseGrid>(deck)),
         m_eclipseProperties( *deck, m_tables, *m_eclipseGrid)
     {
+        // after Eclipse3DProperties has been constructed, we have complete ACTNUM info
+        if (m_eclipseProperties.hasDeckIntGridProperty("ACTNUM"))
+            m_eclipseGrid->resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
+
         initIOConfig(deck);
 
         m_schedule = ScheduleConstPtr( new Schedule(m_parseContext ,  getEclipseGrid() , deck, m_ioConfig) );

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -125,7 +125,7 @@ namespace Opm {
         const UnitSystem& m_deckUnitSystem;
         const ParseContext& m_parseContext;
         const TableManager m_tables;
-        std::shared_ptr<const EclipseGrid> m_eclipseGrid;
+        std::shared_ptr<EclipseGrid> m_eclipseGrid;
         Eclipse3DProperties m_eclipseProperties;
         MessageContainer m_messageContainer;
     };

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -287,12 +287,7 @@ namespace Opm {
         assertVectorSize( DYV    , static_cast<size_t>( dims[1] ) , "DYV");
         assertVectorSize( DZV    , static_cast<size_t>( dims[2] ) , "DZV");
 
-        const int* actnum = nullptr;
-        if (deck->hasKeyword<ParserKeywords::ACTNUM>()) {
-            actnum = deck->getKeyword<ParserKeywords::ACTNUM>().getIntData().data();
-        }
-
-        m_grid.reset( ecl_grid_alloc_dxv_dyv_dzv_depthz( dims[0] , dims[1] , dims[2] , DXV.data() , DYV.data() , DZV.data() , DEPTHZ.data() , actnum ) );
+        m_grid.reset( ecl_grid_alloc_dxv_dyv_dzv_depthz( dims[0] , dims[1] , dims[2] , DXV.data() , DYV.data() , DZV.data() , DEPTHZ.data() , nullptr ) );
     }
 
 
@@ -301,12 +296,7 @@ namespace Opm {
         std::vector<double> DY = createDVector( dims , 1 , "DY" , "DYV" , deck);
         std::vector<double> DZ = createDVector( dims , 2 , "DZ" , "DZV" , deck);
         std::vector<double> TOPS = createTOPSVector( dims , DZ , deck );
-        const int* actnum = nullptr;
-        if (deck->hasKeyword<ParserKeywords::ACTNUM>()) {
-            actnum = deck->getKeyword<ParserKeywords::ACTNUM>().getIntData().data();
-        }
-
-        m_grid.reset( ecl_grid_alloc_dx_dy_dz_tops( dims[0] , dims[1] , dims[2] , DX.data() , DY.data() , DZ.data() , TOPS.data() , actnum ) );
+        m_grid.reset( ecl_grid_alloc_dx_dy_dz_tops( dims[0] , dims[1] , dims[2] , DX.data() , DY.data() , DZ.data() , TOPS.data() , nullptr ) );
     }
 
 
@@ -318,15 +308,7 @@ namespace Opm {
             const auto& COORDKeyWord = deck->getKeyword<ParserKeywords::COORD>();
             const std::vector<double>& zcorn = ZCORNKeyWord.getSIDoubleData();
             const std::vector<double>& coord = COORDKeyWord.getSIDoubleData();
-            const int * actnum = NULL;
             double    * mapaxes = NULL;
-
-            if (deck->hasKeyword<ParserKeywords::ACTNUM>()) {
-                const auto& actnumKeyword = deck->getKeyword<ParserKeywords::ACTNUM>();
-                const std::vector<int>& actnumVector = actnumKeyword.getIntData();
-                actnum = actnumVector.data();
-
-            }
 
             if (deck->hasKeyword<ParserKeywords::MAPAXES>()) {
                 const auto& mapaxesKeyword = deck->getKeyword<ParserKeywords::MAPAXES>();
@@ -347,7 +329,7 @@ namespace Opm {
                     for (size_t i=0; i < 6; i++)
                         mapaxes_float[i] = mapaxes[i];
                 }
-                m_grid.reset( ecl_grid_alloc_GRDECL_data(dims[0] , dims[1] , dims[2] , zcorn_float.data() , coord_float.data() , actnum , mapaxes_float) );
+                m_grid.reset( ecl_grid_alloc_GRDECL_data(dims[0] , dims[1] , dims[2] , zcorn_float.data() , coord_float.data() , nullptr , mapaxes_float) );
 
                 if (mapaxes) {
                     delete[] mapaxes_float;
@@ -390,25 +372,14 @@ namespace Opm {
             const auto& COORDKeyWord = deck->getKeyword<ParserKeywords::COORD>();
             if (COORDKeyWord.getDataSize() != static_cast<size_t>(6*(nx + 1)*(ny + 1))) {
                 const std::string msg =
-                    "Wrong size of the COORD keyword: Expected 8*(nx + 1)*(ny + 1) = "
-                    + std::to_string(static_cast<long long>(8*(nx + 1)*(ny + 1))) + " is "
+                    "Wrong size of the COORD keyword: Expected 6*(nx + 1)*(ny + 1) = "
+                    + std::to_string(static_cast<long long>(6*(nx + 1)*(ny + 1))) + " is "
                     + std::to_string(static_cast<long long>(COORDKeyWord.getDataSize()));
                 OpmLog::addMessage(Log::MessageType::Error , msg);
                 throw std::invalid_argument(msg);
             }
         }
 
-        if (deck->hasKeyword<ParserKeywords::ACTNUM>()) {
-            const auto& ACTNUMKeyWord = deck->getKeyword<ParserKeywords::ACTNUM>();
-            if (ACTNUMKeyWord.getDataSize() != static_cast<size_t>(nx*ny*nz)) {
-                const std::string msg =
-                    "Wrong size of the ACTNUM keyword: Expected nx*ny*nz = "
-                    + std::to_string(static_cast<long long>(nx*ny*nz)) + " is "
-                    + std::to_string(static_cast<long long>(ACTNUMKeyWord.getDataSize()));
-                OpmLog::addMessage(Log::MessageType::Error , msg);
-                throw std::invalid_argument(msg);
-            }
-        }
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -102,7 +102,7 @@ namespace Opm {
         std::array<double, 3> getCellDims(size_t i,size_t j, size_t k) const;
         std::array<double, 3> getCellDims(size_t globalIndex) const;
         bool cellActive( size_t globalIndex ) const;
-        bool cellActive( size_t i , size_t , size_t k ) const;
+        bool cellActive( size_t i , size_t j, size_t k ) const;
         double getCellDepth(size_t i,size_t j, size_t k) const;
         double getCellDepth(size_t globalIndex) const;
 

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -246,7 +246,7 @@ namespace Opm {
                 std::string boxSize = std::to_string(static_cast<long long>(indexList.size()));
                 std::string keywordSize = std::to_string(static_cast<long long>(deckItem.size()));
 
-                throw std::invalid_argument("Size mismatch: Box:" + boxSize + "  DecKeyword:" + keywordSize);
+                throw std::invalid_argument("Size mismatch: Box:" + boxSize + "  DeckKeyword:" + keywordSize);
             }
         }
     }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -110,38 +110,47 @@ static DeckPtr createDeck(const ParseContext& parseContext , const std::string& 
     return parser.parseString(input, parseContext);
 }
 
-static Eclipse3DProperties getGridProperties(DeckPtr deck) {
-    return Eclipse3DProperties( *deck, TableManager( *deck ), EclipseGrid( 10, 3, 4 ) );
-}
 
 BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
     ParseContext parseContext;
     DeckPtr deck = createDeck(parseContext , inputStr);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
     SimulationConfigConstPtr simulationConfigPtr;
     BOOST_CHECK_NO_THROW(simulationConfigPtr = std::make_shared
-            <const SimulationConfig>(parseContext , *deck, getGridProperties(deck)));
+            <const SimulationConfig>(parseContext , *deck, ep));
 }
 
 
 BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
     ParseContext parseContext;
-    DeckPtr deck = createDeck(parseContext , inputStr_noTHPRES);
-    SimulationConfig simulationConfig(parseContext , *deck, getGridProperties(deck));
+    DeckPtr deck = createDeck(parseContext, inputStr_noTHPRES);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
+    SimulationConfig simulationConfig(parseContext , *deck, ep);
     BOOST_CHECK( !simulationConfig.hasThresholdPressure() );
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
     ParseContext parseContext;
-    DeckPtr deck = createDeck(parseContext , inputStr_noTHPRES);
-    SimulationConfig simulationConfig(parseContext , *deck, getGridProperties(deck));
+    DeckPtr deck = createDeck(parseContext, inputStr_noTHPRES);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
+    SimulationConfig simulationConfig(parseContext , *deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
     ParseContext     parseContext;
-    DeckPtr deck   = createDeck(parseContext , inputStr_cpr);
-    SUMMARYSection   summary(*deck);
-    SimulationConfig simulationConfig(parseContext , *deck, getGridProperties(deck));
+    DeckPtr deck = createDeck(parseContext, inputStr_cpr);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
+    SUMMARYSection summary(*deck);
+    SimulationConfig simulationConfig(parseContext , *deck, ep);
     BOOST_CHECK(     simulationConfig.useCPR() );
     BOOST_CHECK(  !  summary.hasKeyword("CPR") );
 }
@@ -149,9 +158,12 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
     ParseContext parseContext;
-    DeckPtr deck = createDeck(parseContext , inputStr_cpr_in_SUMMARY);
+    DeckPtr deck = createDeck(parseContext, inputStr_cpr_in_SUMMARY);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
     SUMMARYSection summary(*deck);
-    SimulationConfig simulationConfig(parseContext , *deck, getGridProperties(deck));
+    SimulationConfig simulationConfig(parseContext , *deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
     BOOST_CHECK(   summary.hasKeyword("CPR"));
 }
@@ -159,9 +171,12 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
     ParseContext parseContext;
-    DeckPtr deck = createDeck(parseContext , inputStr_cpr_BOTH);
+    DeckPtr deck = createDeck(parseContext, inputStr_cpr_BOTH);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
     SUMMARYSection summary(*deck);
-    SimulationConfig simulationConfig(parseContext , *deck, getGridProperties(deck));
+    SimulationConfig simulationConfig(parseContext , *deck, ep);
     BOOST_CHECK(  simulationConfig.useCPR());
     BOOST_CHECK(  summary.hasKeyword("CPR"));
 
@@ -183,13 +198,19 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRRUnspecWithData) {
 
 BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     ParseContext parseContext;
-    DeckPtr deck = createDeck(parseContext , inputStr);
-    SimulationConfig simulationConfig(parseContext , *deck, getGridProperties(deck));
+    DeckPtr deck = createDeck(parseContext, inputStr);
+    TableManager tm(*deck);
+    EclipseGrid eg(10, 3, 4);
+    Eclipse3DProperties ep(*deck, tm, eg);
+    SimulationConfig simulationConfig(parseContext , *deck, ep);
     BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
     BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
 
     DeckPtr deck_vd = createDeck(parseContext, inputStr_vap_dis);
-    SimulationConfig simulationConfig_vd(parseContext , *deck_vd, getGridProperties(deck_vd));
+    TableManager tm_vd(*deck_vd);
+    EclipseGrid eg_vd(10, 3, 4);
+    Eclipse3DProperties ep_vd(*deck_vd, tm, eg);
+    SimulationConfig simulationConfig_vd(parseContext , *deck_vd, ep_vd);
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());
 }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -183,8 +183,13 @@ static DeckPtr createDeck(const ParseContext& parseContext , const std::string& 
 
 static Eclipse3DProperties getEclipseProperties(const Deck& deck)
 {
-    static const EclipseGrid eclipseGrid( 3, 3, 3 );
-    return Eclipse3DProperties( deck, TableManager( deck ), eclipseGrid );
+    TableManager* tm = new TableManager(deck);
+    EclipseGrid* eg = new EclipseGrid(3, 3, 3);
+
+    // We are intentionally leaking memory here.  To save typing three lines
+    // every time we need an Eclipse3DProperties object, we use this helper
+    // function.  We need pointers so that tm and eg do not go out of scope.
+    return Eclipse3DProperties(deck, *tm, *eg);
 }
 
 

--- a/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 using namespace Opm;
@@ -39,7 +40,8 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
+    EclipseState es(deck, ParseContext());
+    auto grid = es.getEclipseGrid();
 
     BOOST_CHECK_EQUAL( 10U  , grid->getNX( ));
     BOOST_CHECK_EQUAL( 10U  , grid->getNY( ));
@@ -52,7 +54,8 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
+    EclipseState es(deck, ParseContext());
+    auto grid = es.getEclipseGrid();
 
     BOOST_CHECK_EQUAL(  10U , grid->getNX( ));
     BOOST_CHECK_EQUAL(  10U , grid->getNY( ));
@@ -65,8 +68,8 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
+    EclipseState es(deck, ParseContext());
+    auto grid = es.getEclipseGrid();
 
     std::vector<int> actnum;
 
@@ -82,8 +85,8 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-
-    std::shared_ptr<EclipseGrid> grid(new EclipseGrid( deck ));
+    EclipseState es(deck, ParseContext());
+    auto grid = es.getEclipseGrid();
 
     std::vector<double> coord;
     std::vector<double> zcorn;


### PR DESCRIPTION
* Added ACTNUM as keyword to Eclipse3DProperties
* Removed certain checks from EclipseGrid that are no longer of use
* Added tests to EclipseGridTests that test boxed ACTNUM and activeCells
* Made EclipseGrid non-const in EclipseState since we must run resetACTNUM
* Fixed a minor typo in an error message in EclipseGrid
* Fixed typo in GridProperty: Deckeyword -> DeckKeyword
* Fixed two errors in tests recently introduced relating to Ecl3DProps
* Removed test in EclipseGridTests; We now accept too small ACTNUM vectors
* Added ACTNUM test for GridProperties