### PR TITLE
Introducing EclipseConfig -- a container class

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -70,6 +70,7 @@ ${generator_source}
 
 set (state_source
 EclipseState/EclipseState.cpp
+EclipseState/EclipseConfig.cpp
 EclipseState/Eclipse3DProperties.cpp
 EclipseState/Messages.cpp
 #
@@ -170,6 +171,7 @@ Units/Dimension.hpp
 Units/ConversionFactors.hpp
 #
 EclipseState/EclipseState.hpp
+EclipseState/EclipseConfig.hpp
 EclipseState/Eclipse3DProperties.hpp
 EclipseState/Messages.hpp
 #

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <memory>
+
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
@@ -42,9 +43,6 @@ namespace Opm {
             m_simulationConfig(std::make_shared<const SimulationConfig>(deck, eclipse3DProperties)),
             m_summaryConfig(   deck, schedule, eclipse3DProperties, inputGrid->getNXYZ())
     {
-    }
-
-    void EclipseConfig::initIOConfigPostSchedule(const Deck& deck, const Schedule& schedule) {
         // Hmmm - would have thought this should iterate through the SCHEDULE section as well?
         if (Section::hasSOLUTION(deck)) {
             std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>(deck);
@@ -72,6 +70,4 @@ namespace Opm {
     SimulationConfigConstPtr EclipseConfig::getSimulationConfig() const {
         return m_simulationConfig;
     }
-
-
 }

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -1,0 +1,77 @@
+/*
+ Copyright 2016 Statoil ASA.
+
+ This file is part of the Open Porous Media project (OPM).
+
+ OPM is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OPM is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <memory>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/Section.hpp>
+#include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+
+namespace Opm {
+
+    EclipseConfig::EclipseConfig(const Deck& deck,
+                                 const ParseContext& parseContext,
+                                 const Eclipse3DProperties& eclipse3DProperties,
+                                 std::shared_ptr< EclipseGrid > inputGrid,
+                                 const Schedule& schedule) :
+            m_ioConfig(        std::make_shared<IOConfig>(deck)),
+            m_initConfig(      std::make_shared<const InitConfig>(deck)),
+            m_simulationConfig(std::make_shared<const SimulationConfig>(deck, eclipse3DProperties)),
+            m_summaryConfig(   deck, schedule, eclipse3DProperties, inputGrid->getNXYZ())
+    {
+    }
+
+    void EclipseConfig::initIOConfigPostSchedule(const Deck& deck, const Schedule& schedule) {
+        // Hmmm - would have thought this should iterate through the SCHEDULE section as well?
+        if (Section::hasSOLUTION(deck)) {
+            std::shared_ptr<const SOLUTIONSection> solutionSection = std::make_shared<const SOLUTIONSection>(deck);
+            m_ioConfig->handleSolutionSection(schedule.getTimeMap(), solutionSection);
+        }
+        m_ioConfig->initFirstOutput(schedule);
+    }
+
+    const SummaryConfig& EclipseConfig::getSummaryConfig() const {
+        return m_summaryConfig;
+    }
+
+    IOConfigConstPtr EclipseConfig::getIOConfigConst() const {
+        return m_ioConfig;
+    }
+
+    IOConfigPtr EclipseConfig::getIOConfig() const {
+        return m_ioConfig;
+    }
+
+    InitConfigConstPtr EclipseConfig::getInitConfig() const {
+        return m_initConfig;
+    }
+
+    SimulationConfigConstPtr EclipseConfig::getSimulationConfig() const {
+        return m_simulationConfig;
+    }
+
+
+}

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -1,0 +1,61 @@
+/*
+ Copyright 2016 Statoil ASA.
+
+ This file is part of the Open Porous Media project (OPM).
+
+ OPM is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ OPM is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef OPM_ECLIPSE_CONFIG_HPP
+#define OPM_ECLIPSE_CONFIG_HPP
+
+#include <memory>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+
+namespace Opm {
+    class EclipseConfig
+    {
+    public:
+        EclipseConfig(const Deck& deck,
+                      const ParseContext& parseContext,
+                      const Eclipse3DProperties& eclipse3DProperties,
+                      std::shared_ptr< EclipseGrid > inputGrid,
+                      const Schedule& schedule);
+
+        std::shared_ptr< const IOConfig > getIOConfigConst() const;
+        std::shared_ptr< IOConfig > getIOConfig() const;
+        std::shared_ptr< const InitConfig > getInitConfig() const;
+        std::shared_ptr< const SimulationConfig > getSimulationConfig() const;
+        const SummaryConfig& getSummaryConfig() const;
+
+
+        void initIOConfigPostSchedule(const Deck& deck, const Schedule& schedule);
+    private:
+        std::shared_ptr<IOConfig> m_ioConfig;
+        std::shared_ptr<const InitConfig> m_initConfig;
+        std::shared_ptr<const SimulationConfig> m_simulationConfig;
+        SummaryConfig m_summaryConfig;
+    };
+}
+
+#endif // OPM_ECLIPSE_CONFIG_HPP

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -22,17 +22,18 @@
 
 #include <memory>
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
-#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
 namespace Opm {
+
+    class Deck;
+    class Eclipse3DProperties;
+    class IOConfig;
+    class InitConfig;
+    class ParseContext;
+    class SimulationConfig;
+
+
     class EclipseConfig
     {
     public:
@@ -48,8 +49,6 @@ namespace Opm {
         std::shared_ptr< const SimulationConfig > getSimulationConfig() const;
         const SummaryConfig& getSummaryConfig() const;
 
-
-        void initIOConfigPostSchedule(const Deck& deck, const Schedule& schedule);
     private:
         std::shared_ptr<IOConfig> m_ioConfig;
         std::shared_ptr<const InitConfig> m_initConfig;

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -67,9 +67,6 @@ namespace Opm {
         if (m_inputGrid->hasCellInfo())
             m_inputGrid->resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
 
-        m_eclipseConfig.initIOConfigPostSchedule(deck, *m_schedule);
-
-
         if (deck.hasKeyword( "TITLE" )) {
             const auto& titleKeyword = deck.getKeyword( "TITLE" );
             const auto& item = titleKeyword.getRecord( 0 ).getItem( 0 );

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -25,7 +25,9 @@
 #include <utility>
 #include <vector>
 
+#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
@@ -35,6 +37,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
 
@@ -43,23 +46,18 @@ namespace Opm {
 
     class Box;
     class BoxManager;
-    class Deck;
     class DeckItem;
     class DeckKeyword;
     class DeckRecord;
     class EclipseGrid;
-    class Eclipse3DProperties;
     class InitConfig;
     class IOConfig;
-    class NNC;
     class ParseContext;
     class Schedule;
     class Section;
     class SimulationConfig;
     class TableManager;
     class TransMult;
-    class UnitSystem;
-    class MessageContainer;
 
     class EclipseState {
     public:
@@ -76,17 +74,16 @@ namespace Opm {
         EclipseState(std::shared_ptr< const Deck > deck , ParseContext parseContext = ParseContext());
 
         const ParseContext& getParseContext() const;
+
         std::shared_ptr< const Schedule > getSchedule() const;
         std::shared_ptr< const IOConfig > getIOConfigConst() const;
         std::shared_ptr< IOConfig > getIOConfig() const;
         std::shared_ptr< const InitConfig > getInitConfig() const;
         std::shared_ptr< const SimulationConfig > getSimulationConfig() const;
+        const SummaryConfig& getSummaryConfig() const;
+
         std::shared_ptr< const EclipseGrid > getInputGrid() const;
         std::shared_ptr< EclipseGrid > getInputGridCopy() const;
-        const SummaryConfig& getSummaryConfig() const;
-        const MessageContainer& getMessageContainer() const;
-        MessageContainer& getMessageContainer();
-        std::string getTitle() const;
 
         const FaultCollection& getFaults() const;
         std::shared_ptr<const TransMult> getTransMult() const;
@@ -106,6 +103,10 @@ namespace Opm {
         const UnitSystem& getDeckUnitSystem() const;
         const UnitSystem& getUnits() const;
 
+        const MessageContainer& getMessageContainer() const;
+        MessageContainer& getMessageContainer();
+        std::string getTitle() const;
+
         /// [deprecated]
         void applyModifierDeck(std::shared_ptr<const Deck>);
         void applyModifierDeck(const Deck& deck);
@@ -122,22 +123,19 @@ namespace Opm {
                                            const std::string& keywordName);
 
         ParseContext m_parseContext;
+        const TableManager m_tables;
         std::shared_ptr<EclipseGrid> m_inputGrid;
         std::shared_ptr< const Schedule > m_schedule;
-        std::shared_ptr< IOConfig >               m_ioConfig;
-        std::shared_ptr< const InitConfig >       m_initConfig;
-        const TableManager m_tables;
         Eclipse3DProperties m_eclipseProperties;
-        std::shared_ptr< const SimulationConfig > m_simulationConfig;
-        SummaryConfig m_summaryConfig;
-
-        std::string m_title;
-        std::shared_ptr<TransMult> m_transMult;
-        FaultCollection m_faults;
+        EclipseConfig m_eclipseConfig;
         NNC m_inputNnc;
+        UnitSystem m_deckUnitSystem;
 
         MessageContainer m_messageContainer;
-        UnitSystem m_deckUnitSystem;
+
+        std::shared_ptr<TransMult> m_transMult;
+        FaultCollection m_faults;
+        std::string m_title;
     };
 
     typedef std::shared_ptr<EclipseState> EclipseStatePtr;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -25,7 +25,6 @@
 #include <utility>
 #include <vector>
 
-#include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
@@ -37,7 +36,6 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 
 namespace Opm {
 
@@ -46,6 +44,7 @@ namespace Opm {
 
     class Box;
     class BoxManager;
+    class Deck;
     class DeckItem;
     class DeckKeyword;
     class DeckRecord;
@@ -58,6 +57,7 @@ namespace Opm {
     class SimulationConfig;
     class TableManager;
     class TransMult;
+    class UnitSystem;
 
     class EclipseState {
     public:


### PR DESCRIPTION
This PR cleans up some dependencies and intricacies in the `EclipseState` constructor and how the members depend on each other.  We do this by introducing a container class `EclipseConfig`.

* The API exposed by Parser (`EclipseState`) is unchanged as of now
* This class contains the following State members with methods
  - `m_ioConfig` and `getIOConfig` as well as `getIOConfigConst`
  - `m_initConfig` and `getInitConfig`
  - `m_simulationConfig` and `getSimulationConfig`
  - `m_summaryConfig` and `getSummaryConfig`
* Got rid of awkward `initIOConfigPostSchedule` function (and corresponding call)
* For better decoupling
* For future, ease the shared_ptr-ref transition
