### PR TITLE
VS2015 : Workaround for VS2015 compiler bug

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -252,7 +252,18 @@ namespace Opm {
 
         using namespace std::placeholders;
         const auto handler = std::bind( handleKW, _1, schedule, props, n_xyz );
-        this->keywords = fun::concat( fun::map( handler, section ) );
+
+        /* This line of code does not compile on VS2015
+         *   this->keywords = fun::concat( fun::map( handler, section ) );
+         * The following code is a workaround for this compiler bug */
+        for (auto& x : section)
+        {
+            auto keywords = handler(x);
+            for (auto& keyword : keywords)
+            {
+                this->keywords.push_back(keyword);
+            }
+        }
     }
 
     SummaryConfig::const_iterator SummaryConfig::begin() const {


### PR DESCRIPTION
I have tested several proposed solutions based on input from @jokva, but unfortunately I was not able to fix the compiler issue in any other way than suggested here. As I have mentioned earlier, I do not have much experience with newer c++, so it is likely there exists an easy solution I am not aware of.

To fix this issue in a different way than suggested here, I believe a developer with experience in this field working on VS2015 will be required.