### PR TITLE
use boost::regex unconditionally

### DIFF
--- a/opm/parser/eclipse/Parser/ParserKeyword.cpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.cpp
@@ -527,11 +527,7 @@ namespace Opm {
 
     void ParserKeyword::setMatchRegex(const std::string& deckNameRegexp) {
         try {
-#ifdef HAVE_REGEX
-            m_matchRegex = std::regex(deckNameRegexp, std::regex::extended);
-#else
             m_matchRegex = boost::regex(deckNameRegexp);
-#endif
             m_matchRegexString = deckNameRegexp;
         }
         catch (const std::exception &e) {
@@ -551,11 +547,7 @@ namespace Opm {
             return true;
 
         else if (hasMatchRegex()) {
-#ifdef HAVE_REGEX
-            return std::regex_match( name.begin(), name.end(), m_matchRegex);
-#else
             return boost::regex_match( name.begin(), name.end(), m_matchRegex);
-#endif
         }
 
         return false;

--- a/opm/parser/eclipse/Parser/ParserKeyword.hpp
+++ b/opm/parser/eclipse/Parser/ParserKeyword.hpp
@@ -23,11 +23,7 @@
 #include <memory>
 #include <set>
 
-#ifdef HAVE_REGEX
-#include <regex>
-#else
 #include <boost/regex.hpp>
-#endif
 
 #include <opm/parser/eclipse/EclipseState/Util/RecordVector.hpp>
 #include <opm/parser/eclipse/Parser/ParserEnums.hpp>
@@ -113,11 +109,7 @@ namespace Opm {
         DeckNameSet m_deckNames;
         DeckNameSet m_validSectionNames;
         std::string m_matchRegexString;
-#ifdef HAVE_REGEX
-        std::regex m_matchRegex;
-#else
         boost::regex m_matchRegex;
-#endif
         RecordVector<std::shared_ptr< ParserRecord >> m_records;
         enum ParserKeywordSizeEnum m_keywordSizeType;
         size_t m_fixedSize;


### PR DESCRIPTION
this fixes OPM/opm-simulators#702. which turned out to be a quirk of the
build system which is due to the fact that opm-parser likes to do some
things differently than the rest of OPM. (in this case the culprit was
that it does not generate a `config.h` file which resulted in the
HAVE_REGEX macro to be different between opm-parser and downstream
which in turn causes the ABI to be incompatible.)

Note that it would be nice to use `std::regex` instead of Boost, but
this is currently blocked by the requirement that the oldest supported
compiler is GCC 4.8. (GCC 4.8 only provides a stub implementation of
`std::regex`.)