### PR TITLE
[SummaryConfig] Refactoring & remove duplicate entries

### DIFF
--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -132,6 +132,14 @@ namespace Opm {
         m_dataFile("")
     {}
 
+    Deck::Deck( std::initializer_list< DeckKeyword > ilist ) :
+        Deck( std::vector< DeckKeyword >( ilist.begin(), ilist.end() ) )
+    {}
+
+    Deck::Deck( std::initializer_list< std::string > ilist ) :
+        Deck( std::vector< DeckKeyword >( ilist.begin(), ilist.end() ) )
+    {}
+
     void Deck::addKeyword( DeckKeyword&& keyword ) {
         this->keywordList.push_back( std::move( keyword ) );
 

--- a/opm/parser/eclipse/Deck/Deck.hpp
+++ b/opm/parser/eclipse/Deck/Deck.hpp
@@ -120,6 +120,8 @@ namespace Opm {
             using iterator = std::vector< DeckKeyword >::iterator;
 
             Deck();
+            Deck( std::initializer_list< DeckKeyword > );
+            Deck( std::initializer_list< std::string > );
             void addKeyword( DeckKeyword&& keyword );
             void addKeyword( const DeckKeyword& keyword );
 

--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -37,6 +37,18 @@ BOOST_AUTO_TEST_CASE(Initialize) {
     BOOST_REQUIRE_NO_THROW(DeckConstPtr deckConstPtr(new Deck()));
 }
 
+BOOST_AUTO_TEST_CASE(Initializer_lists) {
+    DeckKeyword foo( "foo" );
+    DeckKeyword bar( "bar" );
+
+    std::string foostr( "foo" );
+    std::string barstr( "bar" );
+
+    BOOST_REQUIRE_NO_THROW( Deck( { foo, bar } ) );
+    BOOST_REQUIRE_NO_THROW( Deck( { foostr, barstr } ) );
+    BOOST_REQUIRE_NO_THROW( Deck( { "Kappa", "Phi" } ) );
+}
+
 BOOST_AUTO_TEST_CASE(hasKeyword_empty_returnFalse) {
     Deck deck;
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("Bjarne"));

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -283,6 +283,21 @@ inline void handleKW( std::vector< ERT::smspec_node >& list,
     }
 }
 
+inline void uniq( std::vector< ERT::smspec_node >& vec ) {
+    const auto lt = []( const ERT::smspec_node& lhs,
+                        const ERT::smspec_node& rhs ) {
+        return std::strcmp( lhs.key1(), rhs.key1() ) < 0;
+    };
+    const auto eq = []( const ERT::smspec_node& lhs,
+                        const ERT::smspec_node& rhs ) {
+        return std::strcmp( lhs.key1(), rhs.key1() ) == 0;
+    };
+
+    std::sort( vec.begin(), vec.end(), lt );
+    auto logical_end = std::unique( vec.begin(), vec.end(), eq );
+    vec.erase( logical_end, vec.end() );
+}
+
 }
 
 SummaryConfig::SummaryConfig( const Deck& deck, const EclipseState& es , const ParseContext& parseContext)
@@ -305,6 +320,8 @@ SummaryConfig::SummaryConfig( const Deck& deck,
 
     if( section.hasKeyword( "ALL" ) )
         this->merge( { ALL_keywords, schedule, props, parseContext, n_xyz } );
+
+    uniq( this->keywords );
 }
 
 SummaryConfig::const_iterator SummaryConfig::begin() const {
@@ -319,6 +336,8 @@ SummaryConfig& SummaryConfig::merge( const SummaryConfig& other ) {
     this->keywords.insert( this->keywords.end(),
                             other.keywords.begin(),
                             other.keywords.end() );
+
+    uniq( this->keywords );
     return *this;
 }
 
@@ -328,6 +347,7 @@ SummaryConfig& SummaryConfig::merge( SummaryConfig&& other ) {
     this->keywords.insert( this->keywords.end(), begin, end );
     other.keywords.clear();
 
+    uniq( this->keywords );
     return *this;
 }
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -46,27 +46,23 @@
 
 namespace Opm {
 
-    const std::vector <std::string> SummaryConfig::__ALL_expands_keywords ({
-        "FAQR", "FAQRG", "FAQT", "FAQTG", "FGIP", "FGIPG", "FGIPL",
-        "FGIR", "FGIT", "FGOR", "FGPR", "FGPT", "FOIP", "FOIPG",
-        "FOIPL", "FOIR", "FOIT", "FOPR", "FOPT", "FPR", "FVIR",
-        "FVIT", "FVPR", "FVPT", "FWCT", "FWGR", "FWIP", "FWIR",
-        "FWIT", "FWPR", "FWPT",
-        "GGIR", "GGIT", "GGOR", "GGPR", "GGPT", "GOIR", "GOIT",
-        "GOPR", "GOPT", "GVIR", "GVIT", "GVPR", "GVPT", "GWCT",
-        "GWGR", "GWIR", "GWIT", "GWPR", "GWPT",
-        "WBHP", "WGIR", "WGIT", "WGOR", "WGPR", "WGPT", "WOIR",
-        "WOIT", "WOPR", "WOPT", "WPI", "WTHP", "WVIR", "WVIT",
-        "WVPR", "WVPT", "WWCT", "WWGR", "WWIR", "WWIT", "WWPR",
+namespace {
+    constexpr auto ALL_keywords =  {
+        "FAQR",  "FAQRG", "FAQT", "FAQTG", "FGIP", "FGIPG", "FGIPL",
+        "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
+        "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",
+        "FVIT",  "FVPR",  "FVPT", "FWCT",  "FWGR", "FWIP",  "FWIR",
+        "FWIT",  "FWPR",  "FWPT",
+        "GGIR",  "GGIT",  "GGOR", "GGPR",  "GGPT", "GOIR",  "GOIT",
+        "GOPR",  "GOPT",  "GVIR", "GVIT",  "GVPR", "GVPT",  "GWCT",
+        "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT",
+        "WBHP",  "WGIR",  "WGIT", "WGOR",  "WGPR", "WGPT",  "WOIR",
+        "WOIT",  "WOPR",  "WOPT", "WPI",   "WTHP", "WVIR",  "WVIT",
+        "WVPR",  "WVPT",  "WWCT", "WWGR",  "WWIR", "WWIT",  "WWPR",
         "WWPT",
         // ALL will not expand to these keywords yet
-        "AAQR", "AAQRG", "AAQT", "AAQTG"
-    });
-
-	std::vector <std::string> SummaryConfig::getAllExpandedKeywords() {
-		return __ALL_expands_keywords;
-	}
-
+        "AAQR",  "AAQRG", "AAQT", "AAQTG"
+    };
 
     /*
       When the error handling config says that the error should be
@@ -86,7 +82,7 @@ namespace Opm {
       all the way down here.
     */
 
-    static void handleMissingWell( const ParseContext& parseContext , const std::string& keyword, const std::string& well) {
+    void handleMissingWell( const ParseContext& parseContext , const std::string& keyword, const std::string& well) {
         std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such well: ") + well;
         MessageContainer msgContainer;
         if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_WELL) == InputError::WARN)
@@ -96,7 +92,7 @@ namespace Opm {
     }
 
 
-    static void handleMissingGroup( const ParseContext& parseContext , const std::string& keyword, const std::string& group) {
+    void handleMissingGroup( const ParseContext& parseContext , const std::string& keyword, const std::string& group) {
         std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such group: ") + group;
         MessageContainer msgContainer;
         if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_GROUP) == InputError::WARN)
@@ -108,11 +104,11 @@ namespace Opm {
 
 
     template< typename T >
-    static std::string name( const T* x ) {
+    std::string name( const T* x ) {
         return x->name();
     }
 
-    static inline std::vector< ERT::smspec_node > defaultW(
+    inline std::vector< ERT::smspec_node > defaultW(
             const std::string& keyword,
             const Schedule& schedule ) {
 
@@ -124,7 +120,7 @@ namespace Opm {
     }
 
 
-    static inline std::vector< ERT::smspec_node > keywordW(const ParseContext& parseContext,
+    inline std::vector< ERT::smspec_node > keywordW(const ParseContext& parseContext,
                                                            const DeckKeyword& keyword,
                                                            const Schedule& schedule ) {
 
@@ -144,7 +140,7 @@ namespace Opm {
 
 
 
-    static inline std::vector< ERT::smspec_node > defaultG(const std::string& keyword,
+    inline std::vector< ERT::smspec_node > defaultG(const std::string& keyword,
                                                            const Schedule& schedule ) {
 
         const auto mknode = [&keyword]( const std::string& gname ) {
@@ -154,7 +150,7 @@ namespace Opm {
         return fun::map( mknode, fun::map( name< Group  >, schedule.getGroups() ) );
     }
 
-    static inline std::vector< ERT::smspec_node > keywordG(const ParseContext& parseContext,
+    inline std::vector< ERT::smspec_node > keywordG(const ParseContext& parseContext,
                                                            const DeckKeyword& keyword,
                                                            const Schedule& schedule ) {
 
@@ -174,7 +170,7 @@ namespace Opm {
 
 
 
-    static inline std::vector< ERT::smspec_node > keywordF(
+    inline std::vector< ERT::smspec_node > keywordF(
             const DeckKeyword& keyword ) {
 
         std::vector< ERT::smspec_node > res;
@@ -182,7 +178,7 @@ namespace Opm {
         return res;
     }
 
-    static inline std::vector< ERT::smspec_node > keywordF(
+    inline std::vector< ERT::smspec_node > keywordF(
             const std::string& keyword ) {
 
         std::vector< ERT::smspec_node > res;
@@ -190,7 +186,7 @@ namespace Opm {
         return res;
     }
 
-    static inline std::array< int, 3 > dimensions( const EclipseGrid& grid ) {
+    inline std::array< int, 3 > dimensions( const EclipseGrid& grid ) {
         return {{
             int( grid.getNX() ),
             int( grid.getNY() ),
@@ -198,7 +194,7 @@ namespace Opm {
         }};
     }
 
-    static inline std::array< int, 3 > getijk( const DeckRecord& record,
+    inline std::array< int, 3 > getijk( const DeckRecord& record,
                                                int offset = 0 )
     {
         return {{
@@ -208,11 +204,11 @@ namespace Opm {
         }};
     }
 
-    static inline std::array< int, 3 > getijk( const Completion& completion ) {
+    inline std::array< int, 3 > getijk( const Completion& completion ) {
         return {{ completion.getI(), completion.getJ(), completion.getK() }};
     }
 
-    static inline std::vector< ERT::smspec_node > keywordB(
+    inline std::vector< ERT::smspec_node > keywordB(
             const DeckKeyword& keyword,
             std::array< int, 3 > dims ) {
 
@@ -224,7 +220,7 @@ namespace Opm {
         return fun::map( mkrecord, keyword );
     }
 
-    static inline std::vector< ERT::smspec_node > keywordR(
+    inline std::vector< ERT::smspec_node > keywordR(
             const DeckKeyword& keyword,
             const Eclipse3DProperties& props,
             std::array< int, 3 > dims ) {
@@ -248,7 +244,7 @@ namespace Opm {
         return fun::map( mknode, regions );
     }
 
-   static inline std::vector< ERT::smspec_node > keywordC(const ParseContext& parseContext,
+   inline std::vector< ERT::smspec_node > keywordC(const ParseContext& parseContext,
                                                            const DeckKeyword& keyword,
                                                            const Schedule& schedule,
                                                            std::array< int, 3 > dims ) {
@@ -325,11 +321,10 @@ namespace Opm {
 
     std::vector< ERT::smspec_node > handleALL( const Schedule& schedule) {
 
-
         std::vector< ERT::smspec_node > all;
 
-        for(const std::string& keyword: SummaryConfig::getAllExpandedKeywords()) {
-            const auto var_type = ecl_smspec_identify_var_type(keyword.c_str());
+        for( const auto& keyword: ALL_keywords ) {
+            const auto var_type = ecl_smspec_identify_var_type(keyword);
             switch (var_type) {
                 case ECL_SMSPEC_WELL_VAR:
                     for(auto&k :defaultW(keyword, schedule)) all.push_back(k);
@@ -343,13 +338,15 @@ namespace Opm {
                 case ECL_SMSPEC_AQUIFER_VAR:
                     {}
                     break;
-                default:
-                	throw std::runtime_error("Unrecognized keyword type: " + keyword);
+                default: throw std::runtime_error(
+                                 "Unrecognized keyword type: "
+                                 + std::string(keyword) );
             }
         }
 
         return all;
     }
+}
 
     SummaryConfig::SummaryConfig( const Deck& deck, const EclipseState& es , const ParseContext& parseContext)
         : SummaryConfig( deck,

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -66,42 +66,42 @@ namespace {
         "AAQR",  "AAQRG", "AAQT", "AAQTG"
     };
 
-    /*
-      When the error handling config says that the error should be
-      logged, the handleMissingWell and handleMissingGroup routines
-      cheat. Ideally we should have a MessageContainer instance around
-      and pass that to the parseContext::handlError() routine. Instead
-      we:
+/*
+    When the error handling config says that the error should be
+    logged, the handleMissingWell and handleMissingGroup routines
+    cheat. Ideally we should have a MessageContainer instance around
+    and pass that to the parseContext::handlError() routine. Instead
+    we:
 
-        1. We instantiate new MessageContainer() which is just
-           immediately dropped to floor, leaving the messages behind.
+    1. We instantiate new MessageContainer() which is just
+        immediately dropped to floor, leaving the messages behind.
 
-        2. Print a message on stderr.
+    2. Print a message on stderr.
 
-      The case of incorrectly/missing well/group names in the SUMMARY
-      section did just not seem important enough to warrant the
-      refactoring required to pass a mutable proper MessageContainer
-      all the way down here.
-    */
+    The case of incorrectly/missing well/group names in the SUMMARY
+    section did just not seem important enough to warrant the
+    refactoring required to pass a mutable proper MessageContainer
+    all the way down here.
+*/
 
-    void handleMissingWell( const ParseContext& parseContext , const std::string& keyword, const std::string& well) {
-        std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such well: ") + well;
-        MessageContainer msgContainer;
-        if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_WELL) == InputError::WARN)
-            std::cerr << "ERROR: " << msg << std::endl;
+void handleMissingWell( const ParseContext& parseContext , const std::string& keyword, const std::string& well) {
+    std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such well: ") + well;
+    MessageContainer msgContainer;
+    if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_WELL) == InputError::WARN)
+        std::cerr << "ERROR: " << msg << std::endl;
 
-        parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_WELL , msgContainer , msg );
-    }
+    parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_WELL , msgContainer , msg );
+}
 
 
-    void handleMissingGroup( const ParseContext& parseContext , const std::string& keyword, const std::string& group) {
-        std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such group: ") + group;
-        MessageContainer msgContainer;
-        if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_GROUP) == InputError::WARN)
-            std::cerr << "ERROR: " << msg << std::endl;
+void handleMissingGroup( const ParseContext& parseContext , const std::string& keyword, const std::string& group) {
+    std::string msg = std::string("Error in keyword:") + keyword + std::string(" No such group: ") + group;
+    MessageContainer msgContainer;
+    if (parseContext.get( ParseContext::SUMMARY_UNKNOWN_GROUP) == InputError::WARN)
+        std::cerr << "ERROR: " << msg << std::endl;
 
-        parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_GROUP , msgContainer , msg );
-    }
+    parseContext.handleError( ParseContext::SUMMARY_UNKNOWN_GROUP , msgContainer , msg );
+}
 
 inline void keywordW( std::vector< ERT::smspec_node >& list,
                       const ParseContext& parseContext,
@@ -307,28 +307,28 @@ SummaryConfig::SummaryConfig( const Deck& deck,
         this->merge( { ALL_keywords, schedule, props, parseContext, n_xyz } );
 }
 
-    SummaryConfig::const_iterator SummaryConfig::begin() const {
-        return this->keywords.cbegin();
-    }
+SummaryConfig::const_iterator SummaryConfig::begin() const {
+    return this->keywords.cbegin();
+}
 
-    SummaryConfig::const_iterator SummaryConfig::end() const {
-        return this->keywords.cend();
-    }
+SummaryConfig::const_iterator SummaryConfig::end() const {
+    return this->keywords.cend();
+}
 
-    SummaryConfig& SummaryConfig::merge( const SummaryConfig& other ) {
-        this->keywords.insert( this->keywords.end(),
-                               other.keywords.begin(),
-                               other.keywords.end() );
-        return *this;
-    }
+SummaryConfig& SummaryConfig::merge( const SummaryConfig& other ) {
+    this->keywords.insert( this->keywords.end(),
+                            other.keywords.begin(),
+                            other.keywords.end() );
+    return *this;
+}
 
-    SummaryConfig& SummaryConfig::merge( SummaryConfig&& other ) {
-        auto begin = std::make_move_iterator( other.keywords.begin() );
-        auto end = std::make_move_iterator( other.keywords.end() );
-        this->keywords.insert( this->keywords.end(), begin, end );
-        other.keywords.clear();
+SummaryConfig& SummaryConfig::merge( SummaryConfig&& other ) {
+    auto begin = std::make_move_iterator( other.keywords.begin() );
+    auto end = std::make_move_iterator( other.keywords.end() );
+    this->keywords.insert( this->keywords.end(), begin, end );
+    other.keywords.clear();
 
-        return *this;
-    }
+    return *this;
+}
 
 }

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -132,17 +132,18 @@ namespace {
             return defaultW( keyword.name(), schedule );
 
         const auto& item = keyword.getDataRecord().getDataItem();
-        if (item.hasValue( 0 )) {
-            std::vector<ERT::smspec_node> nodes;
-            for (const std::string& well : item.getData< std::string >()) {
-                if (schedule.hasWell( well ))
-                    nodes.emplace_back( ECL_SMSPEC_WELL_VAR , well , keyword.name());
-                else
-                    handleMissingWell( parseContext , keyword.name() , well );
-            }
-            return nodes;
-        } else
-            return defaultW( keyword.name() , schedule );
+
+        if( !item.hasValue( 0 ) )
+            return defaultW( keyword.name(), schedule );
+
+        std::vector<ERT::smspec_node> nodes;
+        for( const std::string& well : item.getData< std::string >() ) {
+            if (schedule.hasWell( well ))
+                nodes.emplace_back( ECL_SMSPEC_WELL_VAR , well , keyword.name());
+            else
+                handleMissingWell( parseContext , keyword.name() , well );
+        }
+        return nodes;
     }
 
 
@@ -164,17 +165,18 @@ namespace {
             return defaultG( keyword.name(), schedule );
 
         const auto& item = keyword.getDataRecord().getDataItem();
-        if (item.hasValue( 0 )) {
-            std::vector<ERT::smspec_node> nodes;
-            for (const std::string& group : item.getData< std::string >()) {
-                if (schedule.hasGroup( group ))
-                    nodes.emplace_back( ECL_SMSPEC_GROUP_VAR , group , keyword.name());
-                else
-                    handleMissingGroup( parseContext , keyword.name() , group );
-            }
-            return nodes;
-        } else
-            return defaultG( keyword.name() , schedule );
+
+        if( !item.hasValue( 0 ) )
+            return defaultG( keyword.name(), schedule );
+
+        std::vector<ERT::smspec_node> nodes;
+        for( const std::string& group : item.getData< std::string >() ) {
+            if (schedule.hasGroup( group ))
+                nodes.emplace_back( ECL_SMSPEC_GROUP_VAR , group , keyword.name());
+            else
+                handleMissingGroup( parseContext , keyword.name() , group );
+        }
+        return nodes;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -392,4 +392,20 @@ namespace {
         return this->keywords.cend();
     }
 
+    SummaryConfig& SummaryConfig::merge( const SummaryConfig& other ) {
+        this->keywords.insert( this->keywords.end(),
+                               other.keywords.begin(),
+                               other.keywords.end() );
+        return *this;
+    }
+
+    SummaryConfig& SummaryConfig::merge( SummaryConfig&& other ) {
+        auto begin = std::make_move_iterator( other.keywords.begin() );
+        auto end = std::make_move_iterator( other.keywords.end() );
+        this->keywords.insert( this->keywords.end(), begin, end );
+        other.keywords.clear();
+
+        return *this;
+    }
+
 }

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -47,6 +47,9 @@ namespace Opm {
             const_iterator begin() const;
             const_iterator end() const;
 
+            SummaryConfig& merge( const SummaryConfig& );
+            SummaryConfig& merge( SummaryConfig&& );
+
         private:
             std::vector< ERT::smspec_node > keywords;
     };

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -47,11 +47,8 @@ namespace Opm {
             const_iterator begin() const;
             const_iterator end() const;
 
-            static std::vector <std::string> getAllExpandedKeywords();
-
         private:
             std::vector< ERT::smspec_node > keywords;
-            static const std::vector <std::string> __ALL_expands_keywords;
     };
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -189,6 +189,24 @@ BOOST_AUTO_TEST_CASE(completions) {
             names.begin(), names.end() );
 }
 
+constexpr auto ALL_keywords =  {
+    "FAQR",  "FAQRG", "FAQT", "FAQTG", "FGIP", "FGIPG", "FGIPL",
+    "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
+    "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",
+    "FVIT",  "FVPR",  "FVPT", "FWCT",  "FWGR", "FWIP",  "FWIR",
+    "FWIT",  "FWPR",  "FWPT",
+    "GGIR",  "GGIT",  "GGOR", "GGPR",  "GGPT", "GOIR",  "GOIT",
+    "GOPR",  "GOPT",  "GVIR", "GVIT",  "GVPR", "GVPT",  "GWCT",
+    "GWGR",  "GWIR",  "GWIT", "GWPR",  "GWPT",
+    "WBHP",  "WGIR",  "WGIT", "WGOR",  "WGPR", "WGPT",  "WOIR",
+    "WOIT",  "WOPR",  "WOPT", "WPI",   "WTHP", "WVIR",  "WVIT",
+    "WVPR",  "WVPT",  "WWCT", "WWGR",  "WWIR", "WWIT",  "WWPR",
+    "WWPT",
+    // ALL will not expand to these keywords yet
+    "AAQR",  "AAQRG", "AAQT", "AAQTG"
+};
+
+
 BOOST_AUTO_TEST_CASE(summary_ALL) {
 
     const auto input = "ALL\n";
@@ -198,7 +216,7 @@ BOOST_AUTO_TEST_CASE(summary_ALL) {
 
     std::vector<std::string> all;
 
-    for(const std::string& keyword: SummaryConfig::getAllExpandedKeywords()) {
+    for( std::string keyword: ALL_keywords ) {
         if(keyword[0]=='F') {
             all.push_back(keyword);
         }

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -187,6 +187,51 @@ BOOST_AUTO_TEST_CASE(completions) {
     BOOST_CHECK_EQUAL_COLLECTIONS(
             keywords.begin(), keywords.end(),
             names.begin(), names.end() );
+
+}
+
+BOOST_AUTO_TEST_CASE( merge ) {
+    const auto input1 = "WWCT\n/\n";
+    auto summary1 = createSummary( input1 );
+
+    const auto keywords = { "FOPT", "WWCT", "WWCT", "WWCT", "WWCT" };
+    const auto wells = { "PRODUCER", "WX2", "W_1", "W_3" };
+
+    const auto input2 = "FOPT\n";
+    const auto summary2 = createSummary( input2 );
+
+    summary1.merge( summary2 );
+    const auto kw_names = sorted_keywords( summary1 );
+    const auto well_names = sorted_names( summary1 );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            keywords.begin(), keywords.end(),
+            kw_names.begin(), kw_names.end() );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            wells.begin(), wells.end(),
+            well_names.begin(), well_names.end() );
+}
+
+BOOST_AUTO_TEST_CASE( merge_move ) {
+    const auto input = "WWCT\n/\n";
+    auto summary = createSummary( input );
+
+    const auto keywords = { "FOPT", "WWCT", "WWCT", "WWCT", "WWCT" };
+    const auto wells = { "PRODUCER", "WX2", "W_1", "W_3" };
+
+    summary.merge( createSummary( "FOPT\n" ) );
+
+    const auto kw_names = sorted_keywords( summary );
+    const auto well_names = sorted_names( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            keywords.begin(), keywords.end(),
+            kw_names.begin(), kw_names.end() );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            wells.begin(), wells.end(),
+            well_names.begin(), well_names.end() );
 }
 
 constexpr auto ALL_keywords =  {

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -325,3 +325,22 @@ BOOST_AUTO_TEST_CASE(INVALID_GROUP) {
     parseContext.updateKey( ParseContext::SUMMARY_UNKNOWN_GROUP , InputError::IGNORE );
     BOOST_CHECK_NO_THROW( createSummary( input , parseContext ));
 }
+
+BOOST_AUTO_TEST_CASE( REMOVE_DUPLICATED_ENTRIES ) {
+    ParseContext parseContext;
+    const auto input = "WGPR \n/\n"
+                       "WGPR \n/\n"
+                       "ALL\n";
+
+    const auto summary = createSummary( input );
+    const auto keys = sorted_key_names( summary );
+    auto uniq_keys = keys;
+    uniq_keys.erase( std::unique( uniq_keys.begin(),
+                                  uniq_keys.end(),
+                                  std::equal_to< std::string >() ),
+                     uniq_keys.end() );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            keys.begin(), keys.end(),
+            uniq_keys.begin(), uniq_keys.end() );
+}


### PR DESCRIPTION
This PR gives some love to the `SummaryConfig` internals and also adds a new feature to address https://github.com/OPM/opm-output/issues/57

Notable additions:
* `SummaryConfig` **no longer contains duplicate entries**.
* Some initialization list support for `Deck`
* Support for merging two `SummaryConfig` objects
* `SummaryConfig` internals refactored.