### PR TITLE
Check for symlink() and compile test conditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ endif()
 include(UseMultiArch)
 include(OpmSatellites)
 include(UseWarnings)
+include(cmake/build_check.cmake)
 
 #-----------------------------------------------------------------
 # This is modified copy & paste from the OpmDefaults.cmake module.
@@ -113,6 +114,7 @@ find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_frame
 include_directories(${Boost_INCLUDE_DIRS})
 
 include_directories(BEFORE ${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_BINARY_DIR})
 
 # if we are using dynamic boost, the header file must generate a main() function
 if (NOT Boost_USE_STATIC_LIBS)

--- a/cmake/build_check.cmake
+++ b/cmake/build_check.cmake
@@ -1,0 +1,13 @@
+# This file contains checks which are used to implement portable
+# utility functions. The results of these check are assembled in the
+# generated header "opm_parser_build_config.hpp" - that header is NOT part
+# of the public api and it should only be included from source files
+# as part of the compilation.
+
+include( CheckFunctionExists )
+
+
+check_function_exists( symlink OPM_PARSER_BUILD_HAVE_SYMLINK )
+
+
+configure_file( ${PROJECT_SOURCE_DIR}/cmake/config/opm_parser_build_config.hpp.in ${PROJECT_BINARY_DIR}/opm_parser_build_config.hpp)

--- a/cmake/config/opm_parser_build_config.hpp.in
+++ b/cmake/config/opm_parser_build_config.hpp.in
@@ -1,0 +1,7 @@
+// This file contains #define symols which come from feature tests
+// during the configure phase. This file should not be part of the
+// public api of opm-parser, and it should *only* be included in .cpp
+// files.
+
+#cmakedefine OPM_PARSER_BUILD_HAVE_SYMLINK
+

--- a/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserIncludeTests.cpp
@@ -27,6 +27,10 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 
+#include "opm_parser_build_config.hpp"
+
+
+#ifdef OPM_PARSER_BUILD_HAVE_SYMLINK
 
 BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_is_a_symlink) {
     boost::filesystem::path inputFilePath("testdata/parser/includeSymlinkTestdata/symlink1/case_symlink.data");
@@ -57,6 +61,7 @@ BOOST_AUTO_TEST_CASE(Verify_find_includes_Data_file_has_include_file_that_again_
     BOOST_CHECK_EQUAL(false , deck->hasKeyword("WATER"));
 }
 
+#endif
 
 
 BOOST_AUTO_TEST_CASE(ParserKeyword_includeValid) {


### PR DESCRIPTION
We have some tests checking symlink behavior - disable these tests if we don't have `symlink()`