### PR TITLE
EclipseState stores copy of Deck's UnitSystem

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -133,7 +133,7 @@ namespace Opm {
         NNC m_nnc;
 
         MessageContainer m_messageContainer;
-        const UnitSystem& m_deckUnitSystem;
+        UnitSystem m_deckUnitSystem;
     };
 
     typedef std::shared_ptr<EclipseState> EclipseStatePtr;


### PR DESCRIPTION
With the introduction of Parser::parse methods and the relaxed lifetime
requirement of Deck (i.e. users no longer need to keep a Deck instance
around for EclipseState to be considered valid), the UnitSystem cannot
be a reference, but must rather be stored.

Since the unit system is immutable once the deck is read this is
unproblematic. It's also small and cheap to copy.