### PR TITLE
Parser::parse functions and ParseContext is member of state, allowing for default constructor

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -40,6 +40,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/parser/eclipse/Units/Dimension.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
@@ -49,11 +50,11 @@
 namespace Opm {
 
 
-    EclipseState::EclipseState(std::shared_ptr<const Deck> deckptr, const ParseContext& parseContext) :
+    EclipseState::EclipseState(std::shared_ptr<const Deck> deckptr, const ParseContext parseContext) :
         EclipseState(*deckptr, parseContext)
     {}
 
-    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext) :
+    EclipseState::EclipseState(const Deck& deck, const ParseContext parseContext) :
         m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_parseContext(      parseContext ),
         m_tables(            deck ),

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -50,11 +50,11 @@
 namespace Opm {
 
 
-    EclipseState::EclipseState(std::shared_ptr<const Deck> deckptr, const ParseContext parseContext) :
+    EclipseState::EclipseState(std::shared_ptr<const Deck> deckptr, ParseContext parseContext) :
         EclipseState(*deckptr, parseContext)
     {}
 
-    EclipseState::EclipseState(const Deck& deck, const ParseContext parseContext) :
+    EclipseState::EclipseState(const Deck& deck, ParseContext parseContext) :
         m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_parseContext(      parseContext ),
         m_tables(            deck ),

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -33,6 +33,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 namespace Opm {
 
@@ -68,10 +69,10 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
-        EclipseState(const Deck& deck , const ParseContext& parseContext);
+        EclipseState(const Deck& deck , const ParseContext parseContext = ParseContext());
 
         /// [deprecated]
-        EclipseState(std::shared_ptr< const Deck > deck , const ParseContext& parseContext);
+        EclipseState(std::shared_ptr< const Deck > deck , const ParseContext parseContext = ParseContext());
 
         const ParseContext& getParseContext() const;
         std::shared_ptr< const Schedule > getSchedule() const;
@@ -129,7 +130,7 @@ namespace Opm {
 
 
         const UnitSystem& m_deckUnitSystem;
-        const ParseContext& m_parseContext;
+        const ParseContext m_parseContext;
         const TableManager m_tables;
         std::shared_ptr<EclipseGrid> m_inputGrid;
         Eclipse3DProperties m_eclipseProperties;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -69,10 +69,10 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
-        EclipseState(const Deck& deck , const ParseContext parseContext = ParseContext());
+        EclipseState(const Deck& deck , ParseContext parseContext = ParseContext());
 
         /// [deprecated]
-        EclipseState(std::shared_ptr< const Deck > deck , const ParseContext parseContext = ParseContext());
+        EclipseState(std::shared_ptr< const Deck > deck , ParseContext parseContext = ParseContext());
 
         const ParseContext& getParseContext() const;
         std::shared_ptr< const Schedule > getSchedule() const;

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -573,7 +573,6 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
         IOConfigConstPtr ioConfig = state.getIOConfigConst();
 
         BOOST_CHECK_EQUAL(true, ioConfig->getWriteRestartFile(0));
-        BOOST_CHECK_EQUAL(&parseContext , &(state.getParseContext()));
     }
 
     {   //old fashion integer mnemonics

--- a/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -299,11 +299,7 @@ BOOST_AUTO_TEST_CASE( NorneResttartConfig ) {
     rptConfig.push_back( std::make_tuple(241 , true , boost::gregorian::date( 2006,10,10)) );
 
 
-    ParseContext parseContext;
-    ParserPtr parser(new Parser());
-    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/RPTRST_DECK.DATA", parseContext);
-    EclipseState state( deck , parseContext );
-
+    auto state = Parser::parse("testdata/integration_tests/IOConfig/RPTRST_DECK.DATA");
     verifyRestartConfig(state.getIOConfigConst(), rptConfig);
 }
 

--- a/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -100,6 +100,19 @@ namespace Opm {
         return m_errorContexts.end();
     }
 
+    ParseContext ParseContext::withKey(const std::string& key, InputError::Action action) const {
+        ParseContext pc(*this);
+        pc.addKey(key);
+        pc.updateKey(key, action);
+        return pc;
+    }
+
+    ParseContext& ParseContext::withKey(const std::string& key, InputError::Action action) {
+        this->addKey(key);
+        this->updateKey(key, action);
+        return *this;
+    }
+
     bool ParseContext::hasKey(const std::string& key) const {
         if (m_errorContexts.find( key ) == m_errorContexts.end())
             return false;
@@ -218,6 +231,8 @@ namespace Opm {
     const std::string ParseContext::UNSUPPORTED_INITIAL_THPRES = "UNSUPPORTED_INITIAL_THPRES";
 
     const std::string ParseContext::INTERNAL_ERROR_UNINITIALIZED_THPRES = "INTERNAL_ERROR_UNINITIALIZED_THPRES";
+
+    const std::string ParseContext::PARSE_MISSING_SECTIONS = "PARSE_MISSING_SECTIONS";
 }
 
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -82,6 +82,8 @@ namespace Opm {
         ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
         Message::type handleError( const std::string& errorKey, const std::string& msg ) const;
         bool hasKey(const std::string& key) const;
+        ParseContext  withKey(const std::string& key, InputError::Action action = InputError::WARN) const;
+        ParseContext& withKey(const std::string& key, InputError::Action action = InputError::WARN);
         void updateKey(const std::string& key , InputError::Action action);
         void update(InputError::Action action);
         void update(const std::string& keyString , InputError::Action action);
@@ -190,6 +192,12 @@ namespace Opm {
           not supported.
         */
         const static std::string INTERNAL_ERROR_UNINITIALIZED_THPRES;
+
+        /*
+         If the deck is partial deck, and thus a full EclipseState is
+         meaningless, we can still construct a slim EclipseGrid.
+         */
+        const static std::string PARSE_MISSING_SECTIONS;
 
     private:
         void initDefault();

--- a/opm/parser/eclipse/Parser/Parser.hpp
+++ b/opm/parser/eclipse/Parser/Parser.hpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <boost/filesystem.hpp>
 
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Utility/Stringview.hpp>
 
@@ -93,6 +94,27 @@ namespace Opm {
             addParserKeyword( std::unique_ptr< ParserKeyword >( new T ) );
         }
 
+        static EclipseState parse(const Deck& deck,            const ParseContext& context = ParseContext());
+        static EclipseState parse(const std::string &filename, const ParseContext& context = ParseContext());
+        static EclipseState parseData(const std::string &data, const ParseContext& context = ParseContext());
+
+        /// Parses the deck specified in filename.  If context contains ParseContext::PARSE_PARTIAL_DECK,
+        /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
+        /// fully constructed InputGrid
+        static std::shared_ptr<const EclipseGrid> parseGrid(const std::string &filename,
+                const ParseContext& context = ParseContext());
+
+        /// Parses the provided deck.  If context contains ParseContext::PARSE_PARTIAL_DECK,
+        /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
+        /// fully constructed InputGrid
+        static std::shared_ptr<const EclipseGrid> parseGrid(const Deck& deck,
+                const ParseContext& context = ParseContext());
+
+        /// Parses the provided deck string.  If context contains ParseContext::PARSE_PARTIAL_DECK,
+        /// we construct only a lean grid, otherwise, we construct a full EclipseState and return the
+        /// fully constructed InputGrid
+        static std::shared_ptr<const EclipseGrid> parseGridData(const std::string &data,
+                const ParseContext& context = ParseContext());
 
     private:
         // associative map of the parser internal name and the corresponding ParserKeyword object


### PR DESCRIPTION
ParseContext is member of state, allowing for default constructor

* ParseContext is now a true member of EclipseState
* ParseContext is copied into EclipseState so we no longer share reference
* Constructor now has default ParseContext argument
* Updated tests to reflect this, removed a test that checked ref equality
* Added static methods for Parser for constructing grid and state
* Added new ParseContext MISSING_SECTIONS with which we cannot construct state
* parse functions take ref over shared_ptr.  removed duplicate comment
