### PR TITLE
Add EclipseGrid.cartesianAdjacent and throw if out of bounds

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -249,19 +249,40 @@ namespace Opm {
         return m_minpvValue;
     }
 
+    /// static helper function checking that _one_ coordinate differs with 1
+    bool ijk_are_adj(int i1, int j1, int k1, int i2, int j2, int k2) {
+        return ((i1-i2)*(i1-i2)+
+                (j1-j2)*(j1-j2)+
+                (k1-k2)*(k1-k2)) == 1;
+    }
+
+    // checks cartesian adjacency of global indices g1 and g2
+    bool EclipseGrid::cartesianAdjacent(size_t g1, size_t g2) const {
+        assertGlobalIndex(g1); assertGlobalIndex(g2);
+
+        auto cell1 = getIJK(g1);
+        auto cell2 = getIJK(g2);
+        return ijk_are_adj(cell1[0], cell1[1], cell1[2],
+                           cell2[0], cell2[1], cell2[2]);
+    }
+
+
+
 
     size_t EclipseGrid::getGlobalIndex(size_t i, size_t j, size_t k) const {
+        assertIJK(i, j, k);
         return (i + j * getNX() + k * getNX() * getNY());
     }
 
-    std::array<int, 3> EclipseGrid::getIJK(size_t globalIndex) const {
-        std::array<int, 3> r = { 0, 0, 0 };
-        int k = globalIndex / (getNX() * getNY()); globalIndex -= k * (getNX() * getNY());
-        int j = globalIndex / getNX();             globalIndex -= j *  getNX();
-        int i = globalIndex;
-        r[0] = i;
-        r[1] = j;
-        r[2] = k;
+    std::array<int, 3> EclipseGrid::getIJK(size_t g) const {
+        assertGlobalIndex(g);
+        std::array<int, 3> r;
+
+        int i = g % m_nx;  g /= m_nx;
+        int j = g % m_ny;  g /= m_ny;
+        int k = g % m_nz;
+
+        r[0] = i; r[1] = j; r[2] = k;
         return r;
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -96,6 +96,9 @@ namespace Opm {
 
         bool hasCellInfo() const;
 
+        /// Checks if two global indices are Cartesian neighbors
+        bool cartesianAdjacent(size_t g1, size_t g2) const;
+
         size_t getGlobalIndex(size_t i, size_t j, size_t k) const;
         std::array<int, 3> getIJK(size_t globalIndex) const;
         void assertGlobalIndex(size_t globalIndex) const;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -127,6 +127,27 @@ BOOST_AUTO_TEST_CASE(CheckGridIndex) {
     BOOST_CHECK_EQUAL(grid.getGlobalIndex(11, 13, 17), 5723);
 
     BOOST_CHECK_EQUAL(17 * 19 * 41, grid.getCartesianSize());
+
+    BOOST_CHECK_THROW(grid.getIJK(17 * 19 * 41), std::invalid_argument);
+
+    BOOST_CHECK_THROW(grid.getGlobalIndex(17, 0, 0), std::invalid_argument);
+    BOOST_CHECK_THROW(grid.getGlobalIndex(0, 19, 0), std::invalid_argument);
+    BOOST_CHECK_THROW(grid.getGlobalIndex(0, 0, 41), std::invalid_argument);
+
+    size_t c1 = grid.getGlobalIndex(7, 11, 13);
+    size_t c2 = grid.getGlobalIndex(7, 12, 13);
+    size_t c3 = grid.getGlobalIndex(7, 13, 13);
+    size_t c4 = grid.getGlobalIndex(8, 12, 14);
+
+
+    BOOST_CHECK( grid.cartesianAdjacent(c1, c2));
+    BOOST_CHECK( grid.cartesianAdjacent(c3, c2));
+    BOOST_CHECK(!grid.cartesianAdjacent(c1, c3));
+
+    BOOST_CHECK(!grid.cartesianAdjacent(c4, c1));
+    BOOST_CHECK(!grid.cartesianAdjacent(c4, c2));
+    BOOST_CHECK(!grid.cartesianAdjacent(c4, c3));
+
 }
 
 static Opm::DeckPtr createCPDeck() {


### PR DESCRIPTION
* This PR introduces a method EclipseGrid.cartesianAdjacent that takes two global indices and check whether they are adjacent in the cartesian way, that is, _(i<sub>1</sub>-i<sub>2</sub>)<sup>2</sup> + (j<sub>1</sub>-j<sub>2</sub>)<sup>2</sup> + (k<sub>1</sub>-k<sub>2</sub>)<sup>2</sup> = 1_
* Adds tests for EclipseGrid.cartesianAdjacent
* Rewrote, as per @bska the previously implemented `getIJK`
* Added `assertIJK` and `assertGlobalIndex` in corresponding translate functions

The cartesianAdjacent function will be used in PR relating to output NNC.