### PR TITLE
Split Well/Group; ignore unknown names

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -111,6 +111,17 @@ BOOST_AUTO_TEST_CASE(wells_select) {
             names.begin(), names.end() );
 }
 
+BOOST_AUTO_TEST_CASE(wells_select_unknown_well) {
+    const auto input = "WWCT\n'W_1' 'WX2' 'unknown'/\n";
+    const auto summary = createSummary( input );
+    const auto wells = { "WX2", "W_1" };
+    const auto names = sorted_names( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            wells.begin(), wells.end(),
+            names.begin(), names.end() );
+}
+
 BOOST_AUTO_TEST_CASE(fields) {
     const auto input = "FOPT\n";
     const auto summary = createSummary( input );


### PR DESCRIPTION
Occasionally the SUMMARY section requests wells or groups that aren't
defined in the Deck. Ignore these names (which would typically crash
downstream) and carry on.