### PR TITLE
Rename Summary to SummaryConfig

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -13,7 +13,7 @@ add_subdirectory(EclipseState/Grid/tests)
 add_subdirectory(EclipseState/Util/tests)
 add_subdirectory(EclipseState/IOConfig/tests)
 add_subdirectory(EclipseState/InitConfig/tests)
-add_subdirectory(EclipseState/Summary/tests)
+add_subdirectory(EclipseState/SummaryConfig/tests)
 add_subdirectory(Utility/tests)
 
 add_subdirectory(Applications)
@@ -126,7 +126,7 @@ EclipseState/InitConfig/InitConfig.cpp
 EclipseState/InitConfig/Equil.cpp
 EclipseState/SimulationConfig/SimulationConfig.cpp
 EclipseState/SimulationConfig/ThresholdPressure.cpp
-EclipseState/Summary/Summary.cpp
+EclipseState/SummaryConfig/SummaryConfig.cpp
 EclipseState/IOConfig/IOConfig.cpp)
 #
 
@@ -222,7 +222,7 @@ EclipseState/InitConfig/InitConfig.hpp
 EclipseState/InitConfig/Equil.hpp
 EclipseState/SimulationConfig/SimulationConfig.hpp
 EclipseState/SimulationConfig/ThresholdPressure.hpp
-EclipseState/Summary/Summary.hpp
+EclipseState/SummaryConfig/SummaryConfig.hpp
 EclipseState/IOConfig/IOConfig.hpp
 #
 EclipseState/Tables/Tabdims.hpp

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -31,7 +31,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
-#include <opm/parser/eclipse/EclipseState/Summary/Summary.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 
 #include <ert/ecl/ecl_smspec.h>
@@ -204,7 +204,7 @@ namespace Opm {
         }
     }
 
-    Summary::Summary( const Deck& deck, const EclipseState& es ) {
+    SummaryConfig::SummaryConfig( const Deck& deck, const EclipseState& es ) {
 
         SUMMARYSection section( deck );
         const auto handler = [&es]( const DeckKeyword& kw ) {
@@ -213,11 +213,11 @@ namespace Opm {
         this->keywords = fun::concat( fun::map( handler, section ) );
     }
 
-    Summary::const_iterator Summary::begin() const {
+    SummaryConfig::const_iterator SummaryConfig::begin() const {
         return this->keywords.cbegin();
     }
 
-    Summary::const_iterator Summary::end() const {
+    SummaryConfig::const_iterator SummaryConfig::end() const {
         return this->keywords.cend();
     }
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -17,8 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef OPM_SUMMARY_HPP
-#define OPM_SUMMARY_HPP
+#ifndef OPM_SUMMARY_CONFIG_HPP
+#define OPM_SUMMARY_CONFIG_HPP
 
 #include <vector>
 
@@ -30,11 +30,11 @@ namespace Opm {
     class EclipseState;
     class ParserKeyword;
 
-    class Summary {
+    class SummaryConfig {
         public:
             typedef std::vector< ERT::smspec_node >::const_iterator const_iterator;
 
-            Summary( const Deck&, const EclipseState& );
+            SummaryConfig( const Deck&, const EclipseState& );
 
             const_iterator begin() const;
             const_iterator end() const;

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/CMakeLists.txt
@@ -1,2 +1,2 @@
-opm_add_test(runSummaryTests SOURCES SummaryTests.cpp 
+opm_add_test(runSummaryConfigTests SOURCES SummaryConfigTests.cpp 
                                   LIBRARIES opmparser ${Boost_LIBRARIES})

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -17,13 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#define BOOST_TEST_MODULE SummaryTests
+#define BOOST_TEST_MODULE SummaryConfigTests
 
 #include <boost/test/unit_test.hpp>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
-#include <opm/parser/eclipse/EclipseState/Summary/Summary.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
@@ -64,7 +64,7 @@ static DeckPtr createDeck( const std::string& summary ) {
     return parser.parseString(input, ParseContext());
 }
 
-static std::vector< std::string > sorted_names( const Summary& summary ) {
+static std::vector< std::string > sorted_names( const SummaryConfig& summary ) {
     std::vector< std::string > ret;
     for( const auto& x : summary )
         ret.push_back( x.wgname() );
@@ -73,7 +73,7 @@ static std::vector< std::string > sorted_names( const Summary& summary ) {
     return ret;
 }
 
-static std::vector< std::string > sorted_keywords( const Summary& summary ) {
+static std::vector< std::string > sorted_keywords( const SummaryConfig& summary ) {
     std::vector< std::string > ret;
     for( const auto& x : summary )
         ret.push_back( x.keyword() );
@@ -82,10 +82,10 @@ static std::vector< std::string > sorted_keywords( const Summary& summary ) {
     return ret;
 }
 
-static Summary createSummary( std::string input ) {
+static SummaryConfig createSummary( std::string input ) {
     auto deck = createDeck( input );
     EclipseState state( deck, ParseContext() );
-    return Summary( *deck, state );
+    return SummaryConfig( *deck, state );
 }
 
 BOOST_AUTO_TEST_CASE(wells_all) {


### PR DESCRIPTION
This object turns out to be the actual configuration object, not a
mediator state to obtain a configuration. It is therefore renamed to
reflect intent and behaviour.