### PR TITLE
Ignore skiprest

### DIFF
--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -268,6 +268,10 @@ namespace Opm {
         for( const auto& kw : { "IKRGR", "IKRGRX", "IKRGRX-", "IKRGRY", "IKRGRY-", "IKRGRZ", "IKRGRZ-" } )
             supportedDoubleKeywords.emplace_back( kw, IKRGRLookup, "1" );
 
+        // Solution keywords - required fror enumerated restart.
+        supportedDoubleKeywords.emplace_back( "PRESSURE", 0.0 , "Pressure" );
+        supportedDoubleKeywords.emplace_back( "SWAT", 0.0 , "1" );
+        supportedDoubleKeywords.emplace_back( "SGAS", 0.0 , "1" );
 
 
         // cell temperature (E300 only, but makes a lot of sense for E100, too)

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -36,37 +36,44 @@ namespace Opm {
     }
 
     InitConfig::InitConfig(DeckConstPtr deck) : equil( equils( *deck ) ) {
-        m_restartInitiated = false;
+        m_restartRequested = false;
         m_restartStep = 0;
         m_restartRootName = "";
 
         initRestartKW(deck);
     }
 
+
+    void InitConfig::setRestart( const std::string& root, int step) {
+        m_restartRequested = true;
+        m_restartStep = step;
+        m_restartRootName = root;
+    }
+
+
     void InitConfig::initRestartKW(DeckConstPtr deck) {
         if (deck->hasKeyword<ParserKeywords::RESTART>( )) {
-            const auto& restart_kw = deck->getKeyword<ParserKeywords::RESTART>( );
-            const auto& restart_dataRecord = restart_kw.getRecord(0);
-            const auto& restart_rootname_item = restart_dataRecord.getItem(0);
-            const std::string restart_rootname_string = restart_rootname_item.get< std::string >(0);
-
-            const auto& restart_report_step_item = restart_dataRecord.getItem(1);
-            int restart_report_step_int = restart_report_step_item.get< int >(0);
-
-            const auto& save_item = restart_dataRecord.getItem(2);
-            if (save_item.hasValue(0)) {
+            const auto& keyword = deck->getKeyword<ParserKeywords::RESTART>( );
+            const auto& record = keyword.getRecord(0);
+            const auto& save_item = record.getItem(2);
+            if (save_item.hasValue(0))
                 throw std::runtime_error("OPM does not support RESTART from a SAVE file, only from RESTART files");
-            }
 
-            m_restartInitiated = true;
-            m_restartStep = restart_report_step_int;
-            m_restartRootName = restart_rootname_string;
+            {
+                const auto& root_item = record.getItem(0);
+                const std::string& root = root_item.get< std::string >(0);
+
+                const auto& step_item = record.getItem(1);
+                int step = step_item.get< int >(0);
+
+                setRestart( root , step );
+            }
         } else if (deck->hasKeyword<ParserKeywords::SKIPREST>())
             throw std::runtime_error("Error in deck: Can not supply SKIPREST keyword without a preceeding RESTART.");
     }
 
-    bool InitConfig::getRestartInitiated() const {
-        return m_restartInitiated;
+    bool InitConfig::restartRequested() const {
+        return m_restartRequested;
     }
 
     int InitConfig::getRestartStep() const {

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -24,11 +24,15 @@
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp>
 
+#include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
+
 namespace Opm {
 
     static inline Equil equils( const Deck& deck ) {
-        if( !deck.hasKeyword( "EQUIL" ) ) return {};
-        return Equil( deck.getKeyword( "EQUIL" ) );
+        if( !deck.hasKeyword<ParserKeywords::EQUIL>( ) ) return {};
+        return Equil( deck.getKeyword<ParserKeywords::EQUIL>(  ) );
     }
 
     InitConfig::InitConfig(DeckConstPtr deck) : equil( equils( *deck ) ) {
@@ -40,8 +44,8 @@ namespace Opm {
     }
 
     void InitConfig::initRestartKW(DeckConstPtr deck) {
-        if (deck->hasKeyword("RESTART")) {
-            const auto& restart_kw = deck->getKeyword("RESTART");
+        if (deck->hasKeyword<ParserKeywords::RESTART>( )) {
+            const auto& restart_kw = deck->getKeyword<ParserKeywords::RESTART>( );
             const auto& restart_dataRecord = restart_kw.getRecord(0);
             const auto& restart_rootname_item = restart_dataRecord.getItem(0);
             const std::string restart_rootname_string = restart_rootname_item.get< std::string >(0);
@@ -57,7 +61,7 @@ namespace Opm {
             m_restartInitiated = true;
             m_restartStep = restart_report_step_int;
             m_restartRootName = restart_rootname_string;
-        } else if (deck->hasKeyword("SKIPREST"))
+        } else if (deck->hasKeyword<ParserKeywords::SKIPREST>())
             throw std::runtime_error("Error in deck: Can not supply SKIPREST keyword without a preceeding RESTART.");
     }
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -40,7 +40,7 @@ namespace Opm {
     }
 
     void InitConfig::initRestartKW(DeckConstPtr deck) {
-        if (deck->hasKeyword("RESTART") && deck->hasKeyword("SKIPREST")) {
+        if (deck->hasKeyword("RESTART")) {
             const auto& restart_kw = deck->getKeyword("RESTART");
             const auto& restart_dataRecord = restart_kw.getRecord(0);
             const auto& restart_rootname_item = restart_dataRecord.getItem(0);
@@ -57,9 +57,8 @@ namespace Opm {
             m_restartInitiated = true;
             m_restartStep = restart_report_step_int;
             m_restartRootName = restart_rootname_string;
-        } else if (deck->hasKeyword("RESTART") || deck->hasKeyword("SKIPREST")){
-            throw std::runtime_error("Error in deck: Only one of the kewywords RESTART and SKIPREST are supplied. None or both of them should be supplied.");
-        }
+        } else if (deck->hasKeyword("SKIPREST"))
+            throw std::runtime_error("Error in deck: Can not supply SKIPREST keyword without a preceeding RESTART.");
     }
 
     bool InitConfig::getRestartInitiated() const {

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -31,7 +31,8 @@ namespace Opm {
     public:
         InitConfig(std::shared_ptr< const Deck > deck);
 
-        bool getRestartInitiated() const;
+        void setRestart( const std::string& root, int step);
+        bool restartRequested() const;
         int getRestartStep() const;
         const std::string& getRestartRootName() const;
 
@@ -41,7 +42,7 @@ namespace Opm {
     private:
         void initRestartKW(std::shared_ptr< const Deck > deck);
 
-        bool m_restartInitiated;
+        bool m_restartRequested;
         int m_restartStep;
         std::string m_restartRootName;
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(InitConfigTest) {
     BOOST_CHECK_THROW(std::make_shared<InitConfig>(deck3), std::runtime_error);
 
     DeckPtr deck4 = createDeck(deckStr4);
-    BOOST_CHECK_THROW(std::make_shared<InitConfig>(deck4), std::runtime_error);
+    BOOST_CHECK_NO_THROW(std::make_shared<InitConfig>(deck4));
 }
 
 BOOST_AUTO_TEST_CASE( InitConfigWithoutEquil ) {

--- a/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/tests/InitConfigTest.cpp
@@ -112,16 +112,21 @@ BOOST_AUTO_TEST_CASE(InitConfigTest) {
     DeckPtr deck = createDeck(deckStr);
     InitConfigPtr initConfigPtr;
     BOOST_CHECK_NO_THROW(initConfigPtr = std::make_shared<InitConfig>(deck));
-    BOOST_CHECK_EQUAL(initConfigPtr->getRestartInitiated(), true);
+    BOOST_CHECK_EQUAL(initConfigPtr->restartRequested(), true);
     BOOST_CHECK_EQUAL(initConfigPtr->getRestartStep(), 5);
     BOOST_CHECK_EQUAL(initConfigPtr->getRestartRootName(), "BASE");
 
     DeckPtr deck2 = createDeck(deckStr2);
     InitConfigPtr initConfigPtr2;
     BOOST_CHECK_NO_THROW(initConfigPtr2 = std::make_shared<InitConfig>(deck2));
-    BOOST_CHECK_EQUAL(initConfigPtr2->getRestartInitiated(), false);
+    BOOST_CHECK_EQUAL(initConfigPtr2->restartRequested(), false);
     BOOST_CHECK_EQUAL(initConfigPtr2->getRestartStep(), 0);
     BOOST_CHECK_EQUAL(initConfigPtr2->getRestartRootName(), "");
+
+    initConfigPtr2->setRestart( "CASE" , 100);
+    BOOST_CHECK_EQUAL(initConfigPtr2->restartRequested(), true);
+    BOOST_CHECK_EQUAL(initConfigPtr2->getRestartStep(), 100);
+    BOOST_CHECK_EQUAL(initConfigPtr2->getRestartRootName(), "CASE");
 
     DeckPtr deck3 = createDeck(deckStr3);
     BOOST_CHECK_THROW(std::make_shared<InitConfig>(deck3), std::runtime_error);

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -258,12 +258,6 @@ BOOST_AUTO_TEST_CASE(IntProperties) {
     BOOST_CHECK_EQUAL( true,  state.get3DProperties().hasDeckIntGridProperty( "SATNUM" ) );
 }
 
-BOOST_AUTO_TEST_CASE(PropertiesNotSupportsFalse) {
-    DeckPtr deck = createDeck();
-    EclipseState state( deck, ParseContext() );
-    const auto& props = state.get3DProperties();
-    BOOST_CHECK( ! props.supportsGridProperty( "SWAT" ) );
-}
 
 BOOST_AUTO_TEST_CASE(GetProperty) {
     DeckPtr deck = createDeck();


### PR DESCRIPTION
Minor update to support: https://github.com/OPM/opm-parser/issues/773

PR in opm-simulators coming.

The SWAT / SGAS / PRESSURE keywords are added to the Eclipse3DProperites to enable enumerated restarts.