### PR TITLE
Support explicit setting of BaseName

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -465,7 +465,7 @@ namespace Opm {
         m_output_dir = outputDir;
     }
 
-    std::string IOConfig::getBaseName() {
+    const std::string& IOConfig::getBaseName() const {
         return m_base_name;
     }
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -469,4 +469,8 @@ namespace Opm {
         return m_base_name;
     }
 
+    void IOConfig::setBaseName(std::string baseName) {
+        m_base_name = baseName;
+    }
+
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -165,6 +165,7 @@ namespace Opm {
         void setOutputDir(const std::string& outputDir);
 
         std::string getBaseName();
+        void setBaseName(std::string baseName);
 
     private:
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -164,7 +164,7 @@ namespace Opm {
         std::string getOutputDir();
         void setOutputDir(const std::string& outputDir);
 
-        std::string getBaseName();
+        const std::string& getBaseName() const;
         void setBaseName(std::string baseName);
 
     private:


### PR DESCRIPTION
Needed when reading deck from string and trying to write to disk.
If this is not set there is no baseName to base the file name on.

A _very_ special case. Will only ever be used by tests? Should we actually support this? 