### PR TITLE
Added method getIJK in EclipseGrid

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -254,6 +254,17 @@ namespace Opm {
         return (i + j * getNX() + k * getNX() * getNY());
     }
 
+    std::array<int, 3> EclipseGrid::getIJK(size_t globalIndex) const {
+        std::array<int, 3> r = { 0, 0, 0 };
+        int k = globalIndex / (getNX() * getNY()); globalIndex -= k * (getNX() * getNY());
+        int j = globalIndex / getNX();             globalIndex -= j *  getNX();
+        int i = globalIndex;
+        r[0] = i;
+        r[1] = j;
+        r[2] = k;
+        return r;
+    }
+
     void EclipseGrid::assertGlobalIndex(size_t globalIndex) const {
         if (globalIndex >= getCartesianSize())
             throw std::invalid_argument("input index above valid range");

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -96,6 +96,7 @@ namespace Opm {
         bool hasCellInfo() const;
 
         size_t getGlobalIndex(size_t i, size_t j, size_t k) const;
+        std::array<int, 3> getIJK(size_t globalIndex) const;
         void assertGlobalIndex(size_t globalIndex) const;
         void assertIJK(size_t i , size_t j , size_t k) const;
         std::array<double, 3> getCellCenter(size_t i,size_t j, size_t k) const;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -101,7 +101,33 @@ BOOST_AUTO_TEST_CASE(CreateGridNoCells) {
     BOOST_CHECK_EQUAL( 1000 , grid.getCartesianSize());
 }
 
+BOOST_AUTO_TEST_CASE(CheckGridIndex) {
+    Opm::EclipseGrid grid(17, 19, 41); // prime time
 
+    auto v_start = grid.getIJK(0);
+    BOOST_CHECK_EQUAL(v_start[0], 0);
+    BOOST_CHECK_EQUAL(v_start[1], 0);
+    BOOST_CHECK_EQUAL(v_start[2], 0);
+
+    auto v_end = grid.getIJK(17*19*41 - 1);
+    BOOST_CHECK_EQUAL(v_end[0], 16);
+    BOOST_CHECK_EQUAL(v_end[1], 18);
+    BOOST_CHECK_EQUAL(v_end[2], 40);
+
+    auto v167 = grid.getIJK(167);
+    BOOST_CHECK_EQUAL(v167[0], 14);
+    BOOST_CHECK_EQUAL(v167[1], 9);
+    BOOST_CHECK_EQUAL(v167[2], 0);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(14, 9, 0), 167);
+
+    auto v5723 = grid.getIJK(5723);
+    BOOST_CHECK_EQUAL(v5723[0], 11);
+    BOOST_CHECK_EQUAL(v5723[1], 13);
+    BOOST_CHECK_EQUAL(v5723[2], 17);
+    BOOST_CHECK_EQUAL(grid.getGlobalIndex(11, 13, 17), 5723);
+
+    BOOST_CHECK_EQUAL(17 * 19 * 41, grid.getCartesianSize());
+}
 
 static Opm::DeckPtr createCPDeck() {
     const char *deckData =


### PR DESCRIPTION
This PR introduces one new method on `EclipseGrid`: essentially reimplementing (instead of exposing) `ecl_grid.h` function
```C
void ecl_grid_get_ijk1(const ecl_grid_type * , int global_index , int *, int * , int *);
```