### PR TITLE
EclipseGrid copy constructor.

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -114,7 +114,7 @@ namespace Opm {
     }
 
     EclipseGridPtr EclipseState::getInputGridCopy() const {
-        return std::make_shared<EclipseGrid>( m_inputGrid->c_ptr() );
+        return std::make_shared<EclipseGrid>( *m_inputGrid );
     }
 
     const SummaryConfig& EclipseState::getSummaryConfig() const {
@@ -129,7 +129,7 @@ namespace Opm {
         return m_messageContainer;
     }
 
-    
+
     MessageContainer& EclipseState::getMessageContainer() {
         return m_messageContainer;
     }

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -257,6 +257,23 @@ namespace Opm {
     }
 
 
+    size_t EclipseGrid::activeIndex(size_t i, size_t j, size_t k) const {
+        return activeIndex( getGlobalIndex( i,j,k ));
+    }
+
+
+
+    size_t EclipseGrid::activeIndex(size_t globalIndex) const {
+        assertCellInfo();
+        {
+            int active_index = ecl_grid_get_active_index1( m_grid.get() , globalIndex );
+            if (active_index < 0)
+                throw std::invalid_argument("Input argument does not correspond to an active cell");
+            return static_cast<size_t>( active_index );
+        }
+    }
+
+
 
     size_t EclipseGrid::getNX( ) const {
         return m_nx;

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -65,18 +65,21 @@ namespace Opm {
         m_nz = static_cast<size_t>( ecl_grid_get_nz( c_ptr() ));
     }
 
-    EclipseGrid::EclipseGrid(const ecl_grid_type * src_ptr)
-        : m_minpvValue(0),
-          m_minpvMode(MinpvMode::ModeEnum::Inactive),
-          m_pinch("PINCH"),
-          m_pinchoutMode(PinchMode::ModeEnum::TOPBOT),
-          m_multzMode(PinchMode::ModeEnum::TOP)
+    /* Copy constructor */
+    EclipseGrid::EclipseGrid(const EclipseGrid& src)
+        : m_minpvValue( src.m_minpvValue ),
+          m_minpvMode( src.m_minpvMode ),
+          m_pinch( src.m_pinch ),
+          m_pinchoutMode( src.m_pinchoutMode ),
+          m_multzMode( src.m_multzMode ),
+          m_nx( src.m_nx ),
+          m_ny( src.m_ny ),
+          m_nz( src.m_nz ),
+          m_messages( src.m_messages )
     {
-        m_grid.reset( ecl_grid_alloc_copy( src_ptr ) );
+        if (src.hasCellInfo())
+            m_grid.reset( ecl_grid_alloc_copy( src.c_ptr() ) );
 
-        m_nx = static_cast<size_t>( ecl_grid_get_nx( c_ptr() ));
-        m_ny = static_cast<size_t>( ecl_grid_get_ny( c_ptr() ));
-        m_nz = static_cast<size_t>( ecl_grid_get_nz( c_ptr() ));
     }
 
     /*

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -71,7 +71,7 @@ namespace Opm {
     class EclipseGrid {
     public:
         explicit EclipseGrid(const std::string& filename);
-        explicit EclipseGrid(const ecl_grid_type * src_ptr);
+        explicit EclipseGrid(const EclipseGrid& srcGrid);
         explicit EclipseGrid(size_t nx, size_t ny, size_t nz,
                              double dx = 1.0, double dy = 1.0, double dz = 1.0);
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -99,6 +99,16 @@ namespace Opm {
 
         bool hasCellInfo() const;
 
+        /// The activeIndex methods will return from (i,j,k) or g,
+        /// where g \in [0,nx*n*nz) to the corresponding active index
+        /// in the range [0,numActive). Observe that if the input
+        /// argument corresponds to a cell which is not active an
+        /// exception will be raised - check with cellActive() first
+        /// if that is a possibillity.
+        size_t activeIndex(size_t i, size_t j, size_t k) const;
+        size_t activeIndex(size_t globalIndex) const;
+
+
         size_t getGlobalIndex(size_t i, size_t j, size_t k) const;
         std::array<int, 3> getIJK(size_t globalIndex) const;
         void assertGlobalIndex(size_t globalIndex) const;

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -901,19 +901,34 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
 
     BOOST_CHECK_EQUAL(es.getInputGrid()->getNumActive(), active);
 
-    for (size_t x = 0; x < 10; x++) {
-        for (size_t y = 0; y < 10; y++) {
-            for (size_t z = 0; z < 10; z++) {
-                if (z == 0)
-                    BOOST_CHECK(!grid->cellActive(x, y, z));
-                else if (x >= 4 && x <= 6 && y >= 4 && y <= 6 && z >= 4 && z <= 6)
-                    BOOST_CHECK(!grid->cellActive(x, y, z));
-                else if (x >= 5 && x <= 7 && y >= 5 && y <= 7 && z >= 5 && z <= 7)
-                    BOOST_CHECK(!grid->cellActive(x, y, z));
-                else
-                    BOOST_CHECK(grid->cellActive(x, y, z));
+    {
+        size_t active_index = 0;
+        // NB: The implementation of this test actually assumes that
+        //     the loops are running with z as the outer and x as the
+        //     inner direction.
+        for (size_t z = 0; z < grid->getNZ(); z++) {
+            for (size_t y = 0; y < grid->getNY(); y++) {
+                for (size_t x = 0; x < grid->getNX(); x++) {
+                    if (z == 0)
+                        BOOST_CHECK(!grid->cellActive(x, y, z));
+                    else if (x >= 4 && x <= 6 && y >= 4 && y <= 6 && z >= 4 && z <= 6)
+                        BOOST_CHECK(!grid->cellActive(x, y, z));
+                    else if (x >= 5 && x <= 7 && y >= 5 && y <= 7 && z >= 5 && z <= 7)
+                        BOOST_CHECK(!grid->cellActive(x, y, z));
+                    else {
+                        size_t g = grid->getGlobalIndex( x,y,z );
+
+                        BOOST_CHECK(grid->cellActive(x, y, z));
+                        BOOST_CHECK_EQUAL( grid->activeIndex(x,y,z) , active_index );
+                        BOOST_CHECK_EQUAL( grid->activeIndex(g) , active_index );
+
+                        active_index++;
+                    }
+                }
             }
         }
+
+        BOOST_CHECK_THROW( grid->activeIndex(0,0,0) , std::invalid_argument );
     }
 }
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -923,12 +923,16 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
     Opm::EclipseState es(deck, Opm::ParseContext());
     auto ep = es.get3DProperties();
     auto grid = es.getInputGrid();
+    Opm::EclipseGrid grid2( *grid );
 
     BOOST_CHECK_NO_THROW(ep.getIntGridProperty("ACTNUM"));
-
     BOOST_CHECK_NO_THROW(grid->getNumActive());
     BOOST_CHECK(grid->hasCellInfo());
     BOOST_CHECK_EQUAL(grid->getNumActive(), 2 * 2 * 2 - 1);
+
+    BOOST_CHECK_NO_THROW(grid2.getNumActive());
+    BOOST_CHECK(grid2.hasCellInfo());
+    BOOST_CHECK_EQUAL(grid2.getNumActive(), 2 * 2 * 2 - 1);
 }
 
 BOOST_AUTO_TEST_CASE(GridActnumViaState) {


### PR DESCRIPTION
Removed EclipseGrid::EclipseGrid( ecl_grid_type * )

Tiny steps towards fully functional C++ value semantics.