### PR TITLE
Write the VFP testing information into Debug file.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -490,6 +490,8 @@ namespace Opm {
 
             VFPProdTable table;
             table.init(keyword, unit_system);
+            auto message = table.getMessageContainer();
+            m_messages.appendMessages(message);
 
             //Check that the table in question has a unique ID
             int table_id = table.getTableNum();

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -490,8 +490,7 @@ namespace Opm {
 
             VFPProdTable table;
             table.init(keyword, unit_system);
-            auto message = table.getMessageContainer();
-            m_messages.appendMessages(message);
+            m_messages.appendMessages(table.getMessageContainer());
 
             //Check that the table in question has a unique ID
             int table_id = table.getTableNum();

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
@@ -386,10 +386,10 @@ void VFPProdTable::check() {
 
     if (num_decreasing > 0) {
         //TODO: Replace with proper log message
-        std::cerr << "VFPPROD bhp versus thp not monotonic increasing: "
-                << num_decreasing << "/" << m_data.num_elements()
-                << "(" << static_cast<int>(100 * num_decreasing / (double) m_data.num_elements()) << "%)"
-                << " elements failed test" << std::endl;
+        m_messages.debug("VFPPROD bhp versus thp not monotonic increasing: "
+                + std::to_string(num_decreasing) + "/" + std::to_string( m_data.num_elements())
+                + "(" + std::to_string(static_cast<int>(100 * num_decreasing / (double) m_data.num_elements()))
+                + "%) elements failed test");
     }
 }
 
@@ -527,6 +527,17 @@ void VFPProdTable::convertALQToSI(const ALQ_TYPE& type,
 
 
 
+const MessageContainer& VFPProdTable::getMessageContainer() const
+{
+    return m_messages;
+}
+
+
+
+MessageContainer& VFPProdTable::getMessageContainer()
+{
+    return m_messages;
+}
 
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
@@ -533,12 +533,4 @@ const MessageContainer& VFPProdTable::getMessageContainer() const
 }
 
 
-
-MessageContainer& VFPProdTable::getMessageContainer()
-{
-    return m_messages;
-}
-
-
-
 } //Namespace opm

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
@@ -233,7 +233,6 @@ public:
     }
 
     const MessageContainer& getMessageContainer() const;
-    MessageContainer& getMessageContainer();
 
 private:
 

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
@@ -25,7 +25,7 @@
 #include <boost/multi_array.hpp>
 
 #include <opm/common/utility/platform_dependent/reenable_warnings.h>
-
+#include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 
 namespace Opm {
 
@@ -232,6 +232,9 @@ public:
         return m_data;
     }
 
+    const MessageContainer& getMessageContainer() const;
+    MessageContainer& getMessageContainer();
+
 private:
 
     //"Header" variables
@@ -252,6 +255,7 @@ private:
     //The data itself, using the data ordering m_data[thp][wfr][gfr][alq][flo]
     array_type m_data;
 
+    MessageContainer m_messages;
     /**
      * Debug function that runs a series of asserts to check for sanity of inputs.
      * Called after init to check that everything looks ok.


### PR DESCRIPTION
These VFP messages should really go into debug files, that's not useful for the user.

```
VFPPROD bhp versus thp not monotonic increasing: 7/4224(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 9/3168(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 1/7296(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 6/15200(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 5/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 11/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 8/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 10/13300(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 15/13680(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 3/15200(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 73/3360(2%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 335/6804(4%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 32/6804(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 54/6804(0%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 282/6912(4%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 87/6804(1%) elements failed test
VFPPROD bhp versus thp not monotonic increasing: 337/6048(5%) elements failed test

````