### PR TITLE
added: downstream build support in the jenkins trigger

### DIFF
--- a/jenkins/build-opm-parser.sh
+++ b/jenkins/build-opm-parser.sh
@@ -44,7 +44,7 @@ function build_opm_parser {
   pushd .
   mkdir serial/build-opm-parser
   cd serial/build-opm-parser
-  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
+  build_module "-DCMAKE_PREFIX_PATH=$WORKSPACE/serial/install -DCMAKE_INSTALL_PREFIX=$WORKSPACE/serial/install -DOPM_DATA_ROOT=$OPM_DATA_ROOT" 1 $WORKSPACE
   test $? -eq 0 || exit 1
   popd
 }

--- a/jenkins/build-pr.sh
+++ b/jenkins/build-pr.sh
@@ -2,9 +2,9 @@
 
 source `dirname $0`/build-opm-parser.sh
 
+# Upstream revisions
 ERT_REVISION=master
 OPM_COMMON_REVISION=master
-OPM_PARSER_REVISION=$sha1
 
 if grep -q "ert=" <<< $ghprbCommentBody
 then
@@ -15,9 +15,39 @@ then
   OPM_COMMON_REVISION=pull/`echo $ghprbCommentBody | sed -r 's/.*opm-common=([0-9]+).*/\1/g'`/merge
 fi
 
-echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$OPM_PARSER_REVISION"
+echo "Building with ert=$ERT_REVISION opm-common=$OPM_COMMON_REVISION opm-parser=$sha1"
 
 build_opm_parser
 test $? -eq 0 || exit 1
 
-cp serial/build-opm-parser/testoutput.xml .
+# If no downstream builds we are done
+if ! grep -q "with downstreams" <<< $ghprbCommentBody
+then
+  cp serial/build-opm-parser/testoutput.xml .
+  exit 0
+fi
+
+source $WORKSPACE/deps/opm-common/jenkins/build-opm-module.sh
+
+# Downstream revisions
+declare -a downstreams
+downstreams=(opm-material
+             opm-core
+             opm-grid
+             opm-output
+             opm-simulators
+             opm-upscaling
+             ewoms)
+
+declare -A downstreamRev
+downstreamRev[opm-material]=master
+downstreamRev[opm-core]=master
+downstreamRev[opm-grid]=master
+downstreamRev[opm-output]=master
+downstreamRev[opm-simulators]=master
+downstreamRev[opm-upscaling]=master
+downstreamRev[ewoms]=master
+
+build_downstreams opm-parser
+
+test $? -eq 0 || exit 1


### PR DESCRIPTION
use 'jenkins build this with downstreams please'.

this will build all downstreams against the PR, and
execute their tests. PR's for upstream and downstream modules
can be specified.

the aggregated test results are attached to the job result on jenkins.

depends on https://github.com/OPM/opm-common/pull/111