### PR TITLE
Moved NOSIM handling to IOConfig + allow override.

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -230,6 +230,7 @@ namespace Opm {
                   RUNSPECSection( deck ),
                   SCHEDULESection( deck ),
                   std::make_shared< const TimeMap >( deck ),
+                  deck.hasKeyword("NOSIM"),
                   deck.getDataFile() )
     {}
 
@@ -268,6 +269,7 @@ namespace Opm {
                         const RUNSPECSection& runspec,
                         const SCHEDULESection& schedule,
                         std::shared_ptr< const TimeMap > timemap,
+                        bool nosim,
                         const std::string& input_path ) :
         m_timemap( timemap ),
         m_write_INIT_file( grid.hasKeyword( "INIT" ) ),
@@ -279,6 +281,7 @@ namespace Opm {
         m_deck_filename( input_path ),
         m_output_dir( outputdir( input_path ) ),
         m_base_name( basename( input_path ) ),
+        m_nosim( nosim  ),
         m_restart_output_config( std::make_shared< DynamicState< restartConfig > >(
                 rstconf( schedule, timemap ) ) )
     {}
@@ -439,6 +442,11 @@ namespace Opm {
         setWriteInitialRestartFile( interval > 0 );
     }
 
+    void IOConfig::overrideNOSIM(bool nosim) {
+        m_nosim = nosim;
+    }
+
+
     bool IOConfig::getUNIFIN() const {
         return m_UNIFIN;
     }
@@ -582,5 +590,9 @@ namespace Opm {
         return full_path.string();
     }
 
+
+    bool IOConfig::initOnly( ) const {
+        return m_nosim;
+    }
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -136,7 +136,7 @@ namespace Opm {
         const std::string& getEclipseInputPath() const;
 
         void overrideRestartWriteInterval(size_t interval);
-
+        void overrideNOSIM(bool nosim);
         void handleSolutionSection(std::shared_ptr< const TimeMap > timemap, std::shared_ptr<const SOLUTIONSection> solutionSection);
         void setWriteInitialRestartFile(bool writeInitialRestartFile);
 
@@ -165,12 +165,14 @@ namespace Opm {
         /// i.e. /path/to/sim/CASE
         std::string fullBasePath( ) const;
 
+        bool initOnly() const;
     private:
 
         IOConfig( const GRIDSection&,
                   const RUNSPECSection&,
                   const SCHEDULESection&,
                   std::shared_ptr< const TimeMap >,
+                  bool nosim,
                   const std::string& input_path );
 
         void assertTimeMap(std::shared_ptr< const TimeMap > timemap);
@@ -195,6 +197,7 @@ namespace Opm {
         bool            m_output_enabled = true;
         std::string     m_output_dir;
         std::string     m_base_name;
+        bool            m_nosim;
 
         struct restartConfig {
             /*

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -82,7 +82,6 @@ namespace Opm {
             m_timeMap( createTimeMap( deck ) ),
             m_grid( grid )
     {
-        initializeNOSIM(deck);
         m_tuning.reset(new Tuning(m_timeMap));
         m_events.reset(new Events(m_timeMap));
         m_modifierDeck.reset( new DynamicVector<std::shared_ptr<Deck> >( m_timeMap , std::shared_ptr<Deck>( 0 ) ));
@@ -113,13 +112,6 @@ namespace Opm {
         m_rootGroupTree.reset(new DynamicState<GroupTreePtr>(timeMap, GroupTreePtr(new GroupTree())));
     }
 
-    void Schedule::initializeNOSIM(const Deck& deck) {
-        if (deck.hasKeyword("NOSIM")){
-            nosim = true;
-        } else {
-            nosim = false;
-        }
-    }
 
     void Schedule::iterateScheduleSection(const ParseContext& parseContext , const SCHEDULESection& section ) {
         /*
@@ -216,9 +208,6 @@ namespace Opm {
 
             if (keyword.name() == "TUNING")
                 handleTUNING(keyword, currentStep);
-
-            if (keyword.name() == "NOSIM")
-                handleNOSIM();
 
             if (keyword.name() == "WRFT")
                 rftProperties.push_back( std::make_pair( &keyword , currentStep ));
@@ -1137,10 +1126,6 @@ namespace Opm {
     }
 
 
-    void Schedule::handleNOSIM() {
-        nosim = true;
-    }
-
     void Schedule::handleCOMPDAT( const DeckKeyword& keyword, size_t currentStep) {
         std::map<std::string , std::vector< CompletionPtr> > completionMapList = Completion::completionsFromCOMPDATKeyword( keyword );
         std::map<std::string , std::vector< CompletionPtr> >::iterator iter;
@@ -1418,9 +1403,6 @@ namespace Opm {
         return m_groups.find(groupName) != m_groups.end();
     }
 
-    bool Schedule::initOnly() const {
-        return nosim;
-    }
 
     const Group* Schedule::getGroup(const std::string& groupName) const {
         if (hasGroup(groupName)) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -84,7 +84,6 @@ namespace Opm
         std::vector< const Group* > getGroups() const;
         std::shared_ptr< Tuning > getTuning() const;
 
-        bool initOnly() const;
         const Events& getEvents() const;
         bool hasOilVaporizationProperties();
         std::shared_ptr<const Deck> getModifierDeck(size_t timeStep) const;
@@ -102,14 +101,12 @@ namespace Opm
         std::shared_ptr<Events> m_events;
         std::shared_ptr<DynamicVector<std::shared_ptr<Deck> > > m_modifierDeck;
         std::shared_ptr< Tuning > m_tuning;
-        bool nosim;
         MessageContainer m_messages;
 
 
         std::vector< Well* > getWells(const std::string& wellNamePattern);
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
-        void initializeNOSIM(const Deck& deck);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
         void initOilVaporization(std::shared_ptr< const TimeMap > timeMap);
         void iterateScheduleSection(const ParseContext& parseContext ,  const SCHEDULESection& );
@@ -136,7 +133,6 @@ namespace Opm
         void handleGCONPROD( const DeckKeyword& keyword, size_t currentStep);
         void handleGEFAC( const DeckKeyword& keyword, size_t currentStep);
         void handleTUNING( const DeckKeyword& keyword, size_t currentStep);
-        void handleNOSIM();
         void handleDATES( const DeckKeyword& keyword );
         void handleTSTEP( const DeckKeyword& keyword );
         void handleGRUPTREE( const DeckKeyword& keyword, size_t currentStep);


### PR DESCRIPTION
The IOConfig object is maybe not the perfect place for it - but that object is already mutable.

The purpose of this is to allow easier testing of INIT and EGRID files from flow, by allowing somthing like 'flow --nosim FILE.DATA'