### PR TITLE
Minor refactor. Changed shared_ptr to references in EclipseState and related objects

### DIFF
--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -24,17 +24,13 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
-#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/BoxManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/parser/eclipse/Units/Dimension.hpp>
-#include <opm/parser/eclipse/Units/UnitSystem.hpp>
 #include <opm/parser/eclipse/Utility/String.hpp>
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013 Statoil ASA.
+  Copyright 2016  Statoil ASA.
 
   This file is part of the Open Porous Media project (OPM).
 

--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
@@ -19,9 +19,8 @@
 #ifndef OPM_ECLIPSE_PROPERTIES_HPP
 #define OPM_ECLIPSE_PROPERTIES_HPP
 
-#include <utility>
-#include <memory>
-#include <set>
+#include <vector>
+#include <string>
 
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
@@ -36,13 +35,8 @@ namespace Opm {
     class DeckKeyword;
     class DeckRecord;
     class EclipseGrid;
-    class EclipseState;
-    class InitConfig;
-    class IOConfig;
-    class Schedule;
     class Section;
     class TableManager;
-    class TransMult;
     class UnitSystem;
 
     /// Class representing properties on 3D grid for use in EclipseState.

--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
@@ -1,5 +1,5 @@
 /*
-  Copyright 2013 Statoil ASA.
+  Copyright 2016  Statoil ASA.
 
   This file is part of the Open Porous Media project (OPM).
 
@@ -22,9 +22,13 @@
 #include <vector>
 #include <string>
 
-#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Deck/DeckItem.hpp>
+#include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp>
-#include <opm/parser/eclipse/Parser/MessageContainer.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -207,7 +207,7 @@ namespace Opm {
 
 
 
-    void EclipseState::setMULTFLT(const Section section) {
+    void EclipseState::setMULTFLT(const Section& section) {
         for (size_t index=0; index < section.count("MULTFLT"); index++) {
             const auto& faultsKeyword = section.getKeyword("MULTFLT" , index);
             for (auto iter = faultsKeyword.begin(); iter != faultsKeyword.end(); ++iter) {

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -76,7 +76,12 @@ namespace Opm {
 
         initTransMult();
         initFaults(deck);
-        initMULTREGT(deck);
+
+        std::vector< const DeckKeyword* > multregtKeywords;
+        if (deck.hasKeyword("MULTREGT"))
+            multregtKeywords = deck.getKeywordList("MULTREGT");
+        m_transMult->createMultregtScanner(m_eclipseProperties, multregtKeywords);
+
 
         m_messageContainer.appendMessages(m_tables.getMessageContainer());
         m_messageContainer.appendMessages(m_schedule->getMessageContainer());
@@ -188,15 +193,13 @@ namespace Opm {
     }
 
     void EclipseState::initFaults(const Deck& deck) {
-        EclipseGridConstPtr grid = getInputGrid();
-        std::shared_ptr<GRIDSection> gridSection = std::make_shared<GRIDSection>( deck );
+        const GRIDSection gridSection ( deck );
 
-        m_faults = FaultCollection(gridSection, grid);
+        m_faults = FaultCollection(gridSection, *m_inputGrid);
         setMULTFLT(gridSection);
 
         if (Section::hasEDIT(deck)) {
-            std::shared_ptr<EDITSection> editSection = std::make_shared<EDITSection>( deck );
-            setMULTFLT(editSection);
+            setMULTFLT(EDITSection ( deck ));
         }
 
         m_transMult->applyMULTFLT( m_faults );
@@ -204,9 +207,9 @@ namespace Opm {
 
 
 
-    void EclipseState::setMULTFLT(std::shared_ptr<const Section> section) {
-        for (size_t index=0; index < section->count("MULTFLT"); index++) {
-            const auto& faultsKeyword = section->getKeyword("MULTFLT" , index);
+    void EclipseState::setMULTFLT(const Section section) {
+        for (size_t index=0; index < section.count("MULTFLT"); index++) {
+            const auto& faultsKeyword = section.getKeyword("MULTFLT" , index);
             for (auto iter = faultsKeyword.begin(); iter != faultsKeyword.end(); ++iter) {
 
                 const auto& faultRecord = *iter;
@@ -218,26 +221,6 @@ namespace Opm {
         }
     }
 
-
-
-    void EclipseState::initMULTREGT(const Deck& deck) {
-        EclipseGridConstPtr grid = getInputGrid();
-
-        std::vector< const DeckKeyword* > multregtKeywords;
-        if (deck.hasKeyword("MULTREGT"))
-            multregtKeywords = deck.getKeywordList("MULTREGT");
-
-        std::shared_ptr<MULTREGTScanner> scanner =
-            std::make_shared<MULTREGTScanner>(
-                m_eclipseProperties,
-                multregtKeywords ,
-                m_eclipseProperties.getDefaultRegionKeyword());
-
-        m_transMult->setMultregtScanner( scanner );
-    }
-
-
-
     void EclipseState::complainAboutAmbiguousKeyword(const Deck& deck, const std::string& keywordName) {
         m_messageContainer.error("The " + keywordName + " keyword must be unique in the deck. Ignoring all!");
         auto keywords = deck.getKeywordList(keywordName);
@@ -247,6 +230,7 @@ namespace Opm {
         }
     }
 
+    /// [deprecated]
     void EclipseState::applyModifierDeck(std::shared_ptr<const Deck> deckptr) {
         applyModifierDeck(*deckptr);
     }

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -32,6 +32,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
@@ -52,7 +53,6 @@ namespace Opm {
     class InitConfig;
     class IOConfig;
     class ParseContext;
-    class Schedule;
     class Section;
     class SimulationConfig;
     class TableManager;
@@ -116,8 +116,7 @@ namespace Opm {
         void initTransMult();
         void initFaults(const Deck& deck);
 
-        void setMULTFLT(std::shared_ptr<const Opm::Section> section);
-        void initMULTREGT(const Deck& deck);
+        void setMULTFLT(const Opm::Section section);
 
         void complainAboutAmbiguousKeyword(const Deck& deck,
                                            const std::string& keywordName);

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -21,19 +21,12 @@
 #define OPM_ECLIPSE_STATE_HPP
 
 #include <memory>
-#include <set>
-#include <utility>
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -53,6 +46,7 @@ namespace Opm {
     class InitConfig;
     class IOConfig;
     class ParseContext;
+    class Schedule;
     class Section;
     class SimulationConfig;
     class TableManager;
@@ -116,7 +110,7 @@ namespace Opm {
         void initTransMult();
         void initFaults(const Deck& deck);
 
-        void setMULTFLT(const Opm::Section section);
+        void setMULTFLT(const Opm::Section& section);
 
         void complainAboutAmbiguousKeyword(const Deck& deck,
                                            const std::string& keywordName);

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -51,15 +51,15 @@ namespace Opm {
                 const auto& faultRecord = *iter;
                 const std::string& faultName = faultRecord.getItem(0).get< std::string >(0);
 
-                initFault(grid, faultRecord, faultName);
+                addFaultFaces(grid, faultRecord, faultName);
             }
         }
     }
 
 
-    void FaultCollection::initFault(const EclipseGrid& grid,
-                                    const DeckRecord& faultRecord,
-                                    const std::string& faultName)
+    void FaultCollection::addFaultFaces(const EclipseGrid& grid,
+                                        const DeckRecord& faultRecord,
+                                        const std::string& faultName)
     {
         int I1 = faultRecord.getItem(1).get<int>(0) - 1;
         int I2 = faultRecord.getItem(2).get<int>(0) - 1;

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -17,7 +17,11 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <stdexcept>
+
+#include <iterator>
+#include <memory>
+#include <string>
+#include <vector>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
@@ -33,40 +37,49 @@
 
 namespace Opm {
 
+
     FaultCollection::FaultCollection()
     {}
 
-
-    FaultCollection::FaultCollection( std::shared_ptr<const GRIDSection> deck, std::shared_ptr<const EclipseGrid> grid) {
-        const auto& faultKeywords = deck->getKeywordList<ParserKeywords::FAULTS>();
+    FaultCollection::FaultCollection(const GRIDSection& gridSection,
+                                     const EclipseGrid& grid) {
+        const auto& faultKeywords = gridSection.getKeywordList<ParserKeywords::FAULTS>();
 
         for (auto keyword_iter = faultKeywords.begin(); keyword_iter != faultKeywords.end(); ++keyword_iter) {
             const auto& faultsKeyword = *keyword_iter;
             for (auto iter = faultsKeyword->begin(); iter != faultsKeyword->end(); ++iter) {
                 const auto& faultRecord = *iter;
                 const std::string& faultName = faultRecord.getItem(0).get< std::string >(0);
-                int I1 = faultRecord.getItem(1).get< int >(0) - 1;
-                int I2 = faultRecord.getItem(2).get< int >(0) - 1;
-                int J1 = faultRecord.getItem(3).get< int >(0) - 1;
-                int J2 = faultRecord.getItem(4).get< int >(0) - 1;
-                int K1 = faultRecord.getItem(5).get< int >(0) - 1;
-                int K2 = faultRecord.getItem(6).get< int >(0) - 1;
-                FaceDir::DirEnum faceDir = FaceDir::FromString( faultRecord.getItem(7).get< std::string >(0) );
-                std::shared_ptr<const FaultFace> face = std::make_shared<const FaultFace>(grid->getNX() , grid->getNY() , grid->getNZ(),
-                                                                                          static_cast<size_t>(I1) , static_cast<size_t>(I2) ,
-                                                                                          static_cast<size_t>(J1) , static_cast<size_t>(J2) ,
-                                                                                          static_cast<size_t>(K1) , static_cast<size_t>(K2) ,
-                                                                                          faceDir);
-                if (!hasFault(faultName)) {
-                    addFault( faultName );
-                }
 
-                {
-                    Fault& fault = getFault( faultName );
-                    fault.addFace( face );
-                }
+                initFault(grid, faultRecord, faultName);
             }
         }
+    }
+
+
+    void FaultCollection::initFault(const EclipseGrid& grid,
+                                    const DeckRecord& faultRecord,
+                                    const std::string& faultName)
+    {
+        int I1 = faultRecord.getItem(1).get<int>(0) - 1;
+        int I2 = faultRecord.getItem(2).get<int>(0) - 1;
+        int J1 = faultRecord.getItem(3).get<int>(0) - 1;
+        int J2 = faultRecord.getItem(4).get<int>(0) - 1;
+        int K1 = faultRecord.getItem(5).get<int>(0) - 1;
+        int K2 = faultRecord.getItem(6).get<int>(0) - 1;
+        FaceDir::DirEnum faceDir = FaceDir::FromString(faultRecord.getItem(7).get<std::string>(0));
+        std::shared_ptr<const FaultFace> face = std::make_shared<const FaultFace>(
+                        grid.getNX(), grid.getNY(), grid.getNZ(),
+                        static_cast<size_t>(I1), static_cast<size_t>(I2),
+                        static_cast<size_t>(J1), static_cast<size_t>(J2),
+                        static_cast<size_t>(K1), static_cast<size_t>(K2),
+                        faceDir);
+
+        if (!hasFault(faultName))
+            addFault(faultName);
+
+        Fault& fault = getFault(faultName);
+        fault.addFace(face);
     }
 
     size_t FaultCollection::size() const {

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -16,8 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FAULT_COLLECTION_HPP_
-#define FAULT_COLLECTION_HPP_
+#ifndef OPM_PARSER_FAULT_COLLECTION_HPP
+#define OPM_PARSER_FAULT_COLLECTION_HPP
 
 #include <cstddef>
 #include <string>
@@ -29,8 +29,7 @@
 
 namespace Opm {
 
-    class Deck;
-    class GRIDSection;
+    class DeckRecord;
     class EclipseGrid;
     class GRIDSection;
 
@@ -38,7 +37,7 @@ namespace Opm {
 class FaultCollection {
 public:
     FaultCollection();
-    FaultCollection( std::shared_ptr<const GRIDSection> deck, std::shared_ptr<const EclipseGrid> grid);
+    FaultCollection(const GRIDSection& gridSection, const EclipseGrid& grid);
 
     size_t size() const;
     bool hasFault(const std::string& faultName) const;
@@ -52,9 +51,12 @@ public:
     void setTransMult(const std::string& faultName , double transMult);
 
 private:
+    void initFault(const EclipseGrid& grid,
+                   const DeckRecord&  faultRecord,
+                   const std::string& faultName);
     OrderedMap<Fault> m_faults;
+
 };
 }
 
-
-#endif
+#endif // OPM_PARSER_FAULT_COLLECTION_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp
@@ -51,9 +51,9 @@ public:
     void setTransMult(const std::string& faultName , double transMult);
 
 private:
-    void initFault(const EclipseGrid& grid,
-                   const DeckRecord&  faultRecord,
-                   const std::string& faultName);
+    void addFaultFaces(const EclipseGrid& grid,
+                       const DeckRecord&  faultRecord,
+                       const std::string& faultName);
     OrderedMap<Fault> m_faults;
 
 };

--- a/opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp
@@ -16,8 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#ifndef FAULT_FACE_HPP_
-#define FAULT_FACE_HPP_
+#ifndef OPM_PARSER_FAULT_FACE_HPP
+#define OPM_PARSER_FAULT_FACE_HPP
 
 #include <cstddef>
 #include <vector>
@@ -48,4 +48,4 @@ private:
 
 }
 
-#endif
+#endif // OPM_PARSER_FAULT_FACE_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.cpp
@@ -127,17 +127,16 @@ namespace Opm {
       Then it will go through the different regions and looking for
       interface with the wanted region values.
     */
-    MULTREGTScanner::MULTREGTScanner(const Eclipse3DProperties& cellRegionNumbers,
-    		                         const std::vector< const DeckKeyword* >& keywords,
-									 const std::string& defaultRegion ) :
-        m_cellRegionNumbers(cellRegionNumbers) {
+    MULTREGTScanner::MULTREGTScanner(const Eclipse3DProperties& e3DProps,
+                                     const std::vector< const DeckKeyword* >& keywords) :
+                m_e3DProps(e3DProps) {
 
         for (size_t idx = 0; idx < keywords.size(); idx++)
-            this->addKeyword(*keywords[idx] , defaultRegion);
+            this->addKeyword(*keywords[idx] , e3DProps.getDefaultRegionKeyword());
 
         MULTREGTSearchMap searchPairs;
         for (std::vector<MULTREGTRecord>::const_iterator record = m_records.begin(); record != m_records.end(); ++record) {
-            if (cellRegionNumbers.hasDeckIntGridProperty( record->m_region.getValue())) {
+            if (e3DProps.hasDeckIntGridProperty( record->m_region.getValue())) {
                 if (record->m_srcRegion.hasValue() && record->m_targetRegion.hasValue()) {
                     int srcRegion    = record->m_srcRegion.getValue();
                     int targetRegion = record->m_targetRegion.getValue();
@@ -148,9 +147,11 @@ namespace Opm {
                 }
             }
             else
-                throw std::logic_error("MULTREGT record is based on region: " + record->m_region.getValue() + " which is not in the deck");
+                throw std::logic_error(
+                                "MULTREGT record is based on region: "
+                              +  record->m_region.getValue()
+                              + " which is not in the deck");
         }
-
 
         for (auto iter = searchPairs.begin(); iter != searchPairs.end(); ++iter) {
             const MULTREGTRecord * record = (*iter).second;
@@ -161,8 +162,6 @@ namespace Opm {
 
             m_searchMap[keyword][pair] = record;
         }
-
-
     }
 
 
@@ -235,7 +234,7 @@ namespace Opm {
     double MULTREGTScanner::getRegionMultiplier(size_t globalIndex1 , size_t globalIndex2, FaceDir::DirEnum faceDir) const {
 
         for (auto iter = m_searchMap.begin(); iter != m_searchMap.end(); iter++) {
-            const Opm::GridProperty<int>& region = m_cellRegionNumbers.getIntGridProperty( (*iter).first );
+            const Opm::GridProperty<int>& region = m_e3DProps.getIntGridProperty( (*iter).first );
             MULTREGTSearchMap map = (*iter).second;
 
             int regionId1 = region.iget(globalIndex1);

--- a/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp
@@ -18,8 +18,8 @@
 */
 
 
-#ifndef MULTREGTSCANNER_HPP
-#define MULTREGTSCANNER_HPP
+#ifndef OPM_PARSER_MULTREGTSCANNER_HPP
+#define OPM_PARSER_MULTREGTSCANNER_HPP
 
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
@@ -70,9 +70,8 @@ namespace Opm {
     class MULTREGTScanner {
 
     public:
-        MULTREGTScanner(const Eclipse3DProperties& cellRegionNumbers,
-        		        const std::vector< const DeckKeyword* >& keywords,
-						const std::string& defaultRegion);
+        MULTREGTScanner(const Eclipse3DProperties& e3DProps,
+                        const std::vector< const DeckKeyword* >& keywords);
         double getRegionMultiplier(size_t globalCellIdx1, size_t globalCellIdx2, FaceDir::DirEnum faceDir) const;
 
     private:
@@ -80,9 +79,9 @@ namespace Opm {
         void assertKeywordSupported(const DeckKeyword& deckKeyword, const std::string& defaultRegion);
         std::vector< MULTREGTRecord > m_records;
         std::map<std::string , MULTREGTSearchMap> m_searchMap;
-        const Eclipse3DProperties& m_cellRegionNumbers;
+        const Eclipse3DProperties& m_e3DProps;
     };
 
 }
 
-#endif
+#endif // OPM_PARSER_MULTREGTSCANNER_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.cpp
@@ -16,15 +16,16 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
-#include <stdexcept>
-#include <iostream>
 
-#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <stdexcept>
+
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultFace.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
+
 
 namespace Opm {
 
@@ -78,7 +79,9 @@ namespace Opm {
     }
 
     double TransMult::getRegionMultiplier(size_t globalCellIndex1,  size_t globalCellIndex2, FaceDir::DirEnum faceDir) const {
-            return m_multregtScanner->getRegionMultiplier(globalCellIndex1, globalCellIndex2, faceDir);
+        if (m_multregtScanner == nullptr)
+            throw new std::logic_error("MULTREGTScanner has not been initialized.");
+        return m_multregtScanner->getRegionMultiplier(globalCellIndex1, globalCellIndex2, faceDir);
     }
 
     bool TransMult::hasDirectionProperty(FaceDir::DirEnum faceDir) const {
@@ -134,7 +137,8 @@ namespace Opm {
 
 
 
-    void TransMult::setMultregtScanner( std::shared_ptr<const MULTREGTScanner> multregtScanner) {
-        m_multregtScanner = multregtScanner;
+    void TransMult::createMultregtScanner(const Eclipse3DProperties& e3DProps,
+                                          std::vector< const DeckKeyword* > multregtKeywords) {
+        m_multregtScanner = new MULTREGTScanner(e3DProps, multregtKeywords);
     }
 }

--- a/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
@@ -26,8 +26,8 @@
       {MULTX , MULTX- , MULTY , MULTY- , MULTZ , MULTZ-, MULTFLT , MULTREGT}
 
 */
-#ifndef TRANSMULT_HPP
-#define TRANSMULT_HPP
+#ifndef OPM_PARSER_TRANSMULT_HPP
+#define OPM_PARSER_TRANSMULT_HPP
 
 
 #include <cstddef>
@@ -35,13 +35,12 @@
 #include <memory>
 
 #include <opm/parser/eclipse/EclipseState/Grid/FaceDir.hpp>
-
+#include <opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 
 namespace Opm {
     template< typename > class GridProperty;
     class Fault;
     class FaultCollection;
-    class MULTREGTScanner;
 
     class TransMult {
 
@@ -53,7 +52,8 @@ namespace Opm {
         void applyMULT(const GridProperty<double>& srcMultProp, FaceDir::DirEnum faceDir);
         void applyMULTFLT(const FaultCollection& faults);
         void applyMULTFLT(const Fault& fault);
-        void setMultregtScanner(std::shared_ptr<const MULTREGTScanner> multregtScanner);
+        void createMultregtScanner(const Eclipse3DProperties& e3DProps,
+                                   std::vector<const DeckKeyword*> multregtKeywords);
 
     private:
         size_t getGlobalIndex(size_t i , size_t j , size_t k) const;
@@ -66,9 +66,9 @@ namespace Opm {
         size_t m_nx , m_ny , m_nz;
         std::map<FaceDir::DirEnum , GridProperty<double> > m_trans;
         std::map<FaceDir::DirEnum , std::string> m_names;
-        std::shared_ptr<const MULTREGTScanner> m_multregtScanner;
+        MULTREGTScanner* m_multregtScanner = nullptr;
     };
 
 }
 
-#endif
+#endif // OPM_PARSER_TRANSMULT_HPP

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MULTREGTScannerTests.cpp
@@ -110,19 +110,19 @@ BOOST_AUTO_TEST_CASE(InvalidInput) {
     std::vector<const Opm::DeckKeyword*> keywords0;
     const auto& multregtKeyword0 = deck->getKeyword( "MULTREGT", 0 );
     keywords0.push_back( &multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0, "MULTNUM" ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0 ); , std::invalid_argument );
 
     // Not supported region
     std::vector<const Opm::DeckKeyword*> keywords1;
     const auto& multregtKeyword1 = deck->getKeyword( "MULTREGT", 1 );
     keywords1.push_back( &multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1, "MULTNUM" ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1 ); , std::invalid_argument );
 
     // The keyword is ok; but it refers to a region which is not in the deck.
     std::vector<const Opm::DeckKeyword*> keywords2;
     const auto& multregtKeyword2 = deck->getKeyword( "MULTREGT", 2 );
     keywords2.push_back( &multregtKeyword2 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords2, "MULTNUM" ); , std::logic_error );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords2 ); , std::logic_error );
 }
 
 
@@ -175,26 +175,26 @@ BOOST_AUTO_TEST_CASE(NotSupported) {
     std::vector<const Opm::DeckKeyword*> keywords0;
     const auto& multregtKeyword0 = deck->getKeyword( "MULTREGT", 0 );
     keywords0.push_back( &multregtKeyword0 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0, "MULTNUM" ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords0 ); , std::invalid_argument );
 
     // Defaulted from value - not supported
     std::vector<const Opm::DeckKeyword*> keywords1;
     const auto& multregtKeyword1 = deck->getKeyword( "MULTREGT", 1 );
     keywords1.push_back( &multregtKeyword1 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1, "MULTNUM" ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords1 ); , std::invalid_argument );
 
 
     // Defaulted to value - not supported
     std::vector<const Opm::DeckKeyword*> keywords2;
     const auto& multregtKeyword2 = deck->getKeyword( "MULTREGT", 2 );
     keywords2.push_back( &multregtKeyword2 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords2, "MULTNUM" ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords2 ); , std::invalid_argument );
 
     // srcValue == targetValue - not supported
     std::vector<const Opm::DeckKeyword*> keywords3;
     const Opm::DeckKeyword& multregtKeyword3 = deck->getKeyword( "MULTREGT", 3 );
     keywords3.push_back( &multregtKeyword3 );
-    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords3, "MULTNUM" ); , std::invalid_argument );
+    BOOST_CHECK_THROW( Opm::MULTREGTScanner scanner( props, keywords3 ); , std::invalid_argument );
 }
 
 static Opm::DeckPtr createCopyMULTNUMDeck() {

--- a/opm/parser/eclipse/IntegrationTests/ResinsightTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ResinsightTest.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE( test_state ) {
     parser.addKeyword<ParserKeywords::GRID>();
     auto deck = parser.parseFile("testdata/integration_tests/Resinsight/DECK1.DATA" , parseContext);
 
-    auto grid = std::make_shared<EclipseGrid>( deck );
-    auto gsec = std::make_shared< GRIDSection >( *deck );
-    auto faults = std::make_shared<FaultCollection>( gsec, grid );
+    auto grid = std::make_shared<EclipseGrid>(deck);
+    GRIDSection gsec(*deck);
+    FaultCollection faults(gsec, *grid);
 }


### PR DESCRIPTION
In stabilizing the OPM-parser API, some minor modifications of internal parser API.

* removed unused `MULTREGTScanner` constructor argument
* removed `shared_ptr` usage in `MULTREGTScanner`
* reduced `shared_ptr` in `EclipseState` (`Section`, `GridSection`, `FaultCollection`, `TransMult`)
* some fixes in includes (removed unused, imported used, sorted)

We will soon remove shared pointers from the EclipseState API, but since that requires a larger synchronized PR, we will wait with that until the internal API seems more stable.  This PR contains just some of the internal modifications necessary that do not require downstream changes.