### PR TITLE
Renamed getEclipseGrid to getInputGrid and changed EclipseGrid constructor

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -54,12 +54,12 @@ namespace Opm {
         m_deckUnitSystem(    deck->getActiveUnitSystem() ),
         m_parseContext(      parseContext ),
         m_tables(            *deck ),
-        m_eclipseGrid(       std::make_shared<EclipseGrid>(deck)),
-        m_eclipseProperties( *deck, m_tables, *m_eclipseGrid)
+        m_inputGrid(         std::make_shared<EclipseGrid>(deck)),
+        m_eclipseProperties( *deck, m_tables, *m_inputGrid)
     {
         // after Eclipse3DProperties has been constructed, we have complete ACTNUM info
         if (m_eclipseProperties.hasDeckIntGridProperty("ACTNUM"))
-            m_eclipseGrid->resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
+            m_inputGrid->resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
 
         initIOConfig(deck);
 
@@ -88,11 +88,11 @@ namespace Opm {
     }
 
     EclipseGridConstPtr EclipseState::getEclipseGrid() const {
-        return m_eclipseGrid;
+        return m_inputGrid;
     }
 
     EclipseGridPtr EclipseState::getEclipseGridCopy() const {
-        return std::make_shared<EclipseGrid>( m_eclipseGrid->c_ptr() );
+        return std::make_shared<EclipseGrid>( m_inputGrid->c_ptr() );
     }
 
     const Eclipse3DProperties& EclipseState::get3DProperties() const {

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -54,7 +54,7 @@ namespace Opm {
         m_deckUnitSystem(    deck->getActiveUnitSystem() ),
         m_parseContext(      parseContext ),
         m_tables(            *deck ),
-        m_inputGrid(         std::make_shared<EclipseGrid>(deck)),
+        m_inputGrid(         std::make_shared<EclipseGrid>(deck, nullptr)),
         m_eclipseProperties( *deck, m_tables, *m_inputGrid)
     {
         // after Eclipse3DProperties has been constructed, we have complete ACTNUM info
@@ -63,7 +63,7 @@ namespace Opm {
 
         initIOConfig(deck);
 
-        m_schedule = ScheduleConstPtr( new Schedule(m_parseContext ,  getEclipseGrid() , deck, m_ioConfig) );
+        m_schedule = ScheduleConstPtr( new Schedule(m_parseContext ,  getInputGrid() , deck, m_ioConfig) );
         initIOConfigPostSchedule(deck);
 
         if (deck->hasKeyword( "TITLE" )) {
@@ -80,18 +80,18 @@ namespace Opm {
         initTransMult();
         initFaults(deck);
         initMULTREGT(deck);
-        m_nnc = std::make_shared<NNC>( deck, getEclipseGrid());
+        m_nnc = std::make_shared<NNC>( deck, getInputGrid());
     }
 
     const UnitSystem& EclipseState::getDeckUnitSystem() const {
         return m_deckUnitSystem;
     }
 
-    EclipseGridConstPtr EclipseState::getEclipseGrid() const {
+    EclipseGridConstPtr EclipseState::getInputGrid() const {
         return m_inputGrid;
     }
 
-    EclipseGridPtr EclipseState::getEclipseGridCopy() const {
+    EclipseGridPtr EclipseState::getInputGridCopy() const {
         return std::make_shared<EclipseGrid>( m_inputGrid->c_ptr() );
     }
 
@@ -180,7 +180,7 @@ namespace Opm {
 
 
     void EclipseState::initTransMult() {
-        EclipseGridConstPtr grid = getEclipseGrid();
+        EclipseGridConstPtr grid = getInputGrid();
         m_transMult = std::make_shared<TransMult>( grid->getNX() , grid->getNY() , grid->getNZ());
 
         const auto& p = m_eclipseProperties;
@@ -201,7 +201,7 @@ namespace Opm {
     }
 
     void EclipseState::initFaults(DeckConstPtr deck) {
-        EclipseGridConstPtr grid = getEclipseGrid();
+        EclipseGridConstPtr grid = getInputGrid();
         std::shared_ptr<GRIDSection> gridSection = std::make_shared<GRIDSection>( *deck );
 
         m_faults = std::make_shared<FaultCollection>(gridSection , grid);
@@ -234,7 +234,7 @@ namespace Opm {
 
 
     void EclipseState::initMULTREGT(DeckConstPtr deck) {
-        EclipseGridConstPtr grid = getEclipseGrid();
+        EclipseGridConstPtr grid = getInputGrid();
 
         std::vector< const DeckKeyword* > multregtKeywords;
         if (deck->hasKeyword("MULTREGT"))

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -125,7 +125,7 @@ namespace Opm {
         const UnitSystem& m_deckUnitSystem;
         const ParseContext& m_parseContext;
         const TableManager m_tables;
-        std::shared_ptr<EclipseGrid> m_eclipseGrid;
+        std::shared_ptr<EclipseGrid> m_inputGrid;
         Eclipse3DProperties m_eclipseProperties;
         MessageContainer m_messageContainer;
     };

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -74,8 +74,8 @@ namespace Opm {
         std::shared_ptr< IOConfig > getIOConfig() const;
         std::shared_ptr< const InitConfig > getInitConfig() const;
         std::shared_ptr< const SimulationConfig > getSimulationConfig() const;
-        std::shared_ptr< const EclipseGrid > getEclipseGrid() const;
-        std::shared_ptr< EclipseGrid > getEclipseGridCopy() const;
+        std::shared_ptr< const EclipseGrid > getInputGrid() const;
+        std::shared_ptr< EclipseGrid > getInputGridCopy() const;
         const MessageContainer& getMessageContainer() const;
         MessageContainer& getMessageContainer();
         std::string getTitle() const;

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -112,7 +112,7 @@ namespace Opm {
         return dims;
     }
 
-    EclipseGrid::EclipseGrid(const std::shared_ptr<const Deck>& deck)
+    EclipseGrid::EclipseGrid(const std::shared_ptr<const Deck>& deck, const int * actnum)
         : m_minpvValue(0),
           m_minpvMode(MinpvMode::ModeEnum::Inactive),
           m_pinch("PINCH"),
@@ -161,6 +161,8 @@ namespace Opm {
                 throw std::invalid_argument(msg);
             }
         }
+        if (actnum != nullptr)
+            resetACTNUM(actnum);
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -72,7 +72,11 @@ namespace Opm {
         explicit EclipseGrid(const ecl_grid_type * src_ptr);
         explicit EclipseGrid(size_t nx, size_t ny, size_t nz,
                              double dx = 1.0, double dy = 1.0, double dz = 1.0);
-        explicit EclipseGrid(const std::shared_ptr<const Deck>& deck);
+
+        /// EclipseGrid ignores ACTNUM in Deck, and therefore needs ACTNUM
+        /// explicitly.  If a null pointer is passed, every cell is active.
+        explicit EclipseGrid(const std::shared_ptr<const Deck>& deck, const int * actnum = nullptr);
+
         static bool hasCornerPointKeywords(std::shared_ptr<const Deck> deck);
         static bool hasCartesianKeywords(std::shared_ptr<const Deck> deck);
         size_t  getNumActive( ) const;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -815,7 +815,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
     Opm::DeckConstPtr deck = createActnumBoxDeck();
     Opm::EclipseState es(deck, Opm::ParseContext());
     auto ep = es.get3DProperties();
-    auto grid = es.getEclipseGrid();
+    auto grid = es.getInputGrid();
 
     BOOST_CHECK_NO_THROW(ep.getIntGridProperty("ACTNUM"));
 
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
     BOOST_CHECK_NO_THROW(grid->getNumActive());
     BOOST_CHECK_EQUAL(grid->getNumActive(), active);
 
-    BOOST_CHECK_EQUAL(es.getEclipseGrid()->getNumActive(), active);
+    BOOST_CHECK_EQUAL(es.getInputGrid()->getNumActive(), active);
 
     for (size_t x = 0; x < 10; x++) {
         for (size_t y = 0; y < 10; y++) {
@@ -851,7 +851,7 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
 
     Opm::EclipseState es(deck, Opm::ParseContext());
     auto ep = es.get3DProperties();
-    auto grid = es.getEclipseGrid();
+    auto grid = es.getInputGrid();
 
     BOOST_CHECK_NO_THROW(ep.getIntGridProperty("ACTNUM"));
 
@@ -865,6 +865,6 @@ BOOST_AUTO_TEST_CASE(GridActnumViaState) {
 
     BOOST_CHECK_NO_THROW(Opm::EclipseState(deck, Opm::ParseContext()));
     Opm::EclipseState es(deck, Opm::ParseContext());
-    BOOST_CHECK(es.getEclipseGrid()->hasCellInfo());
-    BOOST_CHECK_EQUAL(es.getEclipseGrid()->getNumActive(), 2 * 2 * 2 - 1);
+    BOOST_CHECK(es.getInputGrid()->hasCellInfo());
+    BOOST_CHECK_EQUAL(es.getInputGrid()->getNumActive(), 2 * 2 * 2 - 1);
 }

--- a/opm/parser/eclipse/EclipseState/Summary/Summary.cpp
+++ b/opm/parser/eclipse/EclipseState/Summary/Summary.cpp
@@ -108,7 +108,7 @@ namespace Opm {
             const DeckKeyword& keyword,
             const EclipseState& es ) {
 
-        auto dims = dimensions( *es.getEclipseGrid() );
+        auto dims = dimensions( *es.getInputGrid() );
 
         const auto mkrecord = [&dims,&keyword]( const DeckRecord& record ) {
             auto ijk = getijk( record );
@@ -122,7 +122,7 @@ namespace Opm {
             const DeckKeyword& keyword,
             const EclipseState& es ) {
 
-        auto dims = dimensions( *es.getEclipseGrid() );
+        auto dims = dimensions( *es.getInputGrid() );
 
         const auto mknode = [&dims,&keyword]( int region ) {
             return ERT::smspec_node( keyword.name(), dims.data(), region );
@@ -144,7 +144,7 @@ namespace Opm {
        const auto& keywordstring = keyword.name();
        const auto& schedule = es.getSchedule();
        const auto last_timestep = schedule->getTimeMap()->last();
-       auto dims = dimensions( *es.getEclipseGrid() );
+       auto dims = dimensions( *es.getInputGrid() );
 
        for( const auto& record : keyword ) {
 

--- a/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
@@ -144,50 +144,66 @@ static Opm::DeckPtr createValidPERMXDeck() {
     return parser->parseString(deckData, Opm::ParseContext());
 }
 
-static Opm::Eclipse3DProperties getProps(Opm::DeckPtr deck) {
-    return Opm::Eclipse3DProperties(*deck, *new Opm::TableManager(*deck), *new Opm::EclipseGrid(deck));
-}
+
+/// Setup fixture
+struct Setup
+{
+    Opm::ParseContext parseContext;
+    Opm::DeckPtr deck;
+    Opm::TableManager tablemanager;
+    Opm::EclipseGrid grid;
+    Opm::Eclipse3DProperties props;
+
+    explicit Setup(Opm::DeckPtr deck) :
+            deck(deck),
+            tablemanager(*deck),
+            grid(deck),
+            props(*deck, tablemanager, grid)
+    {
+    }
+};
+
 
 BOOST_AUTO_TEST_CASE(HasDeckProperty) {
-    auto ep = getProps(createDeck());
-    BOOST_CHECK(ep.hasDeckIntGridProperty("SATNUM"));
+    Setup s(createDeck());
+    BOOST_CHECK(s.props.hasDeckIntGridProperty("SATNUM"));
 }
 
 BOOST_AUTO_TEST_CASE(SupportsProperty) {
-    auto ep = getProps(createDeck());
+    Setup s(createDeck());
     std::vector<std::string> keywordList = {
         // int props
-        "SATNUM", "IMBNUM", "PVTNUM", "EQLNUM", "ENDNUM", "FLUXNUM", "MULTNUM", "FIPNUM", "MISCNUM", "OPERNUM",
+        "ACTNUM", "SATNUM", "IMBNUM", "PVTNUM", "EQLNUM", "ENDNUM", "FLUXNUM", "MULTNUM", "FIPNUM", "MISCNUM", "OPERNUM",
         // double props
         "TEMPI", "MULTPV", "PERMX", "PERMY", "PERMZ", "SWATINIT", "THCONR", "NTG"
     };
 
     for (auto keyword : keywordList)
-        BOOST_CHECK(ep.supportsGridProperty(keyword));
+        BOOST_CHECK(s.props.supportsGridProperty(keyword));
 
 }
 
 BOOST_AUTO_TEST_CASE(DefaultRegionFluxnum) {
-    auto ep = getProps(createDeck());
-    BOOST_CHECK_EQUAL(ep.getDefaultRegionKeyword(), "FLUXNUM");
+    Setup s(createDeck());
+    BOOST_CHECK_EQUAL(s.props.getDefaultRegionKeyword(), "FLUXNUM");
 }
 
 BOOST_AUTO_TEST_CASE(UnsupportedKeywordsThrows) {
-    auto ep = getProps(createDeck());
-    BOOST_CHECK_THROW(ep.hasDeckIntGridProperty("NONO"), std::logic_error);
-    BOOST_CHECK_THROW(ep.hasDeckDoubleGridProperty("NONO"), std::logic_error);
+    Setup s(createDeck());
+    BOOST_CHECK_THROW(s.props.hasDeckIntGridProperty("NONO"), std::logic_error);
+    BOOST_CHECK_THROW(s.props.hasDeckDoubleGridProperty("NONO"), std::logic_error);
 
-    BOOST_CHECK_THROW(ep.getIntGridProperty("NONO"), std::logic_error);
-    BOOST_CHECK_THROW(ep.getDoubleGridProperty("NONO"), std::logic_error);
+    BOOST_CHECK_THROW(s.props.getIntGridProperty("NONO"), std::logic_error);
+    BOOST_CHECK_THROW(s.props.getDoubleGridProperty("NONO"), std::logic_error);
 
-    BOOST_CHECK_NO_THROW(ep.hasDeckIntGridProperty("FLUXNUM"));
-    BOOST_CHECK_NO_THROW(ep.supportsGridProperty("NONO"));
+    BOOST_CHECK_NO_THROW(s.props.hasDeckIntGridProperty("FLUXNUM"));
+    BOOST_CHECK_NO_THROW(s.props.supportsGridProperty("NONO"));
 }
 
 BOOST_AUTO_TEST_CASE(IntGridProperty) {
-    auto ep = getProps(createDeck());
+    Setup s(createDeck());
     int cnt = 0;
-    for (auto x : ep.getIntGridProperty("SATNUM").getData()) {
+    for (auto x : s.props.getIntGridProperty("SATNUM").getData()) {
         BOOST_CHECK_EQUAL(x, 2);
         cnt++;
     }
@@ -196,9 +212,9 @@ BOOST_AUTO_TEST_CASE(IntGridProperty) {
 
 BOOST_AUTO_TEST_CASE(AddregIntSetCorrectly) {
     Opm::DeckPtr deck = createValidIntDeck();
-    const auto& ep = getProps(deck);
+    Setup s(deck);
 
-    const auto& property = ep.getIntGridProperty("SATNUM");
+    const auto& property = s.props.getIntGridProperty("SATNUM");
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {
             if (i < 2)
@@ -211,8 +227,8 @@ BOOST_AUTO_TEST_CASE(AddregIntSetCorrectly) {
 
 BOOST_AUTO_TEST_CASE(PermxUnitAppliedCorrectly) {
     Opm::DeckPtr deck = createValidPERMXDeck();
-    const auto& props = getProps(deck);
-    const auto& permx = props.getDoubleGridProperty("PERMX");
+    Setup s(deck);
+    const auto& permx = s.props.getDoubleGridProperty("PERMX");
 
     for (size_t j = 0; j < 5; j++)
         for (size_t i = 0; i < 5; i++) {

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
 DeckPtr deck = createDeck();
 EclipseState state(deck , ParseContext());
 ScheduleConstPtr schedule = state.getSchedule();
-EclipseGridConstPtr eclipseGrid = state.getEclipseGrid();
+EclipseGridConstPtr eclipseGrid = state.getInputGrid();
 
 BOOST_CHECK_EQUAL( schedule->getStartTime() , boost::posix_time::ptime(boost::gregorian::date(1998 , 3 , 8 )));
 }

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -56,7 +56,7 @@ BOOST_AUTO_TEST_CASE( PERMX ) {
     const auto& permy = state.get3DProperties().getDoubleGridProperty( "PERMY" );
     const auto& permz = state.get3DProperties().getDoubleGridProperty( "PERMZ" );
     size_t i, j, k;
-    std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
+    std::shared_ptr<const EclipseGrid> grid = state.getInputGrid();
 
     for (k = 0; k < grid->getNZ(); k++) {
         for (j = 0; j < grid->getNY(); j++) {
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE( PARSE_BOX_OK ) {
     const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" );
     {
         size_t i, j, k;
-        std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
+        std::shared_ptr<const EclipseGrid> grid = state.getInputGrid();
         for (k = 0; k < grid->getNZ(); k++) {
             for (j = 0; j < grid->getNY(); j++) {
                 for (i = 0; i < grid->getNX(); i++) {
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE( PARSE_MULTIPLY_COPY ) {
     const auto& satnum = state.get3DProperties().getIntGridProperty( "SATNUM" );
     const auto& fipnum = state.get3DProperties().getIntGridProperty( "FIPNUM" );
     size_t i, j, k;
-    std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
+    std::shared_ptr<const EclipseGrid> grid = state.getInputGrid();
 
     for (k = 0; k < grid->getNZ(); k++) {
         for (j = 0; j < grid->getNY(); j++) {
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE( EQUAL ) {
     const auto& eqlnum = state.get3DProperties().getIntGridProperty( "EQLNUM" );
     const auto& poro = state.get3DProperties().getDoubleGridProperty( "PORO" );
     size_t i, j, k;
-    std::shared_ptr<const EclipseGrid> grid = state.getEclipseGrid();
+    std::shared_ptr<const EclipseGrid> grid = state.getInputGrid();
 
     for (k = 0; k < grid->getNZ(); k++) {
         for (j = 0; j < grid->getNY(); j++) {

--- a/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
     EclipseState es(deck, ParseContext());
-    auto grid = es.getEclipseGrid();
+    auto grid = es.getInputGrid();
 
     BOOST_CHECK_EQUAL( 10U  , grid->getNX( ));
     BOOST_CHECK_EQUAL( 10U  , grid->getNY( ));
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
     EclipseState es(deck, ParseContext());
-    auto grid = es.getEclipseGrid();
+    auto grid = es.getInputGrid();
 
     BOOST_CHECK_EQUAL(  10U , grid->getNX( ));
     BOOST_CHECK_EQUAL(  10U , grid->getNY( ));
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
     EclipseState es(deck, ParseContext());
-    auto grid = es.getEclipseGrid();
+    auto grid = es.getInputGrid();
 
     std::vector<int> actnum;
 
@@ -86,7 +86,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
     EclipseState es(deck, ParseContext());
-    auto grid = es.getEclipseGrid();
+    auto grid = es.getInputGrid();
 
     std::vector<double> coord;
     std::vector<double> zcorn;

--- a/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
@@ -45,7 +45,7 @@ BOOST_AUTO_TEST_CASE(noNNC)
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
     Opm::EclipseStateConstPtr eclipseState(new EclipseState(deck , parseContext));
-    auto eclGrid = eclipseState->getEclipseGrid();
+    auto eclGrid = eclipseState->getInputGrid();
     Opm::NNC nnc(deck, eclGrid);
     BOOST_CHECK(!nnc.hasNNC());
 }
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(readDeck)
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
     Opm::EclipseStateConstPtr eclipseState(new EclipseState(deck , parseContext));
-    auto eclGrid = eclipseState->getEclipseGrid();
+    auto eclGrid = eclipseState->getInputGrid();
     Opm::NNC nnc(deck, eclGrid);
     BOOST_CHECK(nnc.hasNNC());
     const std::vector<NNCdata>& nncdata = nnc.nncdata();
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(addNNCfromDeck)
     Opm::ParserPtr parser(new Opm::Parser());
     Opm::DeckConstPtr deck(parser->parseFile(filename, parseContext));
     Opm::EclipseStateConstPtr eclipseState(new EclipseState(deck , parseContext));
-    auto eclGrid = eclipseState->getEclipseGrid();
+    auto eclGrid = eclipseState->getInputGrid();
     Opm::NNC nnc(deck, eclGrid);
     const std::vector<NNCdata>& nncdata = nnc.nncdata();
 

--- a/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE( PARSE_TOPS_OK) {
     ParseContext parseContext;
     DeckPtr deck =  parser->parseFile(deckFile, parseContext);
     EclipseState state(deck , parseContext);
-    EclipseGridConstPtr grid = state.getEclipseGrid();
+    EclipseGridConstPtr grid = state.getInputGrid();
 
     BOOST_CHECK_EQUAL( grid->getNX() , 9 );
     BOOST_CHECK_EQUAL( grid->getNY() , 9 );


### PR DESCRIPTION
This commit introduces two changes:
* EclipseState.getEclipseGrid has been changed to getInputGrid
* EclipseGrid---ignoring ACTNUM in Deck as it now does---has a new constructor, one that explicitly (but default `nullptr`) takes an `const int* actnum`.

Relevant PR's from other repos:
* OPM/opm-output#18
* OPM/opm-material#141
* OPM/opm-core#1002
* OPM/opm-simulators#657
* OPM/ewoms#55
