### PR TITLE
Removed dependency on shared_ptr for deck and faults

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -166,13 +166,15 @@ namespace Opm {
     }
 
     void EclipseState::initIOConfig(const Deck& deck) {
-        m_ioConfig = std::make_shared<IOConfig>();
+        std::string dataFile = deck.getDataFile();
+        m_ioConfig = std::make_shared<IOConfig>(dataFile);
+
         if (Section::hasGRID(deck)) {
-            std::shared_ptr<const GRIDSection> gridSection = std::make_shared<const GRIDSection>(deck);
+            auto gridSection = std::make_shared<const GRIDSection>(deck);
             m_ioConfig->handleGridSection(gridSection);
         }
         if (Section::hasRUNSPEC(deck)) {
-            std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(deck);
+            auto runspecSection = std::make_shared<const RUNSPECSection>(deck);
             m_ioConfig->handleRunspecSection(runspecSection);
         }
     }

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -48,12 +48,17 @@
 
 namespace Opm {
 
-    EclipseState::EclipseState(std::shared_ptr<const Deck> deck, const ParseContext& parseContext) :
-        m_deckUnitSystem(    deck->getActiveUnitSystem() ),
+
+    EclipseState::EclipseState(std::shared_ptr<const Deck> deckptr, const ParseContext& parseContext) :
+        EclipseState(*deckptr, parseContext)
+    {}
+
+    EclipseState::EclipseState(const Deck& deck, const ParseContext& parseContext) :
+        m_deckUnitSystem(    deck.getActiveUnitSystem() ),
         m_parseContext(      parseContext ),
-        m_tables(            *deck ),
+        m_tables(            deck ),
         m_inputGrid(         std::make_shared<EclipseGrid>(deck, nullptr)),
-        m_eclipseProperties( *deck, m_tables, *m_inputGrid)
+        m_eclipseProperties( deck, m_tables, *m_inputGrid)
     {
         // after Eclipse3DProperties has been constructed, we have complete ACTNUM info
         if (m_eclipseProperties.hasDeckIntGridProperty("ACTNUM"))
@@ -61,24 +66,24 @@ namespace Opm {
 
         initIOConfig(deck);
 
-        m_schedule = ScheduleConstPtr( new Schedule(m_parseContext ,  getInputGrid() , deck, m_ioConfig) );
+        m_schedule = ScheduleConstPtr(new Schedule(m_parseContext, getInputGrid(), deck, m_ioConfig));
         initIOConfigPostSchedule(deck);
 
-        if (deck->hasKeyword( "TITLE" )) {
-            const auto& titleKeyword = deck->getKeyword( "TITLE" );
+        if (deck.hasKeyword( "TITLE" )) {
+            const auto& titleKeyword = deck.getKeyword( "TITLE" );
             const auto& item = titleKeyword.getRecord( 0 ).getItem( 0 );
             std::vector<std::string> itemValue = item.getData<std::string>();
             m_title = boost::algorithm::join( itemValue, " " );
         }
 
         m_initConfig = std::make_shared<const InitConfig>(deck);
-        m_simulationConfig = std::make_shared<const SimulationConfig>(m_parseContext, *deck,
+        m_simulationConfig = std::make_shared<const SimulationConfig>(m_parseContext, deck,
                                                                       m_eclipseProperties);
 
         initTransMult();
         initFaults(deck);
         initMULTREGT(deck);
-        m_nnc = std::make_shared<NNC>( deck, getInputGrid());
+        m_nnc = NNC(deck, getInputGrid());
 
         m_messageContainer.appendMessages(m_tables.getMessageContainer());
         m_messageContainer.appendMessages(m_schedule->getMessageContainer());
@@ -148,36 +153,34 @@ namespace Opm {
         return m_transMult;
     }
 
-    std::shared_ptr<const NNC> EclipseState::getNNC() const {
+    const NNC& EclipseState::getNNC() const {
         return m_nnc;
     }
 
     bool EclipseState::hasNNC() const {
-        return m_nnc->hasNNC();
+        return m_nnc.hasNNC();
     }
 
     std::string EclipseState::getTitle() const {
         return m_title;
     }
 
-    void EclipseState::initIOConfig(DeckConstPtr deck) {
-        std::string dataFile = deck->getDataFile();
-
-        m_ioConfig = std::make_shared<IOConfig>(dataFile);
-        if (Section::hasGRID(*deck)) {
-            std::shared_ptr<const GRIDSection> gridSection = std::make_shared<const GRIDSection>(*deck);
+    void EclipseState::initIOConfig(const Deck& deck) {
+        m_ioConfig = std::make_shared<IOConfig>();
+        if (Section::hasGRID(deck)) {
+            std::shared_ptr<const GRIDSection> gridSection = std::make_shared<const GRIDSection>(deck);
             m_ioConfig->handleGridSection(gridSection);
         }
-        if (Section::hasRUNSPEC(*deck)) {
-            std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(*deck);
+        if (Section::hasRUNSPEC(deck)) {
+            std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>(deck);
             m_ioConfig->handleRunspecSection(runspecSection);
         }
     }
 
     // Hmmm - would have thought this should iterate through the SCHEDULE section as well?
-    void EclipseState::initIOConfigPostSchedule(DeckConstPtr deck) {
-        if (Section::hasSOLUTION(*deck)) {
-            std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>(*deck);
+    void EclipseState::initIOConfigPostSchedule(const Deck& deck) {
+        if (Section::hasSOLUTION(deck)) {
+            std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>(deck);
             m_ioConfig->handleSolutionSection(m_schedule->getTimeMap(), solutionSection);
         }
         m_ioConfig->initFirstOutput( *m_schedule );
@@ -207,13 +210,13 @@ namespace Opm {
 
     void EclipseState::initFaults(DeckConstPtr deck) {
         EclipseGridConstPtr grid = getInputGrid();
-        std::shared_ptr<GRIDSection> gridSection = std::make_shared<GRIDSection>( *deck );
+        std::shared_ptr<GRIDSection> gridSection = std::make_shared<GRIDSection>( deck );
 
         m_faults = std::make_shared<FaultCollection>(gridSection , grid);
         setMULTFLT(gridSection);
 
-        if (Section::hasEDIT(*deck)) {
-            std::shared_ptr<EDITSection> editSection = std::make_shared<EDITSection>( *deck );
+        if (Section::hasEDIT(deck)) {
+            std::shared_ptr<EDITSection> editSection = std::make_shared<EDITSection>( deck );
             setMULTFLT(editSection);
         }
 
@@ -222,7 +225,7 @@ namespace Opm {
 
 
 
-    void EclipseState::setMULTFLT(std::shared_ptr<const Section> section) const {
+    void EclipseState::setMULTFLT(std::shared_ptr<const Section> section) {
         for (size_t index=0; index < section->count("MULTFLT"); index++) {
             const auto& faultsKeyword = section->getKeyword("MULTFLT" , index);
             for (auto iter = faultsKeyword.begin(); iter != faultsKeyword.end(); ++iter) {
@@ -231,19 +234,19 @@ namespace Opm {
                 const std::string& faultName = faultRecord.getItem(0).get< std::string >(0);
                 double multFlt = faultRecord.getItem(1).get< double >(0);
 
-                m_faults->setTransMult( faultName , multFlt );
+                m_faults.setTransMult( faultName , multFlt );
             }
         }
     }
 
 
 
-    void EclipseState::initMULTREGT(DeckConstPtr deck) {
+    void EclipseState::initMULTREGT(const Deck& deck) {
         EclipseGridConstPtr grid = getInputGrid();
 
         std::vector< const DeckKeyword* > multregtKeywords;
-        if (deck->hasKeyword("MULTREGT"))
-            multregtKeywords = deck->getKeywordList("MULTREGT");
+        if (deck.hasKeyword("MULTREGT"))
+            multregtKeywords = deck.getKeywordList("MULTREGT");
 
         std::shared_ptr<MULTREGTScanner> scanner =
             std::make_shared<MULTREGTScanner>(
@@ -267,9 +270,9 @@ namespace Opm {
     }
 
 
-    void EclipseState::complainAboutAmbiguousKeyword(DeckConstPtr deck, const std::string& keywordName) {
+    void EclipseState::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) {
         m_messageContainer.error("The " + keywordName + " keyword must be unique in the deck. Ignoring all!");
-        auto keywords = deck->getKeywordList(keywordName);
+        auto keywords = deck.getKeywordList(keywordName);
         for (size_t i = 0; i < keywords.size(); ++i) {
             std::string msg = "Ambiguous keyword "+keywordName+" defined here";
             m_messageContainer.error(keywords[i]->getFileName(), msg, keywords[i]->getLineNumber());

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -26,6 +26,10 @@
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
@@ -43,8 +47,6 @@ namespace Opm {
     class DeckRecord;
     class EclipseGrid;
     class Eclipse3DProperties;
-    class Fault;
-    class FaultCollection;
     class InitConfig;
     class IOConfig;
     class NNC;
@@ -83,9 +85,9 @@ namespace Opm {
         MessageContainer& getMessageContainer();
         std::string getTitle() const;
 
-        std::shared_ptr<const FaultCollection> getFaults() const;
+        const FaultCollection& getFaults() const;
         std::shared_ptr<const TransMult> getTransMult() const;
-        std::shared_ptr<const NNC> getNNC() const;
+        const NNC& getNNC() const;
         bool hasNNC() const;
 
         const Eclipse3DProperties& get3DProperties() const;
@@ -97,18 +99,20 @@ namespace Opm {
         // the unit system used by the deck. note that it is rarely needed to convert
         // units because internally to opm-parser everything is represented by SI
         // units...
-        const UnitSystem& getDeckUnitSystem()  const;
-        void applyModifierDeck( const Deck& deck);
+        const UnitSystem& getDeckUnitSystem() const;
+
+        /// [deprecated]
+        void applyModifierDeck(std::shared_ptr<const Deck>);
+        void applyModifierDeck(const Deck& deck);
 
     private:
         void initIOConfig(const Deck& deck);
         void initIOConfigPostSchedule(const Deck& deck);
         void initTransMult();
-        void initFaults(std::shared_ptr< const Deck > deck);
+        void initFaults(const Deck& deck);
 
-
-        void setMULTFLT(std::shared_ptr<const Opm::Section> section) const;
-        void initMULTREGT(std::shared_ptr< const Deck > deck);
+        void setMULTFLT(std::shared_ptr<const Opm::Section> section);
+        void initMULTREGT(const Deck& deck);
 
         void complainAboutAmbiguousKeyword(const Deck& deck,
                                            const std::string& keywordName);
@@ -120,8 +124,8 @@ namespace Opm {
 
         std::string m_title;
         std::shared_ptr<TransMult> m_transMult;
-        std::shared_ptr<FaultCollection> m_faults;
-        std::shared_ptr<NNC> m_nnc;
+        FaultCollection m_faults;
+        NNC m_nnc;
 
 
         const UnitSystem& m_deckUnitSystem;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -66,6 +66,9 @@ namespace Opm {
             AllProperties = IntProperties | DoubleProperties
         };
 
+        EclipseState(const Deck& deck , const ParseContext& parseContext);
+
+        /// [deprecated]
         EclipseState(std::shared_ptr< const Deck > deck , const ParseContext& parseContext);
 
         const ParseContext& getParseContext() const;
@@ -95,12 +98,11 @@ namespace Opm {
         // units because internally to opm-parser everything is represented by SI
         // units...
         const UnitSystem& getDeckUnitSystem()  const;
-        void applyModifierDeck( std::shared_ptr<const Deck> deck);
+        void applyModifierDeck( const Deck& deck);
 
     private:
-        void initTabdims(std::shared_ptr< const Deck > deck);
-        void initIOConfig(std::shared_ptr< const Deck > deck);
-        void initIOConfigPostSchedule(std::shared_ptr< const Deck > deck);
+        void initIOConfig(const Deck& deck);
+        void initIOConfigPostSchedule(const Deck& deck);
         void initTransMult();
         void initFaults(std::shared_ptr< const Deck > deck);
 
@@ -108,7 +110,7 @@ namespace Opm {
         void setMULTFLT(std::shared_ptr<const Opm::Section> section) const;
         void initMULTREGT(std::shared_ptr< const Deck > deck);
 
-        void complainAboutAmbiguousKeyword(std::shared_ptr< const Deck > deck,
+        void complainAboutAmbiguousKeyword(const Deck& deck,
                                            const std::string& keywordName);
 
         std::shared_ptr< IOConfig >               m_ioConfig;

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -110,18 +110,23 @@ namespace Opm {
         return dims;
     }
 
-    EclipseGrid::EclipseGrid(const std::shared_ptr<const Deck>& deck, const int * actnum)
+    EclipseGrid::EclipseGrid(const std::shared_ptr<const Deck>& deckptr, const int * actnum)
+       :
+               EclipseGrid(*deckptr, actnum)
+    {}
+
+    EclipseGrid::EclipseGrid(const Deck& deck, const int * actnum)
         : m_minpvValue(0),
           m_minpvMode(MinpvMode::ModeEnum::Inactive),
           m_pinch("PINCH"),
           m_pinchoutMode(PinchMode::ModeEnum::TOPBOT),
           m_multzMode(PinchMode::ModeEnum::TOP)
     {
-        const bool hasRUNSPEC = Section::hasRUNSPEC(*deck);
-        const bool hasGRID = Section::hasGRID(*deck);
+        const bool hasRUNSPEC = Section::hasRUNSPEC(deck);
+        const bool hasGRID = Section::hasGRID(deck);
         if (hasRUNSPEC && hasGRID) {
             // Equivalent to first constructor.
-            RUNSPECSection runspecSection( *deck );
+            RUNSPECSection runspecSection( deck );
             if( runspecSection.hasKeyword<ParserKeywords::DIMENS>() ) {
                 const auto& dimens = runspecSection.getKeyword<ParserKeywords::DIMENS>();
                 std::vector<int> dims = getDims(dimens);
@@ -133,8 +138,8 @@ namespace Opm {
             }
         } else if (hasGRID) {
             // Look for SPECGRID instead of DIMENS.
-            if (deck->hasKeyword<ParserKeywords::SPECGRID>()) {
-                const auto& specgrid = deck->getKeyword<ParserKeywords::SPECGRID>();
+            if (deck.hasKeyword<ParserKeywords::SPECGRID>()) {
+                const auto& specgrid = deck.getKeyword<ParserKeywords::SPECGRID>();
                 std::vector<int> dims = getDims(specgrid);
                 initGrid(dims, deck);
             } else {
@@ -145,12 +150,12 @@ namespace Opm {
         } else {
             // The deck contains no relevant section, so it is probably a sectionless GRDECL file.
             // Either SPECGRID or DIMENS is OK.
-            if (deck->hasKeyword("SPECGRID")) {
-                const auto& specgrid = deck->getKeyword<ParserKeywords::SPECGRID>();
+            if (deck.hasKeyword("SPECGRID")) {
+                const auto& specgrid = deck.getKeyword<ParserKeywords::SPECGRID>();
                 std::vector<int> dims = getDims(specgrid);
                 initGrid(dims, deck);
-            } else if (deck->hasKeyword<ParserKeywords::DIMENS>()) {
-                const auto& dimens = deck->getKeyword<ParserKeywords::DIMENS>();
+            } else if (deck.hasKeyword<ParserKeywords::DIMENS>()) {
+                const auto& dimens = deck.getKeyword<ParserKeywords::DIMENS>();
                 std::vector<int> dims = getDims(dimens);
                 initGrid(dims, deck);
             } else {
@@ -164,7 +169,7 @@ namespace Opm {
     }
 
 
-    void EclipseGrid::initGrid( const std::vector<int>& dims, DeckConstPtr deck) {
+    void EclipseGrid::initGrid( const std::vector<int>& dims, const Deck& deck) {
         m_nx = static_cast<size_t>(dims[0]);
         m_ny = static_cast<size_t>(dims[1]);
         m_nz = static_cast<size_t>(dims[2]);
@@ -175,8 +180,8 @@ namespace Opm {
             initCartesianGrid(dims , deck);
         }
 
-        if (deck->hasKeyword<ParserKeywords::PINCH>()) {
-            const auto& record = deck->getKeyword<ParserKeywords::PINCH>( ).getRecord(0);
+        if (deck.hasKeyword<ParserKeywords::PINCH>()) {
+            const auto& record = deck.getKeyword<ParserKeywords::PINCH>( ).getRecord(0);
             const auto& item = record.getItem<ParserKeywords::PINCH::THRESHOLD_THICKNESS>( );
             m_pinch.setValue( item.getSIDouble(0) );
 
@@ -187,20 +192,20 @@ namespace Opm {
             m_multzMode = PinchMode::PinchModeFromString(multzString);
         }
 
-        if (deck->hasKeyword<ParserKeywords::MINPV>() && deck->hasKeyword<ParserKeywords::MINPVFIL>()) {
+        if (deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
             throw std::invalid_argument("Can not have both MINPV and MINPVFIL in deck.");
         }
 
-        if (deck->hasKeyword<ParserKeywords::MINPV>()) {
-            const auto& record = deck->getKeyword<ParserKeywords::MINPV>( ).getRecord(0);
+        if (deck.hasKeyword<ParserKeywords::MINPV>()) {
+            const auto& record = deck.getKeyword<ParserKeywords::MINPV>( ).getRecord(0);
             const auto& item = record.getItem<ParserKeywords::MINPV::VALUE>( );
             m_minpvValue = item.getSIDouble(0);
             m_minpvMode = MinpvMode::ModeEnum::EclSTD;
         }
 
 
-        if (deck->hasKeyword<ParserKeywords::MINPVFIL>()) {
-            const auto& record = deck->getKeyword<ParserKeywords::MINPVFIL>( ).getRecord(0);
+        if (deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
+            const auto& record = deck.getKeyword<ParserKeywords::MINPVFIL>( ).getRecord(0);
             const auto& item = record.getItem<ParserKeywords::MINPVFIL::VALUE>( );
             m_minpvValue = item.getSIDouble(0);
             m_minpvMode = MinpvMode::ModeEnum::OpmFIL;
@@ -277,7 +282,7 @@ namespace Opm {
 
 
 
-    void EclipseGrid::initCartesianGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+    void EclipseGrid::initCartesianGrid(const std::vector<int>& dims , const Deck& deck) {
         if (hasDVDEPTHZKeywords( deck ))
             initDVDEPTHZGrid( dims , deck );
         else if (hasDTOPSKeywords(deck))
@@ -287,11 +292,11 @@ namespace Opm {
     }
 
 
-    void EclipseGrid::initDVDEPTHZGrid(const std::vector<int>& dims , DeckConstPtr deck) {
-        const std::vector<double>& DXV = deck->getKeyword<ParserKeywords::DXV>().getSIDoubleData();
-        const std::vector<double>& DYV = deck->getKeyword<ParserKeywords::DYV>().getSIDoubleData();
-        const std::vector<double>& DZV = deck->getKeyword<ParserKeywords::DZV>().getSIDoubleData();
-        const std::vector<double>& DEPTHZ = deck->getKeyword<ParserKeywords::DEPTHZ>().getSIDoubleData();
+    void EclipseGrid::initDVDEPTHZGrid(const std::vector<int>& dims, const Deck& deck) {
+        const std::vector<double>& DXV = deck.getKeyword<ParserKeywords::DXV>().getSIDoubleData();
+        const std::vector<double>& DYV = deck.getKeyword<ParserKeywords::DYV>().getSIDoubleData();
+        const std::vector<double>& DZV = deck.getKeyword<ParserKeywords::DZV>().getSIDoubleData();
+        const std::vector<double>& DEPTHZ = deck.getKeyword<ParserKeywords::DEPTHZ>().getSIDoubleData();
 
         assertVectorSize( DEPTHZ , static_cast<size_t>( (dims[0] + 1)*(dims[1] +1 )) , "DEPTHZ");
         assertVectorSize( DXV    , static_cast<size_t>( dims[0] ) , "DXV");
@@ -302,7 +307,7 @@ namespace Opm {
     }
 
 
-    void EclipseGrid::initDTOPSGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+    void EclipseGrid::initDTOPSGrid(const std::vector<int>& dims , const Deck& deck) {
         std::vector<double> DX = createDVector( dims , 0 , "DX" , "DXV" , deck);
         std::vector<double> DY = createDVector( dims , 1 , "DY" , "DYV" , deck);
         std::vector<double> DZ = createDVector( dims , 2 , "DZ" , "DZV" , deck);
@@ -310,19 +315,17 @@ namespace Opm {
         m_grid.reset( ecl_grid_alloc_dx_dy_dz_tops( dims[0] , dims[1] , dims[2] , DX.data() , DY.data() , DZ.data() , TOPS.data() , nullptr ) );
     }
 
-
-
-    void EclipseGrid::initCornerPointGrid(const std::vector<int>& dims , DeckConstPtr deck) {
+    void EclipseGrid::initCornerPointGrid(const std::vector<int>& dims, const Deck& deck) {
         assertCornerPointKeywords( dims , deck);
         {
-            const auto& ZCORNKeyWord = deck->getKeyword<ParserKeywords::ZCORN>();
-            const auto& COORDKeyWord = deck->getKeyword<ParserKeywords::COORD>();
+            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>();
+            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>();
             const std::vector<double>& zcorn = ZCORNKeyWord.getSIDoubleData();
             const std::vector<double>& coord = COORDKeyWord.getSIDoubleData();
             double    * mapaxes = NULL;
 
-            if (deck->hasKeyword<ParserKeywords::MAPAXES>()) {
-                const auto& mapaxesKeyword = deck->getKeyword<ParserKeywords::MAPAXES>();
+            if (deck.hasKeyword<ParserKeywords::MAPAXES>()) {
+                const auto& mapaxesKeyword = deck.getKeyword<ParserKeywords::MAPAXES>();
                 const auto& record = mapaxesKeyword.getRecord(0);
                 mapaxes = new double[6];
                 for (size_t i = 0; i < 6; i++) {
@@ -352,21 +355,21 @@ namespace Opm {
 
 
 
-    bool EclipseGrid::hasCornerPointKeywords(DeckConstPtr deck) {
-        if (deck->hasKeyword<ParserKeywords::ZCORN>() && deck->hasKeyword<ParserKeywords::COORD>())
+    bool EclipseGrid::hasCornerPointKeywords(const Deck& deck) {
+        if (deck.hasKeyword<ParserKeywords::ZCORN>() && deck.hasKeyword<ParserKeywords::COORD>())
             return true;
         else
             return false;
     }
 
 
-    void EclipseGrid::assertCornerPointKeywords( const std::vector<int>& dims , DeckConstPtr deck)
+    void EclipseGrid::assertCornerPointKeywords( const std::vector<int>& dims , const Deck& deck)
     {
         const int nx = dims[0];
         const int ny = dims[1];
         const int nz = dims[2];
         {
-            const auto& ZCORNKeyWord = deck->getKeyword<ParserKeywords::ZCORN>();
+            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>();
 
             if (ZCORNKeyWord.getDataSize() != static_cast<size_t>(8*nx*ny*nz)) {
                 const std::string msg =
@@ -379,7 +382,7 @@ namespace Opm {
         }
 
         {
-            const auto& COORDKeyWord = deck->getKeyword<ParserKeywords::COORD>();
+            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>();
             if (COORDKeyWord.getDataSize() != static_cast<size_t>(6*(nx + 1)*(ny + 1))) {
                 const std::string msg =
                     "Wrong size of the COORD keyword: Expected 6*(nx + 1)*(ny + 1) = "
@@ -393,7 +396,7 @@ namespace Opm {
 
 
 
-    bool EclipseGrid::hasCartesianKeywords(DeckConstPtr deck) {
+    bool EclipseGrid::hasCartesianKeywords(const Deck& deck) {
         if (hasDVDEPTHZKeywords( deck ))
             return true;
         else
@@ -401,21 +404,21 @@ namespace Opm {
     }
 
 
-    bool EclipseGrid::hasDVDEPTHZKeywords(DeckConstPtr deck) {
-        if (deck->hasKeyword<ParserKeywords::DXV>() &&
-            deck->hasKeyword<ParserKeywords::DYV>() &&
-            deck->hasKeyword<ParserKeywords::DZV>() &&
-            deck->hasKeyword<ParserKeywords::DEPTHZ>())
+    bool EclipseGrid::hasDVDEPTHZKeywords(const Deck& deck) {
+        if (deck.hasKeyword<ParserKeywords::DXV>() &&
+            deck.hasKeyword<ParserKeywords::DYV>() &&
+            deck.hasKeyword<ParserKeywords::DZV>() &&
+            deck.hasKeyword<ParserKeywords::DEPTHZ>())
             return true;
         else
             return false;
     }
 
-    bool EclipseGrid::hasDTOPSKeywords(DeckConstPtr deck) {
-        if ((deck->hasKeyword<ParserKeywords::DX>() || deck->hasKeyword<ParserKeywords::DXV>()) &&
-            (deck->hasKeyword<ParserKeywords::DY>() || deck->hasKeyword<ParserKeywords::DYV>()) &&
-            (deck->hasKeyword<ParserKeywords::DZ>() || deck->hasKeyword<ParserKeywords::DZV>()) &&
-            deck->hasKeyword<ParserKeywords::TOPS>())
+    bool EclipseGrid::hasDTOPSKeywords(const Deck& deck) {
+        if ((deck.hasKeyword<ParserKeywords::DX>() || deck.hasKeyword<ParserKeywords::DXV>()) &&
+            (deck.hasKeyword<ParserKeywords::DY>() || deck.hasKeyword<ParserKeywords::DYV>()) &&
+            (deck.hasKeyword<ParserKeywords::DZ>() || deck.hasKeyword<ParserKeywords::DZV>()) &&
+            deck.hasKeyword<ParserKeywords::TOPS>())
             return true;
         else
             return false;
@@ -462,11 +465,13 @@ namespace Opm {
             retained.
     */
 
-    std::vector<double> EclipseGrid::createTOPSVector(const std::vector<int>& dims , const std::vector<double>& DZ , DeckConstPtr deck) {
+    std::vector<double> EclipseGrid::createTOPSVector(const std::vector<int>& dims,
+            const std::vector<double>& DZ, const Deck& deck)
+    {
         double z_tolerance = 1e-6;
         size_t volume = dims[0] * dims[1] * dims[2];
         size_t area = dims[0] * dims[1];
-        const auto& TOPSKeyWord = deck->getKeyword<ParserKeywords::TOPS>();
+        const auto& TOPSKeyWord = deck.getKeyword<ParserKeywords::TOPS>();
         std::vector<double> TOPS = TOPSKeyWord.getSIDoubleData();
 
         if (TOPS.size() >= area) {
@@ -493,14 +498,14 @@ namespace Opm {
         return TOPS;
     }
 
-
-
-    std::vector<double> EclipseGrid::createDVector(const std::vector<int>& dims , size_t dim , const std::string& DKey , const std::string& DVKey, DeckConstPtr deck) {
+    std::vector<double> EclipseGrid::createDVector(const std::vector<int>& dims, size_t dim, const std::string& DKey,
+            const std::string& DVKey, const Deck& deck)
+    {
         size_t volume = dims[0] * dims[1] * dims[2];
         size_t area = dims[0] * dims[1];
         std::vector<double> D;
-        if (deck->hasKeyword(DKey)) {
-            D = deck->getKeyword( DKey ).getSIDoubleData();
+        if (deck.hasKeyword(DKey)) {
+            D = deck.getKeyword( DKey ).getSIDoubleData();
 
 
             if (D.size() >= area && D.size() < volume) {
@@ -519,7 +524,7 @@ namespace Opm {
             if (D.size() != volume)
                 throw std::invalid_argument(DKey + " size mismatch");
         } else {
-            const auto& DVKeyWord = deck->getKeyword(DVKey);
+            const auto& DVKeyWord = deck.getKeyword(DVKey);
             const std::vector<double>& DV = DVKeyWord.getSIDoubleData();
             if (DV.size() != (size_t) dims[dim])
                 throw std::invalid_argument(DVKey + " size mismatch");

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -77,10 +77,12 @@ namespace Opm {
 
         /// EclipseGrid ignores ACTNUM in Deck, and therefore needs ACTNUM
         /// explicitly.  If a null pointer is passed, every cell is active.
+        explicit EclipseGrid(const Deck& deck, const int * actnum = nullptr);
+        /// [deprecated]
         explicit EclipseGrid(const std::shared_ptr<const Deck>& deck, const int * actnum = nullptr);
 
-        static bool hasCornerPointKeywords(std::shared_ptr<const Deck> deck);
-        static bool hasCartesianKeywords(std::shared_ptr<const Deck> deck);
+        static bool hasCornerPointKeywords(const Deck&);
+        static bool hasCartesianKeywords(const Deck&);
         size_t  getNumActive( ) const;
         size_t  getNX( ) const;
         size_t  getNY( ) const;
@@ -138,18 +140,20 @@ namespace Opm {
 
         void assertCellInfo() const;
 
-        void initCartesianGrid(const std::vector<int>& dims , std::shared_ptr< const Deck > deck);
-        void initCornerPointGrid(const std::vector<int>& dims , std::shared_ptr< const Deck > deck);
-        void initDTOPSGrid(const std::vector<int>& dims , std::shared_ptr< const Deck > deck);
-        void initDVDEPTHZGrid(const std::vector<int>& dims , std::shared_ptr< const Deck > deck);
-        void initGrid(const std::vector<int>& dims, std::shared_ptr< const Deck > deck);
+        void initCartesianGrid(const std::vector<int>& dims, const Deck&);
+        void initCornerPointGrid(const std::vector<int>& dims, const Deck&);
+        void initDTOPSGrid(const std::vector<int>& dims, const Deck&);
+        void initDVDEPTHZGrid(const std::vector<int>& dims, const Deck& deck);
+        void initGrid(const std::vector<int>& dims, const Deck&);
 
-        void assertCornerPointKeywords(const std::vector<int>& dims, std::shared_ptr< const Deck > deck);
-        static bool hasDVDEPTHZKeywords(std::shared_ptr< const Deck > deck);
-        static bool hasDTOPSKeywords(std::shared_ptr< const Deck > deck);
-        static void assertVectorSize(const std::vector<double>& vector , size_t expectedSize , const std::string& msg);
-        static std::vector<double> createTOPSVector(const std::vector<int>& dims , const std::vector<double>& DZ , std::shared_ptr< const Deck > deck);
-        static std::vector<double> createDVector(const std::vector<int>& dims , size_t dim , const std::string& DKey , const std::string& DVKey, std::shared_ptr< const Deck > deck);
+        void assertCornerPointKeywords(const std::vector<int>& dims, const Deck&);
+        static bool hasDVDEPTHZKeywords(const Deck&);
+        static bool hasDTOPSKeywords(const Deck&);
+        static void assertVectorSize(const std::vector<double>& vector, size_t expectedSize, const std::string& msg);
+        static std::vector<double> createTOPSVector(const std::vector<int>& dims, const std::vector<double>& DZ,
+                const Deck&);
+        static std::vector<double> createDVector(const std::vector<int>& dims, size_t dim, const std::string& DKey,
+                const std::string& DVKey, const Deck&);
         static void scatterDim(const std::vector<int>& dims , size_t dim , const std::vector<double>& DV , std::vector<double>& D);
    };
 

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -34,9 +34,7 @@
 namespace Opm {
 
     FaultCollection::FaultCollection()
-    {
-
-    }
+    {}
 
 
     FaultCollection::FaultCollection( std::shared_ptr<const GRIDSection> deck, std::shared_ptr<const EclipseGrid> grid) {
@@ -60,58 +58,48 @@ namespace Opm {
                                                                                           static_cast<size_t>(K1) , static_cast<size_t>(K2) ,
                                                                                           faceDir);
                 if (!hasFault(faultName)) {
-                    std::shared_ptr<Fault> fault = std::make_shared<Fault>( faultName );
-                    addFault( fault );
+                    addFault( faultName );
                 }
 
                 {
-                    std::shared_ptr<Fault> fault = getFault( faultName );
-                    fault->addFace( face );
+                    Fault& fault = getFault( faultName );
+                    fault.addFace( face );
                 }
             }
         }
     }
 
-
     size_t FaultCollection::size() const {
         return m_faults.size();
     }
-
 
     bool FaultCollection::hasFault(const std::string& faultName) const {
         return m_faults.hasKey( faultName );
     }
 
-
-    std::shared_ptr<const Fault> FaultCollection::getFault(const std::string& faultName) const {
+    const Fault& FaultCollection::getFault(const std::string& faultName) const {
         return m_faults.get( faultName );
     }
 
-    std::shared_ptr<Fault> FaultCollection::getFault(const std::string& faultName) {
+    Fault& FaultCollection::getFault(const std::string& faultName) {
         return m_faults.get( faultName );
     }
 
-
-    std::shared_ptr<Fault> FaultCollection::getFault(size_t faultIndex) {
+    Fault& FaultCollection::getFault(size_t faultIndex) {
         return m_faults.get( faultIndex );
     }
 
-    std::shared_ptr<const Fault> FaultCollection::getFault(size_t faultIndex) const {
+    const Fault& FaultCollection::getFault(size_t faultIndex) const {
         return m_faults.get( faultIndex );
     }
 
-
-    void FaultCollection::addFault(std::shared_ptr<Fault> fault) {
-        m_faults.insert(fault->getName() , fault);
+    void FaultCollection::addFault(const std::string& faultName) {
+        Fault fault(faultName);
+        m_faults.insert(fault.getName() , fault);
     }
-
-
 
     void FaultCollection::setTransMult(const std::string& faultName , double transMult) {
-        std::shared_ptr<Fault> fault = getFault( faultName );
-        fault->setTransMult( transMult );
+        Fault& fault = getFault( faultName );
+        fault.setTransMult( transMult );
     }
-
-
-
 }

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -24,13 +24,14 @@
 #include <memory>
 
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
+
 
 namespace Opm {
 
     class Deck;
     class GRIDSection;
     class EclipseGrid;
-    class Fault;
     class GRIDSection;
 
 
@@ -41,15 +42,17 @@ public:
 
     size_t size() const;
     bool hasFault(const std::string& faultName) const;
-    std::shared_ptr<Fault>  getFault(const std::string& faultName);
-    std::shared_ptr<const Fault>  getFault(const std::string& faultName) const;
-    std::shared_ptr<Fault>  getFault(size_t faultIndex);
-    std::shared_ptr<const Fault>  getFault(size_t faultIndex) const;
-    void addFault(std::shared_ptr<Fault> fault);
+    Fault& getFault(const std::string& faultName);
+    const Fault& getFault(const std::string& faultName) const;
+    Fault& getFault(size_t faultIndex);
+    const Fault& getFault(size_t faultIndex) const;
+
+    /// we construct the fault based on faultName.  To get the fault: getFault
+    void addFault(const std::string& faultName);
     void setTransMult(const std::string& faultName , double transMult);
 
 private:
-    OrderedMap<std::shared_ptr<Fault > > m_faults;
+    OrderedMap<Fault> m_faults;
 };
 }
 

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
@@ -29,9 +29,12 @@
 
 namespace Opm
 {
-    NNC::NNC(Opm::DeckConstPtr deck, EclipseGridConstPtr eclipseGrid)
-    {
-        const auto& nncs = deck->getKeywordList<ParserKeywords::NNC>();
+    NNC::NNC(std::shared_ptr<const Deck> deck, EclipseGridConstPtr eclipseGrid) :
+            NNC(*deck, eclipseGrid)
+    {}
+
+    NNC::NNC(const Deck& deck, EclipseGridConstPtr eclipseGrid) {
+        const auto& nncs = deck.getKeywordList<ParserKeywords::NNC>();
         for (size_t idx_nnc = 0; idx_nnc<nncs.size(); ++idx_nnc) {
             const auto& nnc = *nncs[idx_nnc];
             size_t numNNC = nnc.size();

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
@@ -40,7 +40,8 @@ class NNC
 public:
     /// Construct from input deck.
     NNC();
-    NNC(std::shared_ptr< const Deck > deck, std::shared_ptr< const EclipseGrid > eclipseGrid);
+    NNC(std::shared_ptr<const Deck> deck_ptr, std::shared_ptr< const EclipseGrid > eclipseGrid);
+    NNC(const Deck& deck, std::shared_ptr< const EclipseGrid > eclipseGrid);
     void addNNC(const size_t cell1, const size_t cell2, const double trans);
     const std::vector<NNCdata>& nncdata() const { return m_nnc; }
     size_t numNNC() const;

--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -109,10 +109,10 @@ namespace Opm {
     }
 
 
-    void TransMult::applyMULTFLT( std::shared_ptr<const Fault> fault) {
-        double transMult = fault->getTransMult();
+    void TransMult::applyMULTFLT(const Fault& fault) {
+        double transMult = fault.getTransMult();
 
-        for (auto face_iter = fault->begin(); face_iter != fault->end(); ++face_iter) {
+        for (auto face_iter = fault.begin(); face_iter != fault.end(); ++face_iter) {
             std::shared_ptr<const FaultFace> face = *face_iter;
             FaceDir::DirEnum faceDir = face->getDir();
             auto& multProperty = getDirectionProperty(faceDir);
@@ -125,10 +125,10 @@ namespace Opm {
     }
 
 
-    void TransMult::applyMULTFLT( std::shared_ptr<const FaultCollection> faults) {
-        for (size_t faultIndex = 0; faultIndex < faults->size(); faultIndex++) {
-            std::shared_ptr<const Fault> fault = faults->getFault( faultIndex );
-            applyMULTFLT( fault );
+    void TransMult::applyMULTFLT(const FaultCollection& faults) {
+        for (size_t faultIndex = 0; faultIndex < faults.size(); faultIndex++) {
+            auto& fault = faults.getFault(faultIndex);
+            applyMULTFLT(fault);
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
@@ -51,8 +51,8 @@ namespace Opm {
         double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;
         double getRegionMultiplier( size_t globalCellIndex1, size_t globalCellIndex2, FaceDir::DirEnum faceDir) const;
         void applyMULT(const GridProperty<double>& srcMultProp, FaceDir::DirEnum faceDir);
-        void applyMULTFLT( std::shared_ptr<const FaultCollection> faults);
-        void applyMULTFLT( std::shared_ptr<const Fault> fault);
+        void applyMULTFLT(const FaultCollection& faults);
+        void applyMULTFLT(const Fault& fault);
         void setMultregtScanner(std::shared_ptr<const MULTREGTScanner> multregtScanner);
 
     private:

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -87,8 +87,8 @@ BOOST_AUTO_TEST_CASE(MissingDimsThrows) {
 
 BOOST_AUTO_TEST_CASE(HasGridKeywords) {
     Opm::DeckPtr deck = createDeckHeaders();
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
-    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( *deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( *deck ));
 }
 
 
@@ -369,29 +369,29 @@ BOOST_AUTO_TEST_CASE(DEPTHZ_EQUAL_TOPS) {
 
 BOOST_AUTO_TEST_CASE(HasCPKeywords) {
     Opm::DeckPtr deck = createCPDeck();
-    BOOST_CHECK(  Opm::EclipseGrid::hasCornerPointKeywords( deck ));
-    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( deck ));
+    BOOST_CHECK(  Opm::EclipseGrid::hasCornerPointKeywords( *deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( *deck ));
 }
 
 
 BOOST_AUTO_TEST_CASE(HasCartKeywords) {
     Opm::DeckPtr deck = createCARTDeck();
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
-    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( *deck ));
+    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( *deck ));
 }
 
 
 BOOST_AUTO_TEST_CASE(HasCartKeywordsDEPTHZ) {
     Opm::DeckPtr deck = createCARTDeckDEPTHZ();
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
-    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( *deck ));
+    BOOST_CHECK(  Opm::EclipseGrid::hasCartesianKeywords( *deck ));
 }
 
 
 BOOST_AUTO_TEST_CASE(HasINVALIDCartKeywords) {
     Opm::DeckPtr deck = createCARTInvalidDeck();
-    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( deck ));
-    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCornerPointKeywords( *deck ));
+    BOOST_CHECK( !Opm::EclipseGrid::hasCartesianKeywords( *deck ));
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
@@ -117,20 +117,18 @@ BOOST_AUTO_TEST_CASE(CreateFaultCollection) {
 
 BOOST_AUTO_TEST_CASE(AddFaultsToCollection) {
     Opm::FaultCollection faults;
-    std::shared_ptr<Opm::Fault> fault = std::make_shared<Opm::Fault>("FAULT");
 
-    faults.addFault(fault);
+    faults.addFault("FAULT");
     BOOST_CHECK_EQUAL( faults.size() , 1 );
     BOOST_CHECK(faults.hasFault("FAULT"));
 
-    std::shared_ptr<Opm::Fault> fault2 = faults.getFault("FAULT");
-    std::shared_ptr<Opm::Fault> fault0 = faults.getFault(0);
-    BOOST_CHECK_EQUAL( fault , fault2 );
-    BOOST_CHECK_EQUAL( fault , fault0 );
+    const auto& fault1 = faults.getFault("FAULT");
+    const auto& fault2 = faults.getFault(0);
+    BOOST_CHECK_EQUAL(fault1.getName(), fault2.getName());
 
-    std::shared_ptr<Opm::Fault> faultx = std::make_shared<Opm::Fault>("FAULTX");
-    faults.addFault(faultx);
+    faults.addFault("FAULTX");
+    const auto& faultx = faults.getFault("FAULTX");
     BOOST_CHECK_EQUAL( faults.size() , 2 );
     BOOST_CHECK(faults.hasFault("FAULTX"));
-    BOOST_CHECK_EQUAL( faultx , faults.getFault(1));
+    BOOST_CHECK_EQUAL( faultx.getName() , faults.getFault(1).getName());
 }

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -57,6 +57,8 @@ namespace Opm {
             boost::filesystem::path path( input_path );
             m_base_name = path.stem().string();
             m_output_dir = path.parent_path().string();
+            if (m_output_dir == "")
+                m_output_dir = ".";
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -35,19 +35,11 @@ namespace Opm {
         return Equil( deck.getKeyword<ParserKeywords::EQUIL>(  ) );
     }
 
+    InitConfig::InitConfig(DeckConstPtr deck) : InitConfig(*deck) {}
 
-  InitConfig::InitConfig(DeckConstPtr deck) :
-            InitConfig(*deck)
-    {}
-
-  InitConfig::InitConfig(const Deck& deck) : equil( equils( deck ) ) {
-        m_restartRequested = false;
-        m_restartStep = 0;
-        m_restartRootName = "";
-
+    InitConfig::InitConfig(const Deck& deck) : equil(equils(deck)) {
         initRestartKW(deck);
     }
-
 
     void InitConfig::setRestart( const std::string& root, int step) {
         m_restartRequested = true;
@@ -73,7 +65,7 @@ namespace Opm {
 
                 setRestart( root , step );
             }
-        } else if (deck->hasKeyword<ParserKeywords::SKIPREST>())
+        } else if (deck.hasKeyword<ParserKeywords::SKIPREST>())
             throw std::runtime_error("Error in deck: Can not supply SKIPREST keyword without a preceeding RESTART.");
     }
 

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -35,7 +35,12 @@ namespace Opm {
         return Equil( deck.getKeyword<ParserKeywords::EQUIL>(  ) );
     }
 
-    InitConfig::InitConfig(DeckConstPtr deck) : equil( equils( *deck ) ) {
+
+  InitConfig::InitConfig(DeckConstPtr deck) :
+            InitConfig(*deck)
+    {}
+
+  InitConfig::InitConfig(const Deck& deck) : equil( equils( deck ) ) {
         m_restartRequested = false;
         m_restartStep = 0;
         m_restartRootName = "";
@@ -51,9 +56,9 @@ namespace Opm {
     }
 
 
-    void InitConfig::initRestartKW(DeckConstPtr deck) {
-        if (deck->hasKeyword<ParserKeywords::RESTART>( )) {
-            const auto& keyword = deck->getKeyword<ParserKeywords::RESTART>( );
+    void InitConfig::initRestartKW(const Deck& deck) {
+        if (deck.hasKeyword<ParserKeywords::RESTART>( )) {
+            const auto& keyword = deck.getKeyword<ParserKeywords::RESTART>( );
             const auto& record = keyword.getRecord(0);
             const auto& save_item = record.getItem(2);
             if (save_item.hasValue(0))

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -30,6 +30,7 @@ namespace Opm {
 
     public:
         InitConfig(std::shared_ptr< const Deck > deck);
+        InitConfig(const Deck& deck);
 
         void setRestart( const std::string& root, int step);
         bool restartRequested() const;
@@ -40,7 +41,7 @@ namespace Opm {
         const Equil& getEquil() const;
 
     private:
-        void initRestartKW(std::shared_ptr< const Deck > deck);
+        void initRestartKW(const Deck& deck);
 
         bool m_restartRequested;
         int m_restartStep;

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -43,8 +43,8 @@ namespace Opm {
     private:
         void initRestartKW(const Deck& deck);
 
-        bool m_restartRequested;
-        int m_restartStep;
+        bool m_restartRequested = false;
+        int m_restartStep = 0;
         std::string m_restartRootName;
 
         Equil equil;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -54,7 +54,12 @@ namespace Opm
 
     class Schedule {
     public:
-        Schedule(const ParseContext& parseContext , std::shared_ptr<const EclipseGrid> grid , std::shared_ptr< const Deck > deck, std::shared_ptr< IOConfig > ioConfig);
+        Schedule(const ParseContext& parseContext, std::shared_ptr<const EclipseGrid> grid,
+                 const Deck& deck,                 std::shared_ptr<IOConfig> ioConfig);
+        /// [deprecated]
+        Schedule(const ParseContext& parseContext, std::shared_ptr<const EclipseGrid> grid,
+                 std::shared_ptr<const Deck> deck, std::shared_ptr<IOConfig> ioConfig);
+
         boost::posix_time::ptime getStartTime() const;
         std::shared_ptr< const TimeMap > getTimeMap() const;
 
@@ -101,9 +106,9 @@ namespace Opm
 
         void updateWellStatus(std::shared_ptr<Well> well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( std::shared_ptr< Group > newGroup , std::shared_ptr< Well > well , size_t timeStep);
-        void initFromDeck(const ParseContext& parseContext , std::shared_ptr< const Deck > deck, std::shared_ptr< IOConfig > ioConfig);
-        void initializeNOSIM(std::shared_ptr< const Deck > deck);
-        void createTimeMap(std::shared_ptr< const Deck > deck);
+        void initFromDeck(const ParseContext& parseContext, const Deck& deck, std::shared_ptr<IOConfig> ioConfig);
+        void initializeNOSIM(const Deck& deck);
+        void createTimeMap(const Deck& deck);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
         void initOilVaporization(std::shared_ptr< const TimeMap > timeMap);
         void iterateScheduleSection(const ParseContext& parseContext ,  const SCHEDULESection&  section, std::shared_ptr< IOConfig > ioConfig);

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -414,6 +414,13 @@ BOOST_AUTO_TEST_CASE(TestIOConfigBaseName) {
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseContext);
     EclipseState state(*deck, parseContext);
     BOOST_CHECK_EQUAL(state.getIOConfig()->getBaseName(), "SPE1CASE2");
+    BOOST_CHECK_EQUAL(state.getIOConfig()->getOutputDir(), "testdata/integration_tests/IOConfig");
+
+    ParserPtr parser2(new Parser());
+    DeckConstPtr deck2 = createDeckWithGridOpts();
+    EclipseState state2(*deck2, parseContext);
+    BOOST_CHECK_EQUAL(state2.getIOConfig()->getBaseName(), "");
+    BOOST_CHECK_EQUAL(state2.getIOConfig()->getOutputDir(), ".");
 }
 
 BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -408,6 +408,13 @@ BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     BOOST_CHECK_NE( &fluxnum  , &multnum );
 }
 
+BOOST_AUTO_TEST_CASE(TestIOConfigBaseName) {
+    ParseContext parseContext;
+    ParserPtr parser(new Parser());
+    DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseContext);
+    EclipseState state(*deck, parseContext);
+    BOOST_CHECK_EQUAL(state.getIOConfig()->getBaseName(), "SPE1CASE2");
+}
 
 BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
     const char * deckData  =

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -284,16 +284,16 @@ BOOST_AUTO_TEST_CASE(GetTransMult) {
 BOOST_AUTO_TEST_CASE(GetFaults) {
     DeckPtr deck = createDeck();
     EclipseState state( deck, ParseContext() );
-    std::shared_ptr<const FaultCollection> faults = state.getFaults();
+    const auto& faults = state.getFaults();
 
-    BOOST_CHECK( faults->hasFault( "F1" ) );
-    BOOST_CHECK( faults->hasFault( "F2" ) );
+    BOOST_CHECK( faults.hasFault( "F1" ) );
+    BOOST_CHECK( faults.hasFault( "F2" ) );
 
-    std::shared_ptr<const Fault> F1 = faults->getFault( "F1" );
-    std::shared_ptr<const Fault> F2 = faults->getFault( "F2" );
+    const auto& F1 = faults.getFault( "F1" );
+    const auto& F2 = faults.getFault( "F2" );
 
-    BOOST_CHECK_EQUAL( 0.50, F1->getTransMult() );
-    BOOST_CHECK_EQUAL( 0.25, F2->getTransMult() );
+    BOOST_CHECK_EQUAL( 0.50, F1.getTransMult() );
+    BOOST_CHECK_EQUAL( 0.25, F2.getTransMult() );
 
     std::shared_ptr<const TransMult> transMult = state.getTransMult();
     BOOST_CHECK_EQUAL( transMult->getMultiplier( 0, 0, 0, FaceDir::XPlus ), 0.50 );

--- a/opm/parser/eclipse/IntegrationTests/TransMultIntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/TransMultIntegrationTests.cpp
@@ -53,7 +53,7 @@ BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {
     BOOST_CHECK( events.hasEvent( ScheduleEvents::GEO_MODIFIER , 3 ) );
     {
         std::shared_ptr<const Deck> mini_deck = schedule->getModifierDeck(3);
-        eclState->applyModifierDeck( mini_deck );
+        eclState->applyModifierDeck( *mini_deck );
     }
     BOOST_CHECK_EQUAL( 2.00 , trans->getMultiplier( 2,2,0,FaceDir::XPlus ));
     BOOST_CHECK_EQUAL( 0.10 , trans->getMultiplier( 3,2,0,FaceDir::XPlus ));

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -271,7 +271,7 @@ ParserState::ParserState( const ParseContext& context,
     deck( new Deck() ),
     parseContext( context )
 {
-    loadFile( p );
+    openRootFile( p );
 }
 
 void ParserState::loadString(const std::string& input) {


### PR DESCRIPTION
Four commits.  Work on EclipseState and EclipseGrid
* Removed all dependency on `shared_ptr<Deck>` for EclipseState and EclipseGrid.
* Kept constructors for now, but mark them as deprecated.
* Made NNC a member instead of a shared_ptr.
* Made FaultCollection a raw member of EclipseState, with all Faults being kept in FaultCollection
* Replaced method `addFault(fault)` with `addFault(faultName)` (a string)
* Minor maintenance of InitConfig: moved initialization of primary types to header file.

Needs to be applied as well: OPM/opm-simulators#676