### PR TITLE
Improved well properties interface

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -88,6 +88,33 @@ namespace Opm {
     }
 
 
+    double Well::production_rate( Phase::PhaseEnum phase, size_t timestep ) const {
+        if( !this->isProducer( timestep ) ) return 0.0;
+
+        const auto& p = this->getProductionProperties( timestep );
+
+        switch( phase ) {
+            case Phase::WATER: return p.WaterRate;
+            case Phase::OIL:   return p.OilRate;
+            case Phase::GAS:   return p.GasRate;
+        }
+
+        throw std::logic_error( "Unreachable state. Invalid PhaseEnum value. "
+                                "This is likely a programming error." );
+    }
+
+    double Well::injection_rate( Phase::PhaseEnum phase, size_t timestep ) const {
+        if( !this->isInjector( timestep ) ) return 0.0;
+
+        const auto& i = this->getInjectionProperties( timestep );
+        const auto type = i.injectorType;
+
+        if( phase == Phase::WATER && type != WellInjector::WATER ) return 0.0;
+        if( phase == Phase::OIL   && type != WellInjector::OIL   ) return 0.0;
+        if( phase == Phase::GAS   && type != WellInjector::GAS   ) return 0.0;
+
+        return i.surfaceInjectionRate;
+    }
 
     bool Well::setProductionProperties(size_t timeStep , const WellProductionProperties newProperties) {
         if (isInjector(timeStep))

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -79,6 +79,17 @@ namespace Opm {
         void addCompletionSet(size_t time_step, const std::shared_ptr< const CompletionSet > newCompletionSet);
         std::shared_ptr< const CompletionSet > getCompletions(size_t timeStep) const;
 
+        /* The rate of a given phase under the following assumptions:
+         * * Returns zero if production is requested for an injector (and vice
+         *   versa)
+         * * If this is an injector and something else than the
+         *   requested phase is injected, returns 0, i.e.
+         *   water_injector.injection_rate( gas ) == 0
+         * * Mixed injection is not supported and always returns 0.
+         */
+        double production_rate( Phase::PhaseEnum phase, size_t timestep ) const;
+        double injection_rate( Phase::PhaseEnum phase, size_t timestep ) const;
+
         bool                            setProductionProperties(size_t timeStep , const WellProductionProperties properties);
         WellProductionProperties        getProductionPropertiesCopy(size_t timeStep) const;
         const WellProductionProperties& getProductionProperties(size_t timeStep)  const;

--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -40,6 +40,7 @@ namespace {
      */
 
     static const double to_metric[] = {
+        1,
         1 / Metric::Length,
         1 / Metric::Time,
         1 / Metric::Density,
@@ -59,6 +60,7 @@ namespace {
     };
 
     static const double from_metric[] = {
+        1,
         Metric::Length,
         Metric::Time,
         Metric::Density,
@@ -78,6 +80,7 @@ namespace {
     };
 
     static const double to_field[] = {
+        1,
         1 / Field::Length,
         1 / Field::Time,
         1 / Field::Density,
@@ -97,6 +100,7 @@ namespace {
     };
 
     static const double from_field[] = {
+         1,
          Field::Length,
          Field::Time,
          Field::Density,

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -37,6 +37,7 @@ namespace Opm {
         };
 
         enum class measure : int {
+            identity,
             length,
             time,
             density,


### PR DESCRIPTION
Two convenince call for downstream users that allows querying well rates
with the assumption that if something is unsupported or of the wrong
type, return plain zero.

Adds the "identity" unit which is a no-op under to_si/from_si
conversion.

These are both features I find useful for downstream development.