### PR TITLE
Support Schedule::posixStartTime()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -116,7 +116,9 @@ namespace Opm {
     }
 
     void Schedule::createTimeMap(const Deck& deck) {
-        boost::posix_time::ptime startTime(defaultStartDate);
+        boost::gregorian::date defaultStartTime( 1983, 1, 1 );
+        boost::posix_time::ptime startTime( defaultStartTime );
+
         if (deck.hasKeyword("START")) {
              const auto& startKeyword = deck.getKeyword("START");
             startTime = TimeMap::timeFromEclipse(startKeyword.getRecord(0));

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -78,6 +78,11 @@ namespace Opm {
         return m_timeMap->getStartTime(/*timeStepIdx=*/0);
     }
 
+    time_t Schedule::posixStartTime() const {
+        boost::posix_time::ptime epoch( boost::gregorian::date( 1970, 1, 1 ) );
+        return time_t( ( this->getStartTime() - epoch ).total_seconds() );
+    }
+
     void Schedule::initFromDeck(const ParseContext& parseContext, const Deck& deck, IOConfigPtr ioConfig) {
         initializeNOSIM(deck);
         createTimeMap(deck);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -50,8 +50,6 @@ namespace Opm
     class UnitSystem;
     class Well;
 
-    const boost::gregorian::date defaultStartDate( 1983 , boost::gregorian::Jan , 1);
-
     class Schedule {
     public:
         Schedule(const ParseContext& parseContext, std::shared_ptr<const EclipseGrid> grid,
@@ -60,6 +58,10 @@ namespace Opm
         Schedule(const ParseContext& parseContext, std::shared_ptr<const EclipseGrid> grid,
                  std::shared_ptr<const Deck> deck, std::shared_ptr<IOConfig> ioConfig);
 
+        /*
+         * If the input deck does not specify a start time, Eclipse's 1. Jan
+         * 1983 is defaulted
+         */
         boost::posix_time::ptime getStartTime() const;
         time_t posixStartTime() const;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -61,6 +61,8 @@ namespace Opm
                  std::shared_ptr<const Deck> deck, std::shared_ptr<IOConfig> ioConfig);
 
         boost::posix_time::ptime getStartTime() const;
+        time_t posixStartTime() const;
+
         std::shared_ptr< const TimeMap > getTimeMap() const;
 
         size_t numWells() const;


### PR DESCRIPTION
Allow clients to query time as time_t, not boost::posix::ptime