### PR TITLE
Removed pre calculation of size in fun::concat()

### DIFF
--- a/opm/parser/eclipse/Utility/Functional.hpp
+++ b/opm/parser/eclipse/Utility/Functional.hpp
@@ -103,14 +103,7 @@ namespace fun {
      */
     template< typename A >
     std::vector< A > concat( std::vector< std::vector< A > >&& src ) {
-        const auto size = std::accumulate( src.begin(), src.end(), 0,
-                []( std::size_t acc, const std::vector< A >& x ) {
-                    return acc + x.size();
-                    }
-                );
-
         std::vector< A > dst;
-        dst.reserve( size );
 
         for( auto& x : src )
             std::move( x.begin(), x.end(), std::back_inserter( dst ) );


### PR DESCRIPTION
Looking into the problems mentioned here: https://github.com/OPM/opm-parser/pull/818 it is my suspicion that `fun::concat()` is the culprit. Have therefor tried to alternatives here; good if @magnesj can try these out. 

**Alternative 1:(this PR)** Simplified the `fun::concat( )` by removing the pre calculation of output size. The result might not be so pleasing to a C++ purist - but in the current code base it has zilch effect on performance.

**Alternative 2: (https://github.com/OPM/opm-parser/pull/822)** Removed the `fun::concat( )` from `SummaryConfig` - using only `fun::map()`.

If both alternatives work with VS2015 i would strongly prefer the first alternative