### PR TITLE
VS2015 compiler fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,13 +74,16 @@ if (USE_RUNPATH)
    endif()
 endif (USE_RUNPATH)
 
-
-if (NOT DEFINED CMAKE_CXX_FLAGS)
-  SET( CMAKE_CXX_FLAGS "-pipe -std=c++0x -pedantic -Wall -Wextra -Wformat-nonliteral -Wcast-align -Wpointer-arith -Wmissing-declarations -Wcast-qual -Wshadow -Wwrite-strings -Wchar-subscripts -Wredundant-decls")
-endif()
-
-SET( CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}   -O0 -DDEBUG  -ggdb3")
-SET( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG -mtune=native")
+if (MSVC)
+  add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996 /wd4244 /wd4267")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+else()
+  if (NOT DEFINED CMAKE_CXX_FLAGS)
+    SET( CMAKE_CXX_FLAGS "-pipe -std=c++0x -pedantic -Wall -Wextra -Wformat-nonliteral -Wcast-align -Wpointer-arith -Wmissing-declarations -Wcast-qual -Wshadow -Wwrite-strings -Wchar-subscripts -Wredundant-decls")
+  endif()
+  SET( CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}   -O0 -DDEBUG  -ggdb3")
+  SET( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG -mtune=native")
+endif(MSVC)
 
 if (NOT DEFINED CMAKE_C_FLAGS)
   SET( CMAKE_C_FLAGS "-pipe -Wall -Wno-unknown-pragmas -std=c99")

--- a/opm/json/tests/CMakeLists.txt
+++ b/opm/json/tests/CMakeLists.txt
@@ -1,3 +1,5 @@
 opm_add_test(runjsonTests SOURCES jsonTests.cpp
                           LIBRARIES opmjson ${Boost_LIBRARIES})
-set_source_files_properties( jsonTests.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-variable")
+if (NOT MSVC)
+  set_source_files_properties( jsonTests.cpp PROPERTIES COMPILE_FLAGS "-Wno-unused-variable")
+endif()

--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -25,6 +25,9 @@
 
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 
+#include <ert/util/ssize_t.h>
+
+
 namespace Opm {
 
     /**

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/SegmentSet.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/SegmentSet.cpp
@@ -21,6 +21,11 @@
 #include <cmath>
 #include <map>
 
+#ifdef _WIN32
+#define _USE_MATH_DEFINES 
+#include <math.h>
+#endif
+
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/TableColumn.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableColumn.cpp
@@ -22,6 +22,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableColumn.hpp>
 
+#include <ert/util/ssize_t.h>
+
 namespace Opm {
 
     TableColumn::TableColumn(const ColumnSchema& schema) :

--- a/opm/parser/eclipse/Generator/KeywordGenerator.cpp
+++ b/opm/parser/eclipse/Generator/KeywordGenerator.cpp
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <sstream>
 #include <stdexcept>
+#include <cctype>
 
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -29,7 +30,6 @@
 #include <opm/parser/eclipse/Generator/KeywordGenerator.hpp>
 #include <opm/parser/eclipse/Generator/KeywordLoader.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
-
 namespace Opm {
 
     KeywordGenerator::KeywordGenerator(bool verbose)

--- a/opm/parser/eclipse/Generator/KeywordGenerator.cpp
+++ b/opm/parser/eclipse/Generator/KeywordGenerator.cpp
@@ -41,7 +41,7 @@ namespace Opm {
 
 
     std::string testHeader() {
-        std::string header = "#define BOOST_TEST_MODULE\n"
+        std::string header = "#define BOOST_TEST_MODULE ParserRecordTests\n"
             "#include <boost/filesystem.hpp>\n"
             "#include <boost/test/unit_test.hpp>\n"
             "#include <memory>\n"

--- a/opm/parser/eclipse/Generator/KeywordLoader.cpp
+++ b/opm/parser/eclipse/Generator/KeywordLoader.cpp
@@ -109,7 +109,7 @@ namespace Opm {
         std::shared_ptr<ParserKeyword> parserKeyword = std::make_shared<ParserKeyword>(*jsonConfig);
         {
             boost::filesystem::path abs_path = boost::filesystem::absolute( path );
-            addKeyword( parserKeyword , abs_path.string() );
+            addKeyword( parserKeyword , abs_path.generic_string() );
         }
     }
 

--- a/opm/parser/eclipse/Parser/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/Parser/tests/CMakeLists.txt
@@ -3,8 +3,7 @@ foreach(tapp ParserTests ParserKeywordTests ParserRecordTests
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})
 endforeach()
-set_property(SOURCE ParserRecordTests.cpp PROPERTY COMPILE_FLAGS "-Wno-error")
-
-
-
+if (NOT MSVC)
+    set_property(SOURCE ParserRecordTests.cpp PROPERTY COMPILE_FLAGS "-Wno-error")
+endif()
 

--- a/opm/parser/eclipse/RawDeck/RawKeyword.cpp
+++ b/opm/parser/eclipse/RawDeck/RawKeyword.cpp
@@ -24,6 +24,8 @@
 #include <opm/parser/eclipse/RawDeck/RawKeyword.hpp>
 #include <opm/parser/eclipse/RawDeck/RawRecord.hpp>
 
+#include <cctype>
+
 namespace Opm {
 
     static const std::string emptystr = "";

--- a/opm/parser/eclipse/RawDeck/StarToken.hpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.hpp
@@ -23,6 +23,7 @@
 #include <string>
 
 #include <opm/parser/eclipse/Utility/Stringview.hpp>
+#include <ert/util/ssize_t.h>
 
 namespace Opm {
     bool isStarToken(const string_view& token,


### PR DESCRIPTION
`ssize_t` is included using `<ert/util/ssize_t.h>` On Linux, this will end up with include of `<sys/types.h>`

This PR will fix most of compiler issues on VS2015. The compiler issue related to
```C++ 
this->keywords = fun::concat( fun::map( handler, section ) );
```
will be handled in a separate PR.

See link below for closed (and not merged) PR and commit related to fun::concat issue
https://github.com/OPM/opm-parser/pull/811/commits/d6bd4485b0daef9d397e94f652c157db505c0778
