### PR TITLE
log messages before handleError.

### DIFF
--- a/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckRecordTests.cpp
@@ -102,10 +102,11 @@ BOOST_AUTO_TEST_CASE(StringsWithSpaceOK) {
     ParserRecordPtr record1(new ParserRecord());
     RawRecord rawRecord( " ' VALUE ' " );
     ParseContext parseContext;
+    MessageContainer msgContainer;
     record1->addItem( itemString );
 
 
-    const auto deckRecord = record1->parse( parseContext , rawRecord );
+    const auto deckRecord = record1->parse( parseContext , msgContainer, rawRecord );
     BOOST_CHECK_EQUAL(" VALUE " , deckRecord.getItem(0).get< std::string >(0));
 }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -72,7 +72,7 @@ namespace Opm {
         }
 
         m_initConfig = std::make_shared<const InitConfig>(deck);
-        m_simulationConfig = std::make_shared<const SimulationConfig>(m_parseContext, *deck,
+        m_simulationConfig = std::make_shared<const SimulationConfig>(*deck,
                                                                       m_eclipseProperties);
 
         initTransMult();

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -256,6 +256,7 @@ namespace Opm {
 
                 } else {
                     std::string msg = "OPM does not support grid property modifier " + keyword.name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
+                    m_messages.error(msg);
                     parseContext.handleError( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , msg );
                 }
             }
@@ -317,6 +318,7 @@ namespace Opm {
             const auto& methodItem = record.getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
             if ((methodItem.get< std::string >(0) != "TRACK")  && (methodItem.get< std::string >(0) != "INPUT")) {
                 std::string msg = "The COMPORD keyword only handles 'TRACK' or 'INPUT' order.";
+                m_messages.error(msg);
                 parseContext.handleError( ParseContext::UNSUPPORTED_COMPORD_TYPE , msg );
             }
         }

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -256,8 +256,7 @@ namespace Opm {
 
                 } else {
                     std::string msg = "OPM does not support grid property modifier " + keyword.name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
-                    m_messages.error(msg);
-                    parseContext.handleError( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , msg );
+                    parseContext.handleError( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , m_messages, msg );
                 }
             }
         }
@@ -319,7 +318,7 @@ namespace Opm {
             if ((methodItem.get< std::string >(0) != "TRACK")  && (methodItem.get< std::string >(0) != "INPUT")) {
                 std::string msg = "The COMPORD keyword only handles 'TRACK' or 'INPUT' order.";
                 m_messages.error(msg);
-                parseContext.handleError( ParseContext::UNSUPPORTED_COMPORD_TYPE , msg );
+                parseContext.handleError( ParseContext::UNSUPPORTED_COMPORD_TYPE , m_messages, msg );
             }
         }
     }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -46,8 +46,7 @@
 
 namespace Opm {
 
-    SimulationConfig::SimulationConfig(const ParseContext& parseContext,
-                                       const Deck& deck,
+    SimulationConfig::SimulationConfig(const Deck& deck,
                                        const Eclipse3DProperties& eclipseProperties) :
         m_useCPR(false),
         m_DISGAS(false),
@@ -70,14 +69,13 @@ namespace Opm {
             }
         }
 
-        initThresholdPressure(parseContext , deck, eclipseProperties);
+        initThresholdPressure(deck, eclipseProperties);
     }
 
 
-    void SimulationConfig::initThresholdPressure(const ParseContext& parseContext,
-                                                 const Deck& deck,
+    void SimulationConfig::initThresholdPressure(const Deck& deck,
                                                  const Eclipse3DProperties& eclipseProperties) {
-        m_ThresholdPressure = std::make_shared<const ThresholdPressure>(parseContext , deck, eclipseProperties);
+        m_ThresholdPressure = std::make_shared<const ThresholdPressure>(deck, eclipseProperties);
     }
 
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp
@@ -26,14 +26,12 @@
 namespace Opm {
 
     class ThresholdPressure;
-    class ParseContext;
 
     class SimulationConfig {
 
     public:
 
-        SimulationConfig(const ParseContext& parseContext,
-                         const Deck& deck,
+        SimulationConfig(const Deck& deck,
                          const Eclipse3DProperties& gridProperties);
 
         std::shared_ptr<const ThresholdPressure> getThresholdPressure() const;
@@ -44,8 +42,7 @@ namespace Opm {
 
     private:
 
-        void initThresholdPressure(const ParseContext& parseContext,
-                                   const Deck& deck,
+        void initThresholdPressure(const Deck& deck,
                                    const Eclipse3DProperties& gridProperties);
 
         std::shared_ptr< const ThresholdPressure > m_ThresholdPressure;

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -21,7 +21,6 @@
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
@@ -29,16 +28,14 @@
 
 namespace Opm {
 
-    ThresholdPressure::ThresholdPressure(const ParseContext& parseContext,
-                                         const Deck& deck,
-                                         const Eclipse3DProperties& eclipseProperties) :
-                                         m_parseContext( parseContext )
+    ThresholdPressure::ThresholdPressure(const Deck& deck,
+                                         const Eclipse3DProperties& eclipseProperties)
     {
 
         if (Section::hasRUNSPEC( deck ) && Section::hasSOLUTION( deck )) {
             std::shared_ptr<const RUNSPECSection> runspecSection = std::make_shared<const RUNSPECSection>( deck );
             std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>( deck );
-            initThresholdPressure( parseContext, runspecSection, solutionSection, eclipseProperties );
+            initThresholdPressure( runspecSection, solutionSection, eclipseProperties );
         }
     }
 
@@ -66,8 +63,7 @@ namespace Opm {
     }
 
 
-    void ThresholdPressure::initThresholdPressure(const ParseContext& /* parseContext */,
-                                                  std::shared_ptr<const RUNSPECSection> runspecSection,
+    void ThresholdPressure::initThresholdPressure(std::shared_ptr<const RUNSPECSection> runspecSection,
                                                   std::shared_ptr<const SOLUTIONSection> solutionSection,
                                                   const Eclipse3DProperties& eclipseProperties) {
 
@@ -164,7 +160,7 @@ namespace Opm {
                 return value;
             else {
                 std::string msg = "The THPRES value for regions " + std::to_string(r1) + " and " + std::to_string(r2) + " has not been initialized. Using 0.0";
-                m_parseContext.handleError(ParseContext::INTERNAL_ERROR_UNINITIALIZED_THPRES, msg);
+                throw std::invalid_argument(msg);
                 return 0;
             }
         }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp
@@ -29,7 +29,6 @@ namespace Opm {
 
 
     class Deck;
-    class ParseContext;
     class RUNSPECSection;
     class SOLUTIONSection;
 
@@ -37,8 +36,7 @@ namespace Opm {
 
     public:
 
-        ThresholdPressure(const ParseContext& parseContext,
-                          const Deck& deck,
+        ThresholdPressure(const Deck& deck,
                           const Eclipse3DProperties& eclipseProperties);
 
 
@@ -69,8 +67,7 @@ namespace Opm {
         double getThresholdPressure(int r1 , int r2) const;
         size_t size() const;
     private:
-        void initThresholdPressure(const ParseContext& parseContext,
-                                   std::shared_ptr<const RUNSPECSection> runspecSection,
+        void initThresholdPressure(std::shared_ptr<const RUNSPECSection> runspecSection,
                                    std::shared_ptr<const SOLUTIONSection> solutionSection,
                                    const Eclipse3DProperties& eclipseProperties);
 
@@ -81,7 +78,6 @@ namespace Opm {
 
         std::vector<std::pair<bool,double>> m_thresholdPressureTable;
         std::map<std::pair<int,int> , std::pair<bool , double> > m_pressureTable;
-        const ParseContext& m_parseContext;
     };
 
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -119,7 +119,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigGetThresholdPressureTableTest) {
     Eclipse3DProperties ep(*deck, tm, eg);
     SimulationConfigConstPtr simulationConfigPtr;
     BOOST_CHECK_NO_THROW(simulationConfigPtr = std::make_shared
-            <const SimulationConfig>(parseContext , *deck, ep));
+            <const SimulationConfig>(*deck, ep));
 }
 
 
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigNOTHPRES) {
     TableManager tm(*deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(*deck, tm, eg);
-    SimulationConfig simulationConfig(parseContext , *deck, ep);
+    SimulationConfig simulationConfig(*deck, ep);
     BOOST_CHECK( !simulationConfig.hasThresholdPressure() );
 }
 
@@ -139,18 +139,18 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRNotUsed) {
     TableManager tm(*deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(*deck, tm, eg);
-    SimulationConfig simulationConfig(parseContext , *deck, ep);
+    SimulationConfig simulationConfig(*deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
 }
 
 BOOST_AUTO_TEST_CASE(SimulationConfigCPRUsed) {
-    ParseContext     parseContext;
+    ParseContext parseContext;
     DeckPtr deck = createDeck(parseContext, inputStr_cpr);
     TableManager tm(*deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(*deck, tm, eg);
     SUMMARYSection summary(*deck);
-    SimulationConfig simulationConfig(parseContext , *deck, ep);
+    SimulationConfig simulationConfig(*deck, ep);
     BOOST_CHECK(     simulationConfig.useCPR() );
     BOOST_CHECK(  !  summary.hasKeyword("CPR") );
 }
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRInSUMMARYSection) {
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(*deck, tm, eg);
     SUMMARYSection summary(*deck);
-    SimulationConfig simulationConfig(parseContext , *deck, ep);
+    SimulationConfig simulationConfig(*deck, ep);
     BOOST_CHECK( ! simulationConfig.useCPR());
     BOOST_CHECK(   summary.hasKeyword("CPR"));
 }
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(*deck, tm, eg);
     SUMMARYSection summary(*deck);
-    SimulationConfig simulationConfig(parseContext , *deck, ep);
+    SimulationConfig simulationConfig(*deck, ep);
     BOOST_CHECK(  simulationConfig.useCPR());
     BOOST_CHECK(  summary.hasKeyword("CPR"));
 
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     TableManager tm(*deck);
     EclipseGrid eg(10, 3, 4);
     Eclipse3DProperties ep(*deck, tm, eg);
-    SimulationConfig simulationConfig(parseContext , *deck, ep);
+    SimulationConfig simulationConfig(*deck, ep);
     BOOST_CHECK_EQUAL( false , simulationConfig.hasDISGAS());
     BOOST_CHECK_EQUAL( false , simulationConfig.hasVAPOIL());
 
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE(SimulationConfig_VAPOIL_DISGAS) {
     TableManager tm_vd(*deck_vd);
     EclipseGrid eg_vd(10, 3, 4);
     Eclipse3DProperties ep_vd(*deck_vd, tm, eg);
-    SimulationConfig simulationConfig_vd(parseContext , *deck_vd, ep_vd);
+    SimulationConfig simulationConfig_vd(*deck_vd, ep_vd);
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasDISGAS());
     BOOST_CHECK_EQUAL( true , simulationConfig_vd.hasVAPOIL());
 }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -194,7 +194,7 @@ struct Setup
             tablemanager(*deck),
             grid(10, 3, 4),
             props(*deck, tablemanager, grid),
-            threshPres(parseContext, *deck, props)
+            threshPres(*deck, props)
     {
     }
     explicit Setup(const std::string& input, ParseContext& parseContextArg) :
@@ -203,7 +203,7 @@ struct Setup
             tablemanager(*deck),
             grid(10, 3, 4),
             props(*deck, tablemanager, grid),
-            threshPres(parseContextArg, *deck, props)
+            threshPres(*deck, props)
     {
     }
 

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -259,9 +259,6 @@ BOOST_AUTO_TEST_CASE(ThresholdPressureThrowTest) {
 
     pc.update(ParseContext::INTERNAL_ERROR_UNINITIALIZED_THPRES, InputError::THROW_EXCEPTION);
     BOOST_CHECK_THROW(s.threshPres.getThresholdPressure(2, 3), std::invalid_argument);
-
-    pc.update(ParseContext::INTERNAL_ERROR_UNINITIALIZED_THPRES, InputError::IGNORE);
-    BOOST_CHECK_EQUAL(0.0, s.threshPres.getThresholdPressure(2, 3));
 }
 
 BOOST_AUTO_TEST_CASE(HasPair) {

--- a/opm/parser/eclipse/Parser/ParseContext.cpp
+++ b/opm/parser/eclipse/Parser/ParseContext.cpp
@@ -77,15 +77,20 @@ namespace Opm {
 
     Message::type ParseContext::handleError(
             const std::string& errorKey,
+            MessageContainer& msgContainer,
             const std::string& msg ) const {
 
         InputError::Action action = get( errorKey );
 
-        if (action == InputError::WARN)
+        if (action == InputError::WARN) {
+            msgContainer.warning(msg);
             return Message::Warning;
+        }
 
-        else if (action == InputError::THROW_EXCEPTION)
+        else if (action == InputError::THROW_EXCEPTION) {
+            msgContainer.error(msg);
             throw std::invalid_argument(errorKey + ": " + msg);
+        }
 
         return Message::Debug;
 

--- a/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -80,7 +80,7 @@ namespace Opm {
     public:
         ParseContext();
         ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
-        Message::type handleError( const std::string& errorKey, const std::string& msg ) const;
+        Message::type handleError( const std::string& errorKey, MessageContainer& msgContainer, const std::string& msg ) const;
         bool hasKey(const std::string& key) const;
         void updateKey(const std::string& key , InputError::Action action);
         void update(InputError::Action action);

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -343,7 +343,7 @@ void ParserState::handleRandomText(const string_view& keywordString ) const {
             << this->current_path()
             << ":" << this->line();
     }
-
+    deck->getMessageContainer().warning(msg.str());
     parseContext.handleError( errorKey , msg.str() );
 }
 
@@ -386,6 +386,7 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
     if( !parser.isRecognizedKeyword( keywordString ) ) {
         if( ParserKeyword::validDeckName( keywordString ) ) {
             std::string msg = "Keyword " + keywordString + " not recognized.";
+            parserState.deck->getMessageContainer().error(msg);
             parserState.parseContext.handleError( ParseContext::PARSE_UNKNOWN_KEYWORD, msg );
             return {};
         }
@@ -432,7 +433,7 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
 
     std::string msg = "Expected the kewyord: " + sizeKeyword.first
                     + " to infer the number of records in: " + keywordString;
-
+    parserState.deck->getMessageContainer().error(msg);
     parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msg );
 
     const auto* keyword = parser.getKeyword( sizeKeyword.first );

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -343,8 +343,7 @@ void ParserState::handleRandomText(const string_view& keywordString ) const {
             << this->current_path()
             << ":" << this->line();
     }
-    deck->getMessageContainer().warning(msg.str());
-    parseContext.handleError( errorKey , msg.str() );
+    parseContext.handleError( errorKey , deck->getMessageContainer() , msg.str() );
 }
 
 void ParserState::openRootFile( const boost::filesystem::path& inputFile) {
@@ -386,8 +385,8 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
     if( !parser.isRecognizedKeyword( keywordString ) ) {
         if( ParserKeyword::validDeckName( keywordString ) ) {
             std::string msg = "Keyword " + keywordString + " not recognized.";
-            parserState.deck->getMessageContainer().error(msg);
-            parserState.parseContext.handleError( ParseContext::PARSE_UNKNOWN_KEYWORD, msg );
+            auto& msgContainer = parserState.deck->getMessageContainer();
+            parserState.parseContext.handleError( ParseContext::PARSE_UNKNOWN_KEYWORD, msgContainer, msg );
             return {};
         }
 
@@ -433,8 +432,8 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
 
     std::string msg = "Expected the kewyord: " + sizeKeyword.first
                     + " to infer the number of records in: " + keywordString;
-    parserState.deck->getMessageContainer().error(msg);
-    parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msg );
+    auto& msgContainer = parserState.deck->getMessageContainer();
+    parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msgContainer, msg );
 
     const auto* keyword = parser.getKeyword( sizeKeyword.first );
     const auto record = keyword->getRecord(0);
@@ -538,7 +537,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         if( parser.isRecognizedKeyword( parserState.rawKeyword->getKeywordName() ) ) {
             const auto& kwname = parserState.rawKeyword->getKeywordName();
             const auto* parserKeyword = parser.getParserKeywordFromDeckName( kwname );
-            parserState.deck->addKeyword( parserKeyword->parse( parserState.parseContext, parserState.rawKeyword ) );
+            parserState.deck->addKeyword( parserKeyword->parse( parserState.parseContext, parserState.deck->getMessageContainer(), parserState.rawKeyword ) );
         } else {
             DeckKeyword deckKeyword( parserState.rawKeyword->getKeywordName(), false );
             const std::string msg = "The keyword " + parserState.rawKeyword->getKeywordName() + " is not recognized";

--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -31,6 +31,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParserStringItem.hpp>
+#include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/RawDeck/RawConsts.hpp>
 #include <opm/parser/eclipse/RawDeck/RawKeyword.hpp>
 
@@ -472,7 +473,7 @@ namespace Opm {
         return m_deckNames.end();
     }
 
-    DeckKeyword ParserKeyword::parse(const ParseContext& parseContext , RawKeywordPtr rawKeyword) const {
+    DeckKeyword ParserKeyword::parse(const ParseContext& parseContext , MessageContainer& msgContainer, RawKeywordPtr rawKeyword) const {
         if( !rawKeyword->isFinished() )
             throw std::invalid_argument("Tried to create a deck keyword from an incomplete raw keyword " + rawKeyword->getKeywordName());
 
@@ -485,7 +486,7 @@ namespace Opm {
             if( m_records.size() == 0 && rawRecord.size() > 0 )
                 throw std::invalid_argument("Missing item information " + rawKeyword->getKeywordName());
 
-            keyword.addRecord( getRecord( record_nr )->parse( parseContext, rawRecord ) );
+            keyword.addRecord( getRecord( record_nr )->parse( parseContext, msgContainer, rawRecord ) );
             record_nr++;
         }
 

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -44,6 +44,7 @@ namespace Opm {
     class ParserRecord;
     class RawKeyword;
     class string_view;
+    class MessageContainer;
 
     class ParserKeyword {
     public:
@@ -96,7 +97,7 @@ namespace Opm {
         SectionNameSet::const_iterator validSectionNamesBegin() const;
         SectionNameSet::const_iterator validSectionNamesEnd() const;
 
-        DeckKeyword parse(const ParseContext& parseContext , std::shared_ptr< RawKeyword > rawKeyword) const;
+        DeckKeyword parse(const ParseContext& parseContext , MessageContainer& msgContainer, std::shared_ptr< RawKeyword > rawKeyword) const;
         enum ParserKeywordSizeEnum getSizeType() const;
         const std::pair<std::string,std::string>& getSizeDefinitionPair() const;
         bool isDataKeyword() const;

--- a/opm/parser/eclipse/Parser/ParserRecord.cpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/ParserRecord.hpp>
 #include <opm/parser/eclipse/Parser/ParserItem.hpp>
+#include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
@@ -116,7 +117,7 @@ namespace Opm {
         }
     }
 
-    DeckRecord ParserRecord::parse(const ParseContext& parseContext , RawRecord& rawRecord ) const {
+    DeckRecord ParserRecord::parse(const ParseContext& parseContext , MessageContainer& msgContainer, RawRecord& rawRecord ) const {
         DeckRecord deckRecord( size() + 20 );
         for (size_t i = 0; i < size(); i++) {
             auto parserItem = get(i);
@@ -127,7 +128,7 @@ namespace Opm {
             std::string msg = "The RawRecord for keyword \""  + rawRecord.getKeywordName() + "\" in file\"" + rawRecord.getFileName() + "\" contained " +
                 std::to_string(rawRecord.size()) +
                 " too many items according to the spec. RawRecord was: " + rawRecord.getRecordString();
-            parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msg);
+            parseContext.handleError(ParseContext::PARSE_EXTRA_DATA , msgContainer, msg);
         }
 
         return deckRecord;

--- a/opm/parser/eclipse/Parser/ParserRecord.hpp
+++ b/opm/parser/eclipse/Parser/ParserRecord.hpp
@@ -31,6 +31,7 @@ namespace Opm {
     class ParseContext;
     class ParserItem;
     class RawRecord;
+    class MessageContainer;
 
     class ParserRecord {
     public:
@@ -40,7 +41,7 @@ namespace Opm {
         void addDataItem(std::shared_ptr< const ParserItem > item);
         std::shared_ptr< const ParserItem > get(size_t index) const;
         std::shared_ptr< const ParserItem > get(const std::string& itemName) const;
-        DeckRecord parse( const ParseContext&, RawRecord& ) const;
+        DeckRecord parse( const ParseContext&, MessageContainer&, RawRecord& ) const;
         bool isDataRecord() const;
         bool equal(const ParserRecord& other) const;
         bool hasDimension() const;

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -399,13 +399,14 @@ BOOST_AUTO_TEST_CASE(ParseEmptyRecord) {
     ParserIntItemConstPtr item(new ParserIntItem(std::string("ITEM") , ALL));
     RawKeywordPtr rawkeyword(new RawKeyword( tabdimsKeyword->getName() , "FILE" , 10U , 1));
     ParseContext parseContext;
+    MessageContainer msgContainer;
 
     BOOST_CHECK_EQUAL( Raw::FIXED , rawkeyword->getSizeType());
     rawkeyword->addRawRecordString("/");
     record->addItem(item);
     tabdimsKeyword->addRecord( record );
 
-    const auto deckKeyword = tabdimsKeyword->parse( parseContext , rawkeyword );
+    const auto deckKeyword = tabdimsKeyword->parse( parseContext , msgContainer, rawkeyword );
     BOOST_REQUIRE_EQUAL( 1U , deckKeyword.size());
 
     const auto& deckRecord = deckKeyword.getRecord(0);

--- a/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserRecordTests.cpp
@@ -129,14 +129,16 @@ BOOST_AUTO_TEST_CASE(parse_validRecord_noThrow) {
     ParserRecordPtr record = createSimpleParserRecord();
     ParseContext parseContext;
     RawRecord raw( string_view( "100 443" ) );
-    BOOST_CHECK_NO_THROW(record->parse(parseContext, raw ) );
+    MessageContainer msgContainer;
+    BOOST_CHECK_NO_THROW(record->parse(parseContext, msgContainer, raw ) );
 }
 
 BOOST_AUTO_TEST_CASE(parse_validRecord_deckRecordCreated) {
     ParserRecordPtr record = createSimpleParserRecord();
     RawRecord rawRecord( string_view( "100 443" ) );
     ParseContext parseContext;
-    const auto deckRecord = record->parse(parseContext , rawRecord);
+    MessageContainer msgContainer;
+    const auto deckRecord = record->parse(parseContext , msgContainer, rawRecord);
     BOOST_CHECK_EQUAL(2U, deckRecord.size());
 }
 
@@ -169,7 +171,8 @@ BOOST_AUTO_TEST_CASE(parse_validMixedRecord_noThrow) {
     ParserRecordPtr record = createMixedParserRecord();
     RawRecord rawRecord( string_view( "1 2 10.0 20.0 4 90.0") );
     ParseContext parseContext;
-    BOOST_CHECK_NO_THROW(record->parse(parseContext , rawRecord));
+    MessageContainer msgContainer;
+    BOOST_CHECK_NO_THROW(record->parse(parseContext , msgContainer, rawRecord));
 }
 
 BOOST_AUTO_TEST_CASE(Equal_Equal_ReturnsTrue) {
@@ -309,13 +312,15 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooManyItems_Throws) {
 
 
     RawRecord rawRecord(  "3 3 3 " );
-    BOOST_CHECK_NO_THROW(parserRecord->parse(parseContext , rawRecord));
+    MessageContainer msgContainer;
+
+    BOOST_CHECK_NO_THROW(parserRecord->parse(parseContext , msgContainer, rawRecord));
 
     RawRecord rawRecordOneExtra(  "3 3 3 4 " );
-    BOOST_CHECK_THROW(parserRecord->parse(parseContext , rawRecordOneExtra), std::invalid_argument);
+    BOOST_CHECK_THROW(parserRecord->parse(parseContext , msgContainer, rawRecordOneExtra), std::invalid_argument);
 
     RawRecord rawRecordForgotRecordTerminator(  "3 3 3 \n 4 4 4 " );
-    BOOST_CHECK_THROW(parserRecord->parse(parseContext , rawRecordForgotRecordTerminator), std::invalid_argument);
+    BOOST_CHECK_THROW(parserRecord->parse(parseContext , msgContainer, rawRecordForgotRecordTerminator), std::invalid_argument);
 
 }
 
@@ -334,8 +339,9 @@ BOOST_AUTO_TEST_CASE(Parse_RawRecordTooFewItems) {
     RawRecord rawRecord(  "3 3  " );
     // no default specified for the third item, record can be parsed just fine but trying
     // to access the data will raise an exception...
-    BOOST_CHECK_NO_THROW(parserRecord->parse(parseContext , rawRecord));
-    auto record = parserRecord->parse(parseContext , rawRecord);
+    MessageContainer msgContainer;
+    BOOST_CHECK_NO_THROW(parserRecord->parse(parseContext , msgContainer, rawRecord));
+    auto record = parserRecord->parse(parseContext , msgContainer, rawRecord);
     BOOST_CHECK_NO_THROW(record.getItem(2));
     BOOST_CHECK_THROW(record.getItem(2).get< int >(0), std::out_of_range);
 }


### PR DESCRIPTION
Messages is handled by ``handleError()`` method  in ``ParseContext`` are not logged in the log file, this PR simply write the messages in the log file before ``handleError()`` is called,  but the best way is probably to modify the ``ParseContext`` class itself so that one function can do both thing,  here is a relevant issue  https://github.com/OPM/opm-parser/issues/790. Any comment is welcome.