### PR TITLE
Remove shared_ptr Well alias, make Schedule interface more consistent

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
@@ -100,10 +100,10 @@ namespace Opm {
         /*****************************************************************/
 
         bool hasWell(const std::string& wellName , size_t time_step) const;
-        std::shared_ptr< const Well > getWell(const std::string& wellName , size_t time_step) const;
+        const Well* getWell(const std::string& wellName , size_t time_step) const;
         const WellSet& getWells( size_t time_step ) const;
         size_t numWells(size_t time_step) const;
-        void addWell(size_t time_step , std::shared_ptr< Well > well);
+        void addWell(size_t time_step , Well* well);
         void delWell(size_t time_step, const std::string& wellName );
     private:
         std::shared_ptr< const WellSet > wellMap(size_t time_step) const;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1458,7 +1458,7 @@ namespace Opm {
             currentGroup.delWell( timeStep , well->name());
         }
         well->setGroupName(timeStep , newGroup.name());
-        newGroup.addWell(timeStep , well);
+        newGroup.addWell(timeStep , well.get());
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -351,7 +351,7 @@ namespace Opm {
             }
 
             WellConstPtr currentWell = getWell(wellName);
-            checkWELSPECSConsistency(currentWell, keyword, recordNr);
+            checkWELSPECSConsistency( *currentWell, keyword, recordNr);
 
             addWellToGroup( getGroup(groupName) , getWell(wellName) , currentStep);
             if (handleGroupFromWELSPECS(groupName, newTree))
@@ -398,17 +398,17 @@ namespace Opm {
 
 
 
-    void Schedule::checkWELSPECSConsistency(WellConstPtr well, const DeckKeyword& keyword, size_t recordIdx) {
+    void Schedule::checkWELSPECSConsistency( const Well& well, const DeckKeyword& keyword, size_t recordIdx) {
         const auto& record = keyword.getRecord(recordIdx);
-        if (well->getHeadI() != record.getItem("HEAD_I").get< int >(0) - 1) {
+        if (well.getHeadI() != record.getItem("HEAD_I").get< int >(0) - 1) {
             std::string msg =
-                "Unable process WELSPECS for well " + well->name() + ", HEAD_I deviates from existing value";
+                "Unable process WELSPECS for well " + well.name() + ", HEAD_I deviates from existing value";
             m_messages.error(keyword.getFileName(), msg, keyword.getLineNumber());
             throw std::invalid_argument(msg);
         }
-        if (well->getHeadJ() != record.getItem("HEAD_J").get< int >(0) - 1) {
+        if (well.getHeadJ() != record.getItem("HEAD_J").get< int >(0) - 1) {
             std::string msg =
-                "Unable process WELSPECS for well " + well->name() + ", HEAD_J deviates from existing value";
+                "Unable process WELSPECS for well " + well.name() + ", HEAD_J deviates from existing value";
             m_messages.error(keyword.getFileName(), msg, keyword.getLineNumber());
             throw std::invalid_argument(msg);
         }

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -350,10 +350,10 @@ namespace Opm {
                 addWell(wellName, record, currentStep, wellCompletionOrder);
             }
 
-            WellConstPtr currentWell = getWell(wellName);
+            const auto* currentWell = getWell(wellName);
             checkWELSPECSConsistency( *currentWell, keyword, recordNr);
 
-            addWellToGroup( *this->m_groups.at( groupName ), getWell(wellName), currentStep);
+            addWellToGroup( *this->m_groups.at( groupName ), *this->m_wells.get( wellName ), currentStep);
             if (handleGroupFromWELSPECS(groupName, newTree))
                 needNewTree = true;
 
@@ -422,10 +422,9 @@ namespace Opm {
             const WellCommon::StatusEnum status =
                 WellCommon::StatusFromString(record.getItem("STATUS").getTrimmedString(0));
 
-            const std::vector<WellPtr> wells = getWells(wellNamePattern);
+            auto wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
                 WellProductionProperties properties;
 
 
@@ -502,10 +501,8 @@ namespace Opm {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             double wellPi = record.getItem("WELLPI").get< double >(0);
-            std::vector<WellPtr> wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
                 CompletionSetConstPtr currentCompletionSet = well->getCompletions(currentStep);
 
                 CompletionSetPtr newCompletionSet(new CompletionSet( ));
@@ -569,10 +566,8 @@ namespace Opm {
     void Schedule::handleWCONINJE( const SCHEDULESection& section, const DeckKeyword& keyword, size_t currentStep) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
-            std::vector<WellPtr> wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
                 WellInjector::TypeEnum injectorType = WellInjector::TypeFromString( record.getItem("TYPE").getTrimmedString(0) );
                 WellCommon::StatusEnum status = WellCommon::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
 
@@ -648,11 +643,8 @@ namespace Opm {
     void Schedule::handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep) {
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
-            std::vector<WellPtr> wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
-
+            for( auto* well : getWells( wellNamePattern ) ) {
                 WellPolymerProperties properties(well->getPolymerPropertiesCopy(currentStep));
 
                 properties.m_polymerConcentration = record.getItem("POLYMER_CONCENTRATION").getSIDouble(0);
@@ -677,10 +669,8 @@ namespace Opm {
 
         for( const auto& record : keyword ) {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
-            std::vector<WellPtr> wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
                 WellInjectionProperties injectionProperties = well->getInjectionProperties( currentStep );
                 if (well->isInjector( currentStep ) && injectionProperties.injectorType == WellInjector::GAS) {
                     double fraction = record.getItem("SOLVENT_FRACTION").get< double >(0);
@@ -695,7 +685,6 @@ namespace Opm {
     void Schedule::handleWCONINJH( const SCHEDULESection& section,  const DeckKeyword& keyword, size_t currentStep) {
         for( const auto& record : keyword ) {
             const std::string& wellName = record.getItem("WELL").getTrimmedString(0);
-            WellPtr well = getWell(wellName);
 
             // convert injection rates to SI
             WellInjector::TypeEnum injectorType = WellInjector::TypeFromString( record.getItem("TYPE").getTrimmedString(0));
@@ -704,8 +693,9 @@ namespace Opm {
 
             WellCommon::StatusEnum status = WellCommon::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
 
-            updateWellStatus( *well, currentStep, status );
-            WellInjectionProperties properties(well->getInjectionPropertiesCopy(currentStep));
+            auto& well = *this->m_wells.get( wellName );
+            updateWellStatus( well, currentStep, status );
+            WellInjectionProperties properties(well.getInjectionPropertiesCopy(currentStep));
 
             properties.injectorType = injectorType;
 
@@ -718,15 +708,15 @@ namespace Opm {
             }
             properties.predictionMode = false;
 
-            if (well->setInjectionProperties(currentStep, properties))
+            if (well.setInjectionProperties(currentStep, properties))
                 m_events->addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );
 
-            if ( ! well->getAllowCrossFlow() && (injectionRate == 0) ) {
+            if ( ! well.getAllowCrossFlow() && (injectionRate == 0) ) {
                 std::string msg =
-                        "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
+                        "Well " + well.name() + " is an injector with zero rate where crossflow is banned. " +
                         "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
                 m_messages.note(msg);
-                updateWellStatus( *well, currentStep, WellCommon::StatusEnum::SHUT );
+                updateWellStatus( well, currentStep, WellCommon::StatusEnum::SHUT );
             }
         }
     }
@@ -746,10 +736,8 @@ namespace Opm {
             }
 
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
-            const std::vector<WellPtr>& wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
 
                 if(haveCompletionData){
                     CompletionSetConstPtr currentCompletionSet = well->getCompletions(currentStep);
@@ -853,10 +841,8 @@ namespace Opm {
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
             const std::string& cMode = record.getItem("CMODE").getTrimmedString(0);
             double newValue = record.getItem("NEW_VALUE").get< double >(0);
-            const std::vector<WellPtr>& wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
                 if(well->isProducer(currentStep)){
                     WellProductionProperties prop = well->getProductionPropertiesCopy(currentStep);
 
@@ -1161,8 +1147,7 @@ namespace Opm {
 
         for( iter= completionMapList.begin(); iter != completionMapList.end(); iter++) {
             const std::string wellName = iter->first;
-            WellPtr well = getWell(wellName);
-            well->addCompletions(currentStep, iter->second);
+            m_wells.get( wellName )->addCompletions(currentStep, iter->second);
         }
         m_events->addEvent(ScheduleEvents::COMPLETION_CHANGE, currentStep);
     }
@@ -1172,7 +1157,7 @@ namespace Opm {
         newSegmentset->segmentsFromWELSEGSKeyword(keyword);
 
         const std::string& well_name = newSegmentset->wellName();
-        WellPtr well = getWell(well_name);
+        auto well = this->m_wells.get( well_name );
 
         // update multi-segment related information for the well
         well->addSegmentSet(currentStep, newSegmentset);
@@ -1181,38 +1166,38 @@ namespace Opm {
     void Schedule::handleCOMPSEGS( const DeckKeyword& keyword, size_t currentStep) {
         const auto& record1 = keyword.getRecord(0);
         const std::string& well_name = record1.getItem("WELL").getTrimmedString(0);
-        WellPtr well = getWell(well_name);
+        auto& well = *this->m_wells.get( well_name );
 
         std::vector<CompsegsPtr> compsegs_vector = Compsegs::compsegsFromCOMPSEGSKeyword( keyword );
 
-        SegmentSetConstPtr current_segmentSet = well->getSegmentSet(currentStep);
+        SegmentSetConstPtr current_segmentSet = well.getSegmentSet(currentStep);
         Compsegs::processCOMPSEGS(compsegs_vector, current_segmentSet);
 
-        CompletionSetConstPtr current_completionSet = well->getCompletions(currentStep);
+        CompletionSetConstPtr current_completionSet = well.getCompletions(currentStep);
         // it is necessary to update the segment related information for some completions.
         CompletionSetPtr new_completionSet = CompletionSetPtr(current_completionSet->shallowCopy());
         Compsegs::updateCompletionsWithSegment(compsegs_vector, new_completionSet);
 
-        well->addCompletionSet(currentStep, new_completionSet);
+        well.addCompletionSet(currentStep, new_completionSet);
     }
 
     void Schedule::handleWGRUPCON( const DeckKeyword& keyword, size_t currentStep) {
         for( const auto& record : keyword ) {
             const std::string& wellName = record.getItem("WELL").getTrimmedString(0);
-            WellPtr well = getWell(wellName);
+            auto& well = *this->m_wells.get( wellName );
 
             bool availableForGroupControl = convertEclipseStringToBool(record.getItem("GROUP_CONTROLLED").getTrimmedString(0));
-            well->setAvailableForGroupControl(currentStep, availableForGroupControl);
+            well.setAvailableForGroupControl(currentStep, availableForGroupControl);
 
-            well->setGuideRate(currentStep, record.getItem("GUIDE_RATE").get< double >(0));
+            well.setGuideRate(currentStep, record.getItem("GUIDE_RATE").get< double >(0));
 
             if (!record.getItem("PHASE").defaultApplied(0)) {
                 std::string guideRatePhase = record.getItem("PHASE").getTrimmedString(0);
-                well->setGuideRatePhase(currentStep, GuideRate::GuideRatePhaseEnumFromString(guideRatePhase));
+                well.setGuideRatePhase(currentStep, GuideRate::GuideRatePhaseEnumFromString(guideRatePhase));
             } else
-                well->setGuideRatePhase(currentStep, GuideRate::UNDEFINED);
+                well.setGuideRatePhase(currentStep, GuideRate::UNDEFINED);
 
-            well->setGuideRateScalingFactor(currentStep, record.getItem("SCALING_FACTOR").get< double >(0));
+            well.setGuideRateScalingFactor(currentStep, record.getItem("SCALING_FACTOR").get< double >(0));
         }
     }
 
@@ -1242,10 +1227,9 @@ namespace Opm {
         for( const auto& record : keyword ) {
 
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
-            const std::vector<WellPtr> wells = getWells(wellNamePattern);
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
+
                 well->setRFTActive(currentStep, true);
                 size_t numStep = m_timeMap->numTimesteps();
                 if(currentStep<numStep){
@@ -1255,7 +1239,7 @@ namespace Opm {
         }
 
         for (auto iter = m_wells.begin(); iter != m_wells.end(); ++iter) {
-            WellPtr well = *iter;
+            auto well = *iter;
             well->setRFTForWellWhenFirstOpen(m_timeMap->numTimesteps(), currentStep);
         }
     }
@@ -1265,14 +1249,11 @@ namespace Opm {
         for( const auto& record : keyword ) {
 
             const std::string& wellNamePattern = record.getItem("WELL").getTrimmedString(0);
-            const std::vector<WellPtr> wells = getWells(wellNamePattern);
 
             RFTConnections::RFTEnum RFTKey = RFTConnections::RFTEnumFromString(record.getItem("OUTPUT_RFT").getTrimmedString(0));
-
             PLTConnections::PLTEnum PLTKey = PLTConnections::PLTEnumFromString(record.getItem("OUTPUT_PLT").getTrimmedString(0));
 
-            for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+            for( auto* well : getWells( wellNamePattern ) ) {
                 switch(RFTKey){
                     case RFTConnections::RFTEnum::YES:
                         well->setRFTActive(currentStep, true);
@@ -1323,7 +1304,6 @@ namespace Opm {
         int headJ = record.getItem("HEAD_J").get< int >(0) - 1;
         Phase::PhaseEnum preferredPhase = Phase::PhaseEnumFromString(record.getItem("PHASE").getTrimmedString(0));
         Value<double> refDepth("REF_DEPTH");
-        WellPtr well;
         const auto& refDepthItem = record.getItem("REF_DEPTH");
 
         if (refDepthItem.hasValue(0))
@@ -1334,7 +1314,7 @@ namespace Opm {
         if (allowCrossFlowStr == "NO")
             allowCrossFlow = false;
 
-        well = std::make_shared<Well>(wellName, m_grid , headI, headJ, refDepth, preferredPhase, m_timeMap , timeStep, wellCompletionOrder, allowCrossFlow);
+        auto well = std::make_shared<Well>(wellName, m_grid , headI, headJ, refDepth, preferredPhase, m_timeMap , timeStep, wellCompletionOrder, allowCrossFlow);
         m_wells.insert( wellName  , well);
         m_events->addEvent( ScheduleEvents::NEW_WELL , timeStep );
     }
@@ -1344,39 +1324,37 @@ namespace Opm {
     }
 
     size_t Schedule::numWells(size_t timestep) const {
-      std::vector<WellConstPtr> wells = getWells(timestep);
-      return wells.size();
+        return this->getWells( timestep ).size();
     }
 
     bool Schedule::hasWell(const std::string& wellName) const {
         return m_wells.hasKey( wellName );
     }
 
-    std::vector<WellConstPtr> Schedule::getWells() const {
+    std::vector< const Well* > Schedule::getWells() const {
         return getWells(m_timeMap->size()-1);
     }
 
-    std::vector<WellConstPtr> Schedule::getWells(size_t timeStep) const {
+    std::vector< const Well* > Schedule::getWells(size_t timeStep) const {
         if (timeStep >= m_timeMap->size()) {
             throw std::invalid_argument("Timestep to large");
         }
 
-        std::vector<WellConstPtr> wells;
-        for (auto iter = m_wells.begin(); iter != m_wells.end(); ++iter) {
-            WellConstPtr well = *iter;
-            if (well->hasBeenDefined(timeStep)) {
-                wells.push_back(well);
-            }
+        auto defined = [=]( const Well* w ) {
+            return w->hasBeenDefined( timeStep );
+        };
+
+        std::vector< const Well* > wells;
+        for( const auto well : m_wells ) {
+            if( !defined( well.get() ) ) continue;
+            wells.push_back( well.get() );
         }
+
         return wells;
     }
 
-    WellPtr Schedule::getWell(const std::string& wellName) {
-        return m_wells.get( wellName );
-    }
-
-    const Well& Schedule::getWell(const std::string& wellName) const {
-        return *m_wells.get( wellName );
+    const Well* Schedule::getWell(const std::string& wellName) const {
+        return m_wells.get( wellName ).get();
     }
 
 
@@ -1386,30 +1364,39 @@ namespace Opm {
       been opened by the simulator.
     */
 
-    std::vector<WellPtr> Schedule::getOpenWells(size_t timeStep) {
-        std::vector<WellPtr> wells;
-        for (auto well_iter = m_wells.begin(); well_iter != m_wells.end(); ++well_iter) {
-            auto well = *well_iter;
-            if (well->getStatus( timeStep ) == WellCommon::OPEN)
-                wells.push_back( well );
+    std::vector< const Well* > Schedule::getOpenWells(size_t timeStep) const {
+
+        auto open = [=]( const Well* w ) {
+            return w->getStatus( timeStep ) == WellCommon::OPEN;
+        };
+
+        std::vector< const Well* > wells;
+        for( const auto well : m_wells ) {
+            if( !open( well.get() ) ) continue;
+            wells.push_back( well.get() );
         }
+
         return wells;
     }
 
+    std::vector< const Well* > Schedule::getWellsMatching( const std::string& wellNamePattern ) const {
+        auto tmp = const_cast< Schedule* >( this )->getWells( wellNamePattern );
+        return { tmp.begin(), tmp.end() };
+    }
 
-    std::vector<WellPtr> Schedule::getWells(const std::string& wellNamePattern) {
-        std::vector<WellPtr> wells;
+    std::vector< Well* > Schedule::getWells(const std::string& wellNamePattern) {
+        std::vector< Well* > wells;
         size_t wildcard_pos = wellNamePattern.find("*");
         if (wildcard_pos == wellNamePattern.length()-1) {
             for (auto wellIter = m_wells.begin(); wellIter != m_wells.end(); ++wellIter) {
-                WellPtr well = *wellIter;
+                Well* well = wellIter->get();
                 if (Well::wellNameInWellNamePattern(well->name(), wellNamePattern)) {
                     wells.push_back (well);
                 }
             }
         }
         else {
-            wells.push_back(getWell(wellNamePattern));
+            wells.push_back( m_wells.get( wellNamePattern ).get() );
         }
         return wells;
     }
@@ -1451,14 +1438,13 @@ namespace Opm {
         return groups;
     }
 
-    void Schedule::addWellToGroup( Group& newGroup , WellPtr well , size_t timeStep) {
-        const std::string currentGroupName = well->getGroupName(timeStep);
+    void Schedule::addWellToGroup( Group& newGroup, Well& well , size_t timeStep) {
+        const std::string currentGroupName = well.getGroupName(timeStep);
         if (currentGroupName != "") {
-            auto& currentGroup = *this->m_groups.at( currentGroupName );
-            currentGroup.delWell( timeStep , well->name());
+            m_groups.at( currentGroupName )->delWell( timeStep, well.name() );
         }
-        well->setGroupName(timeStep , newGroup.name());
-        newGroup.addWell(timeStep , well.get());
+        well.setGroupName(timeStep , newGroup.name());
+        newGroup.addWell(timeStep , &well);
     }
 
 
@@ -1512,9 +1498,7 @@ namespace Opm {
 
     size_t Schedule::getMaxNumCompletionsForWells(size_t timestep) const {
       size_t ncwmax = 0;
-      const std::vector<WellConstPtr>& wells = getWells();
-      for (auto wellIter=wells.begin(); wellIter != wells.end(); ++wellIter) {
-        WellConstPtr wellPtr = *wellIter;
+      for( const auto* wellPtr : getWells() ) {
         CompletionSetConstPtr completionsSetPtr = wellPtr->getCompletions(timestep);
 
         if (completionsSetPtr->size() > ncwmax )

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -456,7 +456,7 @@ namespace Opm {
                         throw std::invalid_argument(msg);
                     }
                 }
-                updateWellStatus( well , currentStep , status );
+                updateWellStatus( *well , currentStep , status );
                 if (well->setProductionProperties(currentStep, properties))
                     m_events->addEvent( ScheduleEvents::PRODUCTION_UPDATE , currentStep);
                 
@@ -466,15 +466,15 @@ namespace Opm {
                             "Well " + well->name() + " is a history matched well with zero rate where crossflow is banned. " +
                             "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
                     m_messages.note(msg);
-                    updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
+                    updateWellStatus( *well, currentStep, WellCommon::StatusEnum::SHUT );
                 }
             }
         }
     }
 
-    void Schedule::updateWellStatus(std::shared_ptr<Well> well, size_t reportStep , WellCommon::StatusEnum status) {
-        if (well->setStatus( reportStep , status ))
-            m_events->addEvent( ScheduleEvents::WELL_STATUS_CHANGE , reportStep );
+    void Schedule::updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status) {
+        if( well.setStatus( reportStep, status ) )
+            m_events->addEvent( ScheduleEvents::WELL_STATUS_CHANGE, reportStep );
     }
 
 
@@ -576,7 +576,7 @@ namespace Opm {
                 WellInjector::TypeEnum injectorType = WellInjector::TypeFromString( record.getItem("TYPE").getTrimmedString(0) );
                 WellCommon::StatusEnum status = WellCommon::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
 
-                updateWellStatus( well , currentStep , status );
+                updateWellStatus( *well , currentStep , status );
                 WellInjectionProperties properties(well->getInjectionPropertiesCopy(currentStep));
 
                 properties.injectorType = injectorType;
@@ -638,7 +638,7 @@ namespace Opm {
                             "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
                             "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
                     m_messages.note(msg);
-                    updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
+                    updateWellStatus( *well, currentStep, WellCommon::StatusEnum::SHUT );
                 }
             }
         }
@@ -704,7 +704,7 @@ namespace Opm {
 
             WellCommon::StatusEnum status = WellCommon::StatusFromString( record.getItem("STATUS").getTrimmedString(0));
 
-            updateWellStatus(well ,  currentStep , status );
+            updateWellStatus( *well, currentStep, status );
             WellInjectionProperties properties(well->getInjectionPropertiesCopy(currentStep));
 
             properties.injectorType = injectorType;
@@ -726,7 +726,7 @@ namespace Opm {
                         "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
                         "This well will be closed at " + std::to_string ( m_timeMap->getTimePassedUntil(currentStep) / (60*60*24) ) + " days";
                 m_messages.note(msg);
-                updateWellStatus(well, currentStep, WellCommon::StatusEnum::SHUT );
+                updateWellStatus( *well, currentStep, WellCommon::StatusEnum::SHUT );
             }
         }
     }
@@ -812,7 +812,7 @@ namespace Opm {
                     well->addCompletionSet(currentStep, newCompletionSet);
                     m_events->addEvent(ScheduleEvents::COMPLETION_CHANGE, currentStep);
                     if (newCompletionSet->allCompletionsShut())
-                        updateWellStatus( well , currentStep , WellCommon::StatusEnum::SHUT);
+                        updateWellStatus( *well, currentStep, WellCommon::StatusEnum::SHUT);
 
                 }
                 else if(!haveCompletionData) {
@@ -824,7 +824,7 @@ namespace Opm {
                         m_messages.note(msg);
                         continue;
                     }
-                    updateWellStatus( well , currentStep , status );
+                    updateWellStatus( *well, currentStep, status );
                 }
             }
         }

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -117,7 +117,7 @@ namespace Opm
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, size_t timeStep, WellCompletion::CompletionOrderEnum wellCompletionOrder);
         void handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t currentStep);
-        void checkWELSPECSConsistency(std::shared_ptr< const Well > well, const DeckKeyword& keyword, size_t recordIdx);
+        void checkWELSPECSConsistency( const Well&, const DeckKeyword& keyword, size_t recordIdx);
         void handleWELSPECS( const SCHEDULESection&, const DeckKeyword& keyword, size_t currentStep);
         void handleWCONProducer( const DeckKeyword& keyword, size_t currentStep, bool isPredictionMode);
         void handleWCONHIST( const DeckKeyword& keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -70,12 +70,11 @@ namespace Opm
         size_t numWells(size_t timestep) const;
         size_t getMaxNumCompletionsForWells(size_t timestep) const;
         bool hasWell(const std::string& wellName) const;
-        std::shared_ptr< Well > getWell(const std::string& wellName);
-        const Well& getWell(const std::string& wellName) const;
-        std::vector<std::shared_ptr< Well >> getOpenWells(size_t timeStep);
-        std::vector<std::shared_ptr< const Well >> getWells() const;
-        std::vector<std::shared_ptr< const Well >> getWells(size_t timeStep) const;
-        std::vector<std::shared_ptr< Well >> getWells(const std::string& wellNamePattern);
+        const Well* getWell(const std::string& wellName) const;
+        std::vector< const Well* > getOpenWells(size_t timeStep) const;
+        std::vector< const Well* > getWells() const;
+        std::vector< const Well* > getWells(size_t timeStep) const;
+        std::vector< const Well* > getWellsMatching( const std::string& ) const;
         std::shared_ptr< const OilVaporizationProperties > getOilVaporizationProperties(size_t timestep);
 
         std::shared_ptr< GroupTree > getGroupTree(size_t t) const;
@@ -107,8 +106,9 @@ namespace Opm
         MessageContainer m_messages;
 
 
+        std::vector< Well* > getWells(const std::string& wellNamePattern);
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
-        void addWellToGroup( Group& newGroup , std::shared_ptr< Well > well , size_t timeStep);
+        void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
         void initializeNOSIM(const Deck& deck);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
         void initOilVaporization(std::shared_ptr< const TimeMap > timeMap);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -81,7 +81,7 @@ namespace Opm
         std::shared_ptr< GroupTree > getGroupTree(size_t t) const;
         size_t numGroups() const;
         bool hasGroup(const std::string& groupName) const;
-        std::shared_ptr< Group > getGroup(const std::string& groupName) const;
+        const Group* getGroup(const std::string& groupName) const;
         std::vector< const Group* > getGroups() const;
         std::shared_ptr< Tuning > getTuning() const;
 
@@ -108,7 +108,7 @@ namespace Opm
 
 
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
-        void addWellToGroup( std::shared_ptr< Group > newGroup , std::shared_ptr< Well > well , size_t timeStep);
+        void addWellToGroup( Group& newGroup , std::shared_ptr< Well > well , size_t timeStep);
         void initializeNOSIM(const Deck& deck);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
         void initOilVaporization(std::shared_ptr< const TimeMap > timeMap);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -107,7 +107,7 @@ namespace Opm
         MessageContainer m_messages;
 
 
-        void updateWellStatus(std::shared_ptr<Well> well, size_t reportStep , WellCommon::StatusEnum status);
+        void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( std::shared_ptr< Group > newGroup , std::shared_ptr< Well > well , size_t timeStep);
         void initializeNOSIM(const Deck& deck);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -155,8 +155,6 @@ namespace Opm {
         // flag indicating if the well is a multi-segment well
         std::shared_ptr<DynamicState<std::shared_ptr< const SegmentSet >>> m_segmentset;
     };
-    typedef std::shared_ptr<Well> WellPtr;
-    typedef std::shared_ptr<const Well> WellConstPtr;
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/WellSet.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellSet.cpp
@@ -36,7 +36,7 @@ namespace Opm {
     }
 
 
-    std::shared_ptr< const Well > WellSet::getWell(const std::string& wellName) const {
+    const Well* WellSet::getWell(const std::string& wellName) const {
         if (hasWell(wellName))
             return m_wells.find(wellName)->second;
         else
@@ -44,7 +44,7 @@ namespace Opm {
     }
 
 
-    void WellSet::addWell(std::shared_ptr< Well > well) {
+    void WellSet::addWell( Well* well) {
         const std::string& wellName = well->name();
         if (!hasWell(wellName))
             m_wells[wellName] = well;
@@ -62,12 +62,12 @@ namespace Opm {
 
 
     WellSet * WellSet::shallowCopy() const {
-        WellSet * copy = new WellSet();
+        std::unique_ptr< WellSet > copy( new WellSet() );
 
-        for (std::map<std::string , std::shared_ptr< Well >>::const_iterator iter=m_wells.begin(); iter != m_wells.end(); ++iter)
-            copy->addWell( (*iter).second );
+        for( auto pair : this->m_wells )
+            copy->addWell( pair.second );
 
-        return copy;
+        return copy.release();
     }
 
     WellSet::const_iterator WellSet::begin() const {

--- a/opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp
@@ -23,19 +23,19 @@
 #include <memory>
 #include <string>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
-
 namespace Opm {
+
+    class Well;
 
     class WellSet {
     public:
-        using const_iterator = std::map< std::string, std::shared_ptr< Well > >::const_iterator;
+        using const_iterator = std::map< std::string, Well* >::const_iterator;
 
         WellSet();
         size_t size() const;
         bool hasWell(const std::string& wellName) const;
-        std::shared_ptr< const Well > getWell(const std::string& wellName) const;
-        void addWell(std::shared_ptr< Well > well);
+        const Well* getWell(const std::string& wellName) const;
+        void addWell( Well* well);
         void delWell(const std::string& wellName);
         WellSet * shallowCopy() const;
 
@@ -43,11 +43,8 @@ namespace Opm {
         const_iterator end() const;
 
     private:
-        std::map<std::string , std::shared_ptr< Well >> m_wells;
+        std::map<std::string, Well* > m_wells;
     };
-
-    typedef std::shared_ptr<WellSet> WellSetPtr;
-    typedef std::shared_ptr<const WellSet> WellSetConstPtr;
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -160,16 +160,16 @@ BOOST_AUTO_TEST_CASE(GroupAddWell) {
     Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
-    group.addWell( 3 , well1 );
+    group.addWell( 3 , well1.get() );
     BOOST_CHECK_EQUAL( 1U , group.numWells(3));
     BOOST_CHECK_EQUAL( 0U , group.numWells(1));
 
-    group.addWell( 4 , well1 );
+    group.addWell( 4 , well1.get() );
     BOOST_CHECK_EQUAL( 1U , group.numWells(4));
     BOOST_CHECK_EQUAL( 0U , group.numWells(1));
     BOOST_CHECK_EQUAL( 1U , group.numWells(5));
 
-    group.addWell( 6 , well2 );
+    group.addWell( 6 , well2.get() );
     BOOST_CHECK_EQUAL( 1U , group.numWells(4));
     BOOST_CHECK_EQUAL( 0U , group.numWells(1));
     BOOST_CHECK_EQUAL( 1U , group.numWells(5));
@@ -198,11 +198,11 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
     Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
-    group.addWell( 3 , well1 );
+    group.addWell( 3 , well1.get() );
     BOOST_CHECK_EQUAL( 1U , group.numWells(3));
     BOOST_CHECK_EQUAL( 0U , group.numWells(1));
 
-    group.addWell( 6 , well2 );
+    group.addWell( 6 , well2.get() );
     BOOST_CHECK_EQUAL( 1U , group.numWells(4));
     BOOST_CHECK_EQUAL( 0U , group.numWells(1));
     BOOST_CHECK_EQUAL( 1U , group.numWells(5));
@@ -234,10 +234,10 @@ BOOST_AUTO_TEST_CASE(getWells) {
     Opm::WellPtr well1(new Opm::Well("WELL1" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
     Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
 
-    group.addWell( 2 , well1 );
-    group.addWell( 3 , well1 );
-    group.addWell( 3 , well2 );
-    group.addWell( 4 , well1 );
+    group.addWell( 2 , well1.get() );
+    group.addWell( 3 , well1.get() );
+    group.addWell( 3 , well2.get() );
+    group.addWell( 4 , well1.get() );
 
     std::vector< std::string > names = { "WELL1", "WELL2" };
     std::vector< std::string > wnames;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -288,7 +288,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10, 10, 10);
     Opm::Schedule schedule(parseContext , grid, deck );
 
-    Opm::GroupConstPtr group1 = schedule.getGroup("PRODUC");
+    const auto* group1 = schedule.getGroup("PRODUC");
     BOOST_CHECK_EQUAL(group1->getGroupEfficiencyFactor(0), 0.85);
     BOOST_CHECK_EQUAL(group1->getTransferGroupEfficiencyFactor(0), true);
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -25,8 +25,6 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
-
-
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -37,6 +35,8 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/WellSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
+
+using namespace Opm;
 
 static Opm::TimeMapPtr createXDaysTimeMap(size_t numDays) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
@@ -156,8 +156,8 @@ BOOST_AUTO_TEST_CASE(GroupAddWell) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,10,10);
-    Opm::WellPtr well1(new Opm::Well("WELL1" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
+    auto well1 = std::make_shared< Well >("WELL1", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL2", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1.get() );
@@ -194,8 +194,8 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,10,10);
-    Opm::WellPtr well1(new Opm::Well("WELL1" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
+    auto well1 = std::make_shared< Well >("WELL1", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL2", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 
     BOOST_CHECK_EQUAL(0U , group.numWells(2));
     group.addWell( 3 , well1.get() );
@@ -231,8 +231,8 @@ BOOST_AUTO_TEST_CASE(getWells) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,10,10);
-    Opm::WellPtr well1(new Opm::Well("WELL1" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0));
+    auto well1 = std::make_shared< Well >("WELL1", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL2", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 
     group.addWell( 2 , well1.get() );
     group.addWell( 3 , well1.get() );
@@ -334,7 +334,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWGRUPCONandWCONPROD) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10, 10, 10);
     Opm::Schedule schedule(parseContext , grid, deck );
-    Opm::WellConstPtr currentWell = schedule.getWell("B-37T2"); 
+    const auto* currentWell = schedule.getWell("B-37T2");
     const Opm::WellProductionProperties& wellProductionProperties = currentWell->getProductionProperties(0);
     BOOST_CHECK_EQUAL(wellProductionProperties.controlMode, Opm::WellProducer::ControlModeEnum::GRUP);
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -208,7 +208,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
     DeckPtr deck = createDeckWithWellsOrdered();
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(100,100,100);
     Schedule schedule(ParseContext() , grid , deck );
-    std::vector<WellConstPtr> wells = schedule.getWells();
+    auto wells = schedule.getWells();
 
     BOOST_CHECK_EQUAL( "CW_1" , wells[0]->name());
     BOOST_CHECK_EQUAL( "BW_2" , wells[1]->name());
@@ -307,9 +307,9 @@ BOOST_AUTO_TEST_CASE(WellsIterator_Empty_EmptyVectorReturned) {
     DeckPtr deck = createDeck();
     Schedule schedule(ParseContext() , grid , deck );
     size_t timeStep = 0;
-    std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
+    const auto wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(0U, wells_alltimesteps.size());
-    std::vector<WellConstPtr> wells_t0 = schedule.getWells(timeStep);
+    const auto wells_t0 = schedule.getWells(timeStep);
     BOOST_CHECK_EQUAL(0U, wells_t0.size());
 
     BOOST_CHECK_THROW(schedule.getWells(1), std::invalid_argument);
@@ -321,11 +321,11 @@ BOOST_AUTO_TEST_CASE(WellsIterator_HasWells_WellsReturned) {
     Schedule schedule(ParseContext() , grid , deck );
     size_t timeStep = 0;
 
-    std::vector<WellConstPtr> wells_alltimesteps = schedule.getWells();
+    const auto wells_alltimesteps = schedule.getWells();
     BOOST_CHECK_EQUAL(3U, wells_alltimesteps.size());
-    std::vector<WellConstPtr> wells_t0 = schedule.getWells(timeStep);
+    const auto wells_t0 = schedule.getWells(timeStep);
     BOOST_CHECK_EQUAL(1U, wells_t0.size());
-    std::vector<WellConstPtr> wells_t3 = schedule.getWells(3);
+    const auto wells_t3 = schedule.getWells(3);
     BOOST_CHECK_EQUAL(3U, wells_t3.size());
 }
 
@@ -334,18 +334,17 @@ BOOST_AUTO_TEST_CASE(WellsIteratorWithRegex_HasWells_WellsReturned) {
     DeckPtr deck = createDeckWithWells();
     Schedule schedule(ParseContext() , grid , deck );
     std::string wellNamePattern;
-    std::vector<WellPtr> wells;
 
     wellNamePattern = "*";
-    wells = schedule.getWells(wellNamePattern);
+    auto wells = schedule.getWellsMatching(wellNamePattern);
     BOOST_CHECK_EQUAL(3U, wells.size());
 
     wellNamePattern = "W_*";
-    wells = schedule.getWells(wellNamePattern);
+    wells = schedule.getWellsMatching(wellNamePattern);
     BOOST_CHECK_EQUAL(2U, wells.size());
 
     wellNamePattern = "W_3";
-    wells = schedule.getWells(wellNamePattern);
+    wells = schedule.getWellsMatching(wellNamePattern);
     BOOST_CHECK_EQUAL(1U, wells.size());
 }
 
@@ -374,7 +373,7 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
     DeckPtr deck = createDeckForTestingCrossFlow();
     Schedule schedule(ParseContext() , grid , deck );
 
-    WellPtr well_ban = schedule.getWell("BAN");
+    auto well_ban = schedule.getWell("BAN");
     BOOST_CHECK_EQUAL(well_ban->getAllowCrossFlow(), false);
 
 
@@ -387,8 +386,8 @@ BOOST_AUTO_TEST_CASE(TestCrossFlowHandling) {
 
 
     {
-        WellPtr well_allow = schedule.getWell("ALLOW");
-        WellPtr well_default = schedule.getWell("DEFAULT");
+        auto well_allow = schedule.getWell("ALLOW");
+        auto well_default = schedule.getWell("DEFAULT");
 
         BOOST_CHECK_EQUAL(well_default->getAllowCrossFlow(), true);
         BOOST_CHECK_EQUAL(well_allow->getAllowCrossFlow(), true);
@@ -453,8 +452,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsAndCompletionDataWithWELOPEN) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,10);
     DeckPtr deck = createDeckWithWellsAndCompletionDataWithWELOPEN();
     Schedule schedule(ParseContext() , grid , deck );
-    WellPtr well;
-    well = schedule.getWell("OP_1");
+    auto* well = schedule.getWell("OP_1");
     size_t currentStep = 0;
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
     currentStep = 3;
@@ -558,8 +556,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
   ParseContext parseContext;
   DeckPtr deck = parser.parseString(input, parseContext);
   Schedule schedule(parseContext , grid , deck );
-  WellPtr well;
-  well = schedule.getWell("OP_1");
+  auto* well = schedule.getWell("OP_1");
   size_t currentStep = 3;
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
   currentStep = 4;
@@ -707,8 +704,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithDefaultValuesInWELOPEN) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     DeckPtr deck = parser.parseString(input, ParseContext());
     Schedule schedule(ParseContext() , grid , deck );
-    WellPtr well;
-    well = schedule.getWell("OP_1");
+    auto* well = schedule.getWell("OP_1");
     size_t currentStep = 3;
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(currentStep));
 }
@@ -757,15 +753,13 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
     Schedule schedule(parseContext , grid , deck );
 
     {
-        WellPtr well;
-        well = schedule.getWell("OP_1");
+        auto* well = schedule.getWell("OP_1");
         BOOST_CHECK_EQUAL(well->getRFTActive(2),true);
         BOOST_CHECK_EQUAL(2 , well->firstRFTOutput( ));
     }
 
     {
-        WellPtr well;
-        well = schedule.getWell("OP_2");
+        auto* well = schedule.getWell("OP_2");
         BOOST_CHECK_EQUAL(well->getRFTActive(3),true);
         BOOST_CHECK_EQUAL(3 , well->firstRFTOutput( ));
     }
@@ -822,8 +816,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     DeckPtr deck = parser.parseString(input, parseContext);
     Schedule schedule(parseContext , grid , deck );
-    WellPtr well;
-    well = schedule.getWell("OP_1");
+    auto* well = schedule.getWell("OP_1");
 
     size_t currentStep = 3;
     BOOST_CHECK_EQUAL(well->getRFTActive(currentStep),false);
@@ -870,7 +863,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWeltArg) {
     DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10 , 10 , 10 );
     Schedule schedule(parseContext , grid , deck );
-    WellPtr well = schedule.getWell("OP_1");
+    auto* well = schedule.getWell("OP_1");
 
     size_t currentStep = 1;
     WellProductionProperties wpp = well->getProductionProperties(currentStep);
@@ -980,7 +973,7 @@ BOOST_AUTO_TEST_CASE(createDeckWithWPIMULT) {
     DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10, 10, 10);
     Schedule schedule(parseContext , grid, deck );
-    WellPtr well = schedule.getWell("OP_1");
+    auto* well = schedule.getWell("OP_1");
 
     size_t currentStep = 2;
     CompletionSetConstPtr currentCompletionSet = well->getCompletions(currentStep);
@@ -1171,14 +1164,14 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10, 10, 10);
     Schedule schedule(parseContext , grid, deck );
-    WellPtr well_p = schedule.getWell("P");
+    auto* well_p = schedule.getWell("P");
 
     BOOST_CHECK_EQUAL(well_p->getProductionProperties(0).BHPLimit, 0); //start
     BOOST_CHECK_EQUAL(well_p->getProductionProperties(1).BHPLimit, 50 * 1e5); // 1
     // The BHP limit should not be effected by WCONHIST
     BOOST_CHECK_EQUAL(well_p->getProductionProperties(2).BHPLimit, 50 * 1e5); // 2
 
-    WellPtr well_i = schedule.getWell("I");
+    auto* well_i = schedule.getWell("I");
 
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(0).BHPLimit, 0); //start
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(1).BHPLimit, 600 * 1e5); // 1

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
@@ -58,21 +58,21 @@ BOOST_AUTO_TEST_CASE(AddAndDeleteWell) {
     Opm::WellPtr well(new Opm::Well("WELL1"  , grid , 0, 0, Opm::Value<double>("REF_DEPTH") , Opm::Phase::OIL, timeMap , 0));
     Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH") , Opm::Phase::OIL, timeMap , 0));
 
-    wellSet.addWell( well );
+    wellSet.addWell( well.get() );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL1"));
     BOOST_CHECK_EQUAL(1U , wellSet.size());
-    BOOST_CHECK_EQUAL( well , wellSet.getWell("WELL1"));
+    BOOST_CHECK_EQUAL( well.get(), wellSet.getWell("WELL1"));
 
 
-    wellSet.addWell( well2 );
+    wellSet.addWell( well2.get() );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL2"));
     BOOST_CHECK_EQUAL(2U , wellSet.size());
-    BOOST_CHECK_EQUAL( well2 , wellSet.getWell("WELL2"));
+    BOOST_CHECK_EQUAL( well2.get(), wellSet.getWell("WELL2"));
 
     wellSet.delWell("WELL1");
     BOOST_CHECK_EQUAL(false , wellSet.hasWell("WELL1"));
     BOOST_CHECK_EQUAL(1U , wellSet.size());
-    BOOST_CHECK_EQUAL( well2 , wellSet.getWell("WELL2"));
+    BOOST_CHECK_EQUAL( well2.get(), wellSet.getWell("WELL2"));
 }
 
 
@@ -84,11 +84,11 @@ BOOST_AUTO_TEST_CASE(AddWellSameName) {
     Opm::WellPtr well1(new Opm::Well("WELL" , grid , 0, 0,Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0));
     Opm::WellPtr well2(new Opm::Well("WELL" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0));
 
-    wellSet.addWell( well1 );
+    wellSet.addWell( well1.get() );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL"));
 
-    BOOST_CHECK_NO_THROW( wellSet.addWell( well1 ));
-    BOOST_CHECK_THROW( wellSet.addWell( well2 ) , std::invalid_argument );
+    BOOST_CHECK_NO_THROW( wellSet.addWell( well1.get() ));
+    BOOST_CHECK_THROW( wellSet.addWell( well2.get() ) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(Iterator) {

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 
+using namespace Opm;
 
 static Opm::TimeMapPtr createXDaysTimeMap(size_t numDays) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
@@ -55,8 +56,8 @@ BOOST_AUTO_TEST_CASE(AddAndDeleteWell) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
 
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,10,10);
-    Opm::WellPtr well(new Opm::Well("WELL1"  , grid , 0, 0, Opm::Value<double>("REF_DEPTH") , Opm::Phase::OIL, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL2" , grid , 0, 0, Opm::Value<double>("REF_DEPTH") , Opm::Phase::OIL, timeMap , 0));
+    auto well  = std::make_shared< Well >("WELL1", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0);
+    auto well2 = std::make_shared< Well >("WELL2", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0);
 
     wellSet.addWell( well.get() );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL1"));
@@ -81,8 +82,8 @@ BOOST_AUTO_TEST_CASE(AddWellSameName) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
 
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,10,10);
-    Opm::WellPtr well1(new Opm::Well("WELL" , grid , 0, 0,Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0));
+    auto well1 = std::make_shared< Well >("WELL", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
+    auto well2 = std::make_shared< Well >("WELL", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 
     wellSet.addWell( well1.get() );
     BOOST_CHECK_EQUAL(true , wellSet.hasWell("WELL"));
@@ -96,8 +97,8 @@ BOOST_AUTO_TEST_CASE(Iterator) {
     Opm::TimeMapPtr timeMap = createXDaysTimeMap(10);
 
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>(10,10,10);
-    Opm::WellPtr well1(new Opm::Well("WELL" , grid , 0, 0,Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0));
-    Opm::WellPtr well2(new Opm::Well("WELL" , grid , 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0));
+    auto well1 = std::make_shared< Well >("WELL", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0);
+    auto well2 = std::make_shared< Well >("WELL", grid, 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap , 0);
 
     for( const auto& well : wellSet )
         BOOST_CHECK( well.second->isProducer( 0 ) );

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
@@ -163,7 +163,7 @@ BOOST_AUTO_TEST_CASE(TestDynamicWSOLVENT) {
     BOOST_CHECK_EQUAL(keyword.size(),1);
     const auto& record = keyword.getRecord(0);
     const std::string& wellNamesPattern = record.getItem("WELL").getTrimmedString(0);
-    std::vector<WellPtr> wells_solvent = schedule.getWells(wellNamesPattern);
+    auto wells_solvent = schedule.getWellsMatching(wellNamesPattern);
     BOOST_CHECK_EQUAL(wellNamesPattern, "W_1");
     BOOST_CHECK_EQUAL(wells_solvent[0]->getSolventFraction(0),0); //default 0
     BOOST_CHECK_EQUAL(wells_solvent[0]->getSolventFraction(1),1);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestTRACK) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( 10 , 10 , 10 );
     Opm::Schedule schedule(Opm::ParseContext() , grid , deck );
-    Opm::WellPtr op_1 = schedule.getWell("OP_1");
+    auto* op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
     Opm::CompletionSetConstPtr completions = op_1->getCompletions( timestep );
@@ -240,7 +240,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestDefaultTRACK) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( 10 , 10 , 10 );
     Opm::Schedule schedule(Opm::ParseContext() , grid , deck );
-    Opm::WellPtr op_1 = schedule.getWell("OP_1");
+    auto* op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
     Opm::CompletionSetConstPtr completions = op_1->getCompletions( timestep );
@@ -283,7 +283,7 @@ BOOST_AUTO_TEST_CASE(WellCOMPDATtestINPUT) {
     Opm::DeckPtr deck = parser.parseString(input, parseContext);
     std::shared_ptr<const Opm::EclipseGrid> grid = std::make_shared<const Opm::EclipseGrid>( 10 , 10 , 10 );
     Opm::Schedule schedule(Opm::ParseContext() , grid , deck );
-    Opm::WellPtr op_1 = schedule.getWell("OP_1");
+    auto* op_1 = schedule.getWell("OP_1");
 
     size_t timestep = 2;
     Opm::CompletionSetConstPtr completions = op_1->getCompletions( timestep );

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -43,12 +43,9 @@
 
 namespace Opm {
 
-    static std::string wellName( const std::shared_ptr< const Well >& well ) {
-        return well->name();
-    }
-
-    static std::string groupName( const Group* group ) {
-        return group->name();
+    template< typename T >
+    static std::string name( const T* x ) {
+        return x->name();
     }
 
     static inline std::vector< ERT::smspec_node > keywordW(
@@ -66,7 +63,7 @@ namespace Opm {
         const auto& item = keyword.getDataRecord().getDataItem();
         auto wnames = item.hasValue( 0 )
             ? item.getData< std::string >()
-            : fun::map( wellName, schedule.getWells() );
+            : fun::map( name< Well >, schedule.getWells() );
 
         /* filter all requested names that were not in the Deck */
         wnames.erase(
@@ -91,7 +88,7 @@ namespace Opm {
         const auto& item = keyword.getDataRecord().getDataItem();
         auto gnames = item.hasValue( 0 )
             ? item.getData< std::string >()
-            : fun::map( groupName, schedule.getGroups() );
+            : fun::map( name< Group >, schedule.getGroups() );
 
         gnames.erase(
                 std::remove_if( gnames.begin(), gnames.end(), missing ),
@@ -180,7 +177,7 @@ namespace Opm {
            if( record.getItem( 0 ).defaultApplied( 0 ) ) {
                for( const auto& well : schedule.getWells() ) {
 
-                   const auto& name = wellName( well );
+                   const auto& name = well->name();
 
                    for( const auto& completion : *well->getCompletions( last_timestep ) ) {
                        auto cijk = getijk( *completion );
@@ -207,7 +204,7 @@ namespace Opm {
                }
                else {
                    /* well specified, block coordinates defaulted */
-                   for( const auto& completion : *schedule.getWell( name ).getCompletions( last_timestep ) ) {
+                   for( const auto& completion : *schedule.getWell( name )->getCompletions( last_timestep ) ) {
                        auto ijk = getijk( *completion );
                        nodes.emplace_back( keywordstring, name, dims.data(), ijk.data() );
                    }

--- a/opm/parser/eclipse/IntegrationTests/ParseWellWithWildcards.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseWellWithWildcards.cpp
@@ -53,19 +53,19 @@ BOOST_AUTO_TEST_CASE( parse_WCONPROD_OK ) {
     BOOST_CHECK(sched->hasWell("PROX5"));
 
     {
-        WellPtr well = sched->getWell("PROD2");
+        auto* well = sched->getWell("PROD2");
         BOOST_CHECK_CLOSE(1000/Metric::Time, well->getProductionProperties(0).OilRate, 0.001);
         BOOST_CHECK_CLOSE(1500/Metric::Time, well->getProductionProperties(1).OilRate, 0.001);
     }
 
     {
-        WellPtr well = sched->getWell("PROD3");
+        auto* well = sched->getWell("PROD3");
         BOOST_CHECK_CLOSE(0/Metric::Time, well->getProductionProperties(0).OilRate, 0.001);
         BOOST_CHECK_CLOSE(1500/Metric::Time, well->getProductionProperties(1).OilRate, 0.001);
     }
 
     {
-        WellPtr well = sched->getWell("PROX5");
+        auto* well = sched->getWell("PROX5");
         BOOST_CHECK_CLOSE(2000/Metric::Time, well->getProductionProperties(0).OilRate, 0.001);
         BOOST_CHECK_CLOSE(2000/Metric::Time, well->getProductionProperties(1).OilRate, 0.001);
     }
@@ -88,19 +88,19 @@ BOOST_AUTO_TEST_CASE( parse_WCONINJE_OK ) {
     BOOST_CHECK(sched->hasWell("INJX5"));
 
     {
-        WellPtr well = sched->getWell("INJE2");
+        auto* well = sched->getWell("INJE2");
         BOOST_CHECK_CLOSE(1000/Metric::Time, well->getInjectionProperties(0).surfaceInjectionRate, 0.001);
         BOOST_CHECK_CLOSE(1500/Metric::Time, well->getInjectionProperties(1).surfaceInjectionRate, 0.001);
     }
 
     {
-        WellPtr well = sched->getWell("INJE3");
+        auto* well = sched->getWell("INJE3");
         BOOST_CHECK_CLOSE(0/Metric::Time, well->getInjectionProperties(0).surfaceInjectionRate, 0.001);
         BOOST_CHECK_CLOSE(1500/Metric::Time, well->getInjectionProperties(1).surfaceInjectionRate, 0.001);
     }
 
     {
-        WellPtr well = sched->getWell("INJX5");
+        auto* well = sched->getWell("INJX5");
         BOOST_CHECK_CLOSE(2000/Metric::Time, well->getInjectionProperties(0).surfaceInjectionRate, 0.001);
         BOOST_CHECK_CLOSE(2000/Metric::Time, well->getInjectionProperties(1).surfaceInjectionRate, 0.001);
     }

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -485,7 +485,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     BOOST_CHECK( sched->hasGroup( "OP" ));
 
     {
-        GroupPtr group = sched->getGroup("INJ");
+        auto* group = sched->getGroup("INJ");
         BOOST_CHECK_EQUAL( Phase::WATER , group->getInjectionPhase( 3 ));
         BOOST_CHECK_EQUAL( GroupInjection::VREP , group->getInjectionControlMode( 3 ));
         BOOST_CHECK_CLOSE( 10/Metric::Time , group->getSurfaceMaxRate( 3 ) , 0.001);
@@ -501,7 +501,7 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     }
 
     {
-        GroupPtr group = sched->getGroup("OP");
+        auto* group = sched->getGroup("OP");
         BOOST_CHECK_EQUAL( GroupProduction::ORAT , group->getProductionControlMode(3));
         BOOST_CHECK_CLOSE( 10/Metric::Time , group->getOilTargetRate(3) , 0.001);
         BOOST_CHECK_CLOSE( 20/Metric::Time , group->getWaterTargetRate(3) , 0.001);
@@ -522,8 +522,8 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>(10,10,3);
     SchedulePtr sched( new Schedule(parseContext , grid , deck));
 
-    GroupPtr group1 = sched->getGroup("GROUP1");
-    GroupPtr group2 = sched->getGroup("GROUP2");
+    auto* group1 = sched->getGroup("GROUP1");
+    auto* group2 = sched->getGroup("GROUP2");
 
     BOOST_CHECK( group1->hasBeenDefined(0) );
     BOOST_CHECK_EQUAL(false , group2->hasBeenDefined(0));

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -98,9 +98,9 @@ BOOST_AUTO_TEST_CASE(WellTestRefDepth) {
     SchedulePtr sched(new Schedule(parseContext , grid , deck ));
     BOOST_CHECK_EQUAL(4, 4);
 
-    WellPtr well1 = sched->getWell("W_1");
-    WellPtr well2 = sched->getWell("W_2");
-    WellPtr well4 = sched->getWell("W_4");
+    auto* well1 = sched->getWell("W_1");
+    auto* well2 = sched->getWell("W_2");
+    auto* well4 = sched->getWell("W_4");
     BOOST_CHECK_EQUAL( well1->getRefDepth() , grid->getCellDepth( 29 , 36 , 0 ));
     BOOST_CHECK_EQUAL( well2->getRefDepth() , 100 );
     BOOST_CHECK_THROW( well4->getRefDepth() , std::invalid_argument );
@@ -161,7 +161,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
     BOOST_CHECK(sched->hasWell("W_3"));
 
     {
-        WellPtr well2 = sched->getWell("W_2");
+        auto* well2 = sched->getWell("W_2");
         BOOST_CHECK_EQUAL( 0 , well2->getProductionPropertiesCopy(2).ResVRate);
         BOOST_CHECK_CLOSE( 777/Metric::Time , well2->getProductionPropertiesCopy(7).ResVRate , 0.0001);
         BOOST_CHECK_EQUAL( 0 , well2->getProductionPropertiesCopy(8).ResVRate);
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
 
 
     {
-        WellPtr well3 = sched->getWell("W_3");
+        auto* well3 = sched->getWell("W_3");
 
         BOOST_CHECK_EQUAL( WellCommon::AUTO , well3->getStatus(3));
         BOOST_CHECK_EQUAL( 0 , well3->getProductionPropertiesCopy(2).LiquidRate);
@@ -195,7 +195,7 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
     }
 
     {
-        WellPtr well1 = sched->getWell("W_1");
+        auto* well1 = sched->getWell("W_1");
 
         BOOST_CHECK(well1->getProductionPropertiesCopy(0).predictionMode);
         BOOST_CHECK_EQUAL(0, well1->getProductionPropertiesCopy(0).OilRate);
@@ -286,7 +286,7 @@ BOOST_AUTO_TEST_CASE(WellTestCOMPDAT) {
     BOOST_CHECK(sched->hasWell("W_2"));
     BOOST_CHECK(sched->hasWell("W_3"));
     {
-        WellPtr well1 = sched->getWell("W_1");
+        auto* well1 = sched->getWell("W_1");
         BOOST_CHECK_CLOSE(13000/Metric::Time , well1->getProductionPropertiesCopy(8).OilRate , 0.0001);
         CompletionSetConstPtr completions = well1->getCompletions(0);
         BOOST_CHECK_EQUAL(0U, completions->size());
@@ -556,19 +556,19 @@ BOOST_AUTO_TEST_CASE(WellTestWELSPECSDataLoaded) {
     BOOST_CHECK(sched->hasWell("W_2"));
     BOOST_CHECK(sched->hasWell("W_3"));
     {
-        WellConstPtr well1 = sched->getWell("W_1");
+        const auto* well1 = sched->getWell("W_1");
         BOOST_CHECK(!well1->hasBeenDefined(2));
         BOOST_CHECK(well1->hasBeenDefined(3));
         BOOST_CHECK_EQUAL(29, well1->getHeadI());
         BOOST_CHECK_EQUAL(36, well1->getHeadJ());
 
-        WellConstPtr well2 = sched->getWell("W_2");
+        const auto* well2 = sched->getWell("W_2");
         BOOST_CHECK(!well2->hasBeenDefined(2));
         BOOST_CHECK(well2->hasBeenDefined(3));
         BOOST_CHECK_EQUAL(19, well2->getHeadI());
         BOOST_CHECK_EQUAL(50, well2->getHeadJ());
 
-        WellConstPtr well3 = sched->getWell("W_3");
+        const auto* well3 = sched->getWell("W_3");
         BOOST_CHECK(!well3->hasBeenDefined(2));
         BOOST_CHECK(well3->hasBeenDefined(3));
         BOOST_CHECK_EQUAL(30, well3->getHeadI());
@@ -603,7 +603,7 @@ BOOST_AUTO_TEST_CASE(WellTestWELOPENControlsSet) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10,10,10 );
     SchedulePtr sched(new Schedule(grid , deck));
 
-    WellConstPtr well1 = sched->getWell("W_1");
+    const auto* well1 = sched->getWell("W_1");
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, sched->getWell("W_1")->getStatus(0));
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, sched->getWell("W_1")->getStatus(1));
     BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, sched->getWell("W_1")->getStatus(2));
@@ -623,19 +623,19 @@ BOOST_AUTO_TEST_CASE(WellTestWGRUPCONWellPropertiesSet) {
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 10,10,10 );
     SchedulePtr sched(new Schedule(parseContext , grid , deck));
 
-    WellConstPtr well1 = sched->getWell("W_1");
+    const auto* well1 = sched->getWell("W_1");
     BOOST_CHECK(well1->isAvailableForGroupControl(0));
     BOOST_CHECK_EQUAL(-1, well1->getGuideRate(0));
     BOOST_CHECK_EQUAL(GuideRate::OIL, well1->getGuideRatePhase(0));
     BOOST_CHECK_EQUAL(1.0, well1->getGuideRateScalingFactor(0));
 
-    WellConstPtr well2 = sched->getWell("W_2");
+    const auto* well2 = sched->getWell("W_2");
     BOOST_CHECK(!well2->isAvailableForGroupControl(0));
     BOOST_CHECK_EQUAL(-1, well2->getGuideRate(0));
     BOOST_CHECK_EQUAL(GuideRate::UNDEFINED, well2->getGuideRatePhase(0));
     BOOST_CHECK_EQUAL(1.0, well2->getGuideRateScalingFactor(0));
 
-    WellConstPtr well3 = sched->getWell("W_3");
+    const auto* well3 = sched->getWell("W_3");
     BOOST_CHECK(well3->isAvailableForGroupControl(0));
     BOOST_CHECK_EQUAL(100, well3->getGuideRate(0));
     BOOST_CHECK_EQUAL(GuideRate::RAT, well3->getGuideRatePhase(0));
@@ -661,7 +661,7 @@ COMPDAT \n\
     DeckPtr deck =  parser->parseString(deckString, parseContext);
     std::shared_ptr<const EclipseGrid> grid = std::make_shared<const EclipseGrid>( 30,30,10 );
     SchedulePtr sched(new Schedule(parseContext , grid , deck));
-    WellConstPtr well = sched->getWell("W1");
+    const auto* well = sched->getWell("W1");
     CompletionSetConstPtr completions = well->getCompletions(0);
     BOOST_CHECK_EQUAL( 10 , completions->get(0)->getI() );
     BOOST_CHECK_EQUAL( 20 , completions->get(0)->getJ() );
@@ -692,9 +692,9 @@ BOOST_AUTO_TEST_CASE(WELLS_SHUT) {
     SchedulePtr sched(new Schedule(parseContext , grid , deck));
 
 
-    WellConstPtr well1 = sched->getWell("W1");
-    WellConstPtr well2 = sched->getWell("W2");
-    WellConstPtr well3 = sched->getWell("W3");
+    const auto* well1 = sched->getWell("W1");
+    const auto* well2 = sched->getWell("W2");
+    const auto* well3 = sched->getWell("W3");
 
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::OPEN , well1->getStatus(1));
     BOOST_CHECK_EQUAL( WellCommon::StatusEnum::OPEN , well2->getStatus(1));
@@ -720,7 +720,7 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
     BOOST_CHECK(sched->hasWell("INJE01"));
     BOOST_CHECK(sched->hasWell("PROD01"));
 
-    WellConstPtr well1 = sched->getWell("INJE01");
+    const auto* well1 = sched->getWell("INJE01");
     BOOST_CHECK( well1->isInjector(0));
     {
         const WellPolymerProperties& props_well10 = well1->getPolymerProperties(0);
@@ -731,7 +731,7 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
         BOOST_CHECK_CLOSE(0.1*Metric::PolymerDensity, props_well12.m_polymerConcentration, 0.0001);
     }
 
-    WellConstPtr well2 = sched->getWell("INJE02");
+    const auto* well2 = sched->getWell("INJE02");
     BOOST_CHECK( well2->isInjector(0));
     {
         const WellPolymerProperties& props_well20 = well2->getPolymerProperties(0);
@@ -742,7 +742,7 @@ BOOST_AUTO_TEST_CASE(WellTestWPOLYMER) {
         BOOST_CHECK_CLOSE(0.2*Metric::PolymerDensity, props_well22.m_polymerConcentration, 0.0001);
     }
 
-    WellConstPtr well3 = sched->getWell("INJE03");
+    const auto* well3 = sched->getWell("INJE03");
     BOOST_CHECK( well3->isInjector(0));
     {
         const WellPolymerProperties& props_well30 = well3->getPolymerProperties(0);


### PR DESCRIPTION
I'm doing some work on output that works with the parser, and I keep finding issues with the parser interface.

This patch set smooths some of the edges in the `Schedule` interface by making `Well` and `Group`-functions have uniform behaviour w.r.t. types. Since this soft-breaks the interface anyway, it's about time to retire `WellPtr` and friends.

Ideally I'd make the Well communication here a reference right away, but that would mean a lot of `->` to `.` changes, which is work for another day. By removing the ownership sharing (which was a ruse) from the interface, replacing `shared_ptr` with raw pointers, little changes in client code.