### PR TITLE
Added IOConfig::getOutputBase()

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -572,4 +572,15 @@ namespace Opm {
         m_base_name = baseName;
     }
 
+    std::string IOConfig::fullBasePath( ) const {
+        namespace fs = boost::filesystem;
+
+        fs::path dir( m_output_dir );
+        fs::path base( m_base_name );
+        fs::path full_path = dir / base;
+
+        return full_path.string();
+    }
+
+
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -161,6 +161,10 @@ namespace Opm {
         const std::string& getBaseName() const;
         void setBaseName(std::string baseName);
 
+        /// Return a string consisting of outputpath and basename;
+        /// i.e. /path/to/sim/CASE
+        std::string fullBasePath( ) const;
+
     private:
 
         IOConfig( const GRIDSection&,

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -909,4 +909,5 @@ BOOST_AUTO_TEST_CASE(OutputPaths) {
     config3.setOutputDir( output_dir3 );
     BOOST_CHECK_EQUAL( output_dir3,  config3.getOutputDir() );
     BOOST_CHECK_EQUAL( "testString", config3.getBaseName() );
+    BOOST_CHECK_EQUAL( "/path/to/testString" , config3.fullBasePath( ));
 }


### PR DESCRIPTION
The purpose of this PR is to get the combination of output path and basename as one variable; that can then be sent directly to e.g. the summary output routine.