### PR TITLE
Emit compiler warning when including Deck.hpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,6 +103,7 @@ set(Boost_USE_MULTITHREADED      ON)
 set(Boost_USE_STATIC_RUNTIME    OFF)
 
 
+add_definitions(-DOPM_PARSER_DECK_API=1)
 # Requires BOOST filesystem version 3, thus 1.44 is necessary.
 add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
 find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_framework regex REQUIRED)

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -29,6 +29,21 @@
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 
+#ifdef OPM_PARSER_DECK_API_WARNING
+#ifndef OPM_PARSER_DECK_API
+#pragma message "\n\n" \
+"   ----------------------------------------------------------------------------------\n" \
+"   The current compilation unit includes the header Deck.hpp. Outside of opm-parser  \n" \
+"   you are encouraged to use the EclipseState API instead of the low level Deck API. \n" \
+"   If use of the Deck API is absolutely necessary you can silence this warning with  \n" \
+"   #define OPM_PARSER_DECK_API before including the Deck.hpp header.                 \n" \
+"   ----------------------------------------------------------------------------------\n" \
+""
+#endif
+#endif
+
+
+
 namespace Opm {
 
     /*
@@ -106,7 +121,7 @@ namespace Opm {
 
             DeckKeyword& getKeyword( size_t );
             MessageContainer& getMessageContainer() const;
-        
+
             UnitSystem& getDefaultUnitSystem();
             UnitSystem& getActiveUnitSystem();
 


### PR DESCRIPTION
This commit is a first step towards reducing the use of the Deck api
outside of opm-parser. Downstream modules should preferably use the
EclipseState api which is richer in features, and also easier to use
correctly.

The current form of the code is temporary, in the future we will remove
the OPM_PARSER_DECK_API_WARNING compile guard.