### PR TITLE
Throw now contains name() of deckKeyword

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.cpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.cpp
@@ -97,7 +97,7 @@ namespace Opm {
         if (m_recordList.size() == 1)
             return getRecord(0);
         else
-            throw std::range_error("Not a data keyword ?");
+            throw std::range_error("Not a data keyword \"" + name() + "\"?");
     }
 
 


### PR DESCRIPTION
Replaces error message `"Not a data keyword ?"` with `"Not a data keyword "KEYWORD"?"`