### PR TITLE
Bugfix for a property test

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/tests/SatfuncPropertyInitializersTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/SatfuncPropertyInitializersTests.cpp
@@ -36,7 +36,7 @@ using namespace Opm;
 
 void check_property(const Eclipse3DProperties& props1, const Eclipse3DProperties& props2, const std::string& propertyName) {
     auto& data1 = props1.getDoubleGridProperty(propertyName).getData();
-    auto& data2 = props1.getDoubleGridProperty(propertyName).getData();
+    auto& data2 = props2.getDoubleGridProperty(propertyName).getData();
 
     BOOST_CHECK_CLOSE(data1[0], data2[0], 1e-12);
 }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -197,12 +197,13 @@ struct Setup
             threshPres(parseContext, *deck, props)
     {
     }
-    explicit Setup(const std::string& input, ParseContext& parseContext) :
-            deck(createDeck(parseContext, input)),
+    explicit Setup(const std::string& input, ParseContext& parseContextArg) :
+            parseContext(), // not used
+            deck(createDeck(parseContextArg, input)),
             tablemanager(*deck),
             grid(10, 3, 4),
             props(*deck, tablemanager, grid),
-            threshPres(parseContext, *deck, props)
+            threshPres(parseContextArg, *deck, props)
     {
     }
 

--- a/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
@@ -154,8 +154,8 @@ struct Setup
     Opm::EclipseGrid grid;
     Opm::Eclipse3DProperties props;
 
-    explicit Setup(Opm::DeckPtr deck) :
-            deck(deck),
+    explicit Setup(Opm::DeckPtr deckArg) :
+            deck(deckArg),
             tablemanager(*deck),
             grid(deck),
             props(*deck, tablemanager, grid)


### PR DESCRIPTION
Problem found by compiler warning. It is an extremely useful tool, and I highly recommend compiling at high warning levels (and activating the third-party header warning suppression).

Also fixed two shadowing warnings (think the code is a little more clear for it, too).