### PR TITLE
Remove opm-common dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,6 @@ endif()
 include( cmake/Modules/CheckCaseSensitiveFileSystem.cmake )
 add_definitions("-DHAVE_CASE_SENSITIVE_FILESYSTEM=${HAVE_CASE_SENSITIVE_FILESYSTEM}")
 
-find_package(opm-common)
-include_directories( ${opm-common_INCLUDE_DIRS} )
 include( Findopm-data )
 
 find_package(ERT)

--- a/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckDoubleItemTests.cpp
@@ -20,9 +20,7 @@
 
 #define BOOST_TEST_MODULE DeckItemTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <stdexcept>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckIntItemTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE DeckItemTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <stdexcept>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckKeywordTests.cpp
@@ -22,9 +22,7 @@
 
 #define BOOST_TEST_MODULE DeckKeywordTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/opm/parser/eclipse/Deck/tests/DeckStringItemTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckStringItemTests.cpp
@@ -21,9 +21,7 @@
 
 #define BOOST_TEST_MODULE DeckStringItemTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 

--- a/opm/parser/eclipse/Deck/tests/DeckTests.cpp
+++ b/opm/parser/eclipse/Deck/tests/DeckTests.cpp
@@ -22,9 +22,7 @@
 
 #define BOOST_TEST_MODULE DeckTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/BoxTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/BoxTests.cpp
@@ -23,11 +23,9 @@
 
 #define BOOST_TEST_MODULE BoxManagereTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -23,10 +23,8 @@
 #include <cstdio>
 
 #define BOOST_TEST_MODULE EclipseGridTests
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/FaultTests.cpp
@@ -22,11 +22,9 @@
 
 #define BOOST_TEST_MODULE FaultTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertiesTests.cpp
@@ -22,11 +22,9 @@
 
 #define BOOST_TEST_MODULE EclipseGridTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -23,11 +23,9 @@
 
 #define BOOST_TEST_MODULE EclipseGridTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>

--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp
@@ -24,8 +24,6 @@
 
 #include <stdexcept>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -23,10 +23,8 @@
 
 #define BOOST_TEST_MODULE ScheduleTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TimeMapTest.cpp
@@ -23,10 +23,8 @@
 
 #define BOOST_TEST_MODULE TimeMapTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSolventTests.cpp
@@ -19,10 +19,8 @@
 
 #define BOOST_TEST_MODULE WellSolventTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -21,10 +21,8 @@
 
 #define BOOST_TEST_MODULE SimulationConfigTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/ThresholdPressureTest.cpp
@@ -23,10 +23,8 @@
 
 #define BOOST_TEST_MODULE ThresholdPressureTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/filesystem.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPInjTable.hpp
@@ -23,11 +23,9 @@
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <boost/multi_array.hpp>
 
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 namespace Opm {
 

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.hpp
@@ -20,11 +20,9 @@
 #ifndef OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPPRODTABLE_HPP_
 #define OPM_PARSER_ECLIPSE_ECLIPSESTATE_TABLES_VFPPRODTABLE_HPP_
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 
 #include <boost/multi_array.hpp>
 
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/Tables/tests/ColumnSchemaTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/ColumnSchemaTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE ColumnSchemaTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/PvtxTableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/PvtxTableTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE PvtxTableTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/SimpleTableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/SimpleTableTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE SimpleTableTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/EclipseState/Tables/ColumnSchema.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableColumnTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableColumnTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE TableColumnTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/EclipseState/Tables/TableIndex.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE TableContainerTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE SimpleTableTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableSchemaTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableSchemaTests.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE TableSchemaTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/EclipseState/Tables/TableSchema.hpp>

--- a/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
@@ -23,10 +23,8 @@
 
 #define BOOST_TEST_MODULE Eclipse3DPropertiesTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -23,10 +23,8 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 
 #define BOOST_TEST_MODULE EclipseStateTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>

--- a/opm/parser/eclipse/Generator/tests/KeywordLoaderTests.cpp
+++ b/opm/parser/eclipse/Generator/tests/KeywordLoaderTests.cpp
@@ -23,11 +23,9 @@
 
 #define BOOST_TEST_MODULE InputKeywordTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/filesystem.hpp>
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 
 #include <opm/parser/eclipse/Generator/KeywordLoader.hpp>

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -19,10 +19,8 @@
 
 #define BOOST_TEST_MODULE BoxTest
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <boost/filesystem/path.hpp>
 

--- a/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
@@ -32,9 +32,7 @@
 
 #define BOOST_TEST_MODULE NNCTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 using namespace Opm;
 

--- a/opm/parser/eclipse/IntegrationTests/ParseMULTSEGWELL.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMULTSEGWELL.cpp
@@ -20,10 +20,8 @@
 #define BOOST_TEST_MODULE ParseMULTSEGWELL
 #include <math.h>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMiscible.cpp
@@ -19,10 +19,8 @@
 #define BOOST_TEST_MODULE ParseMiscible
 #include <math.h>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParsePVTO.cpp
@@ -20,10 +20,8 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/EclipseState/Tables/PvtoTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp>

--- a/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
@@ -19,10 +19,8 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
@@ -20,10 +20,8 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseVFPPROD.cpp
@@ -20,10 +20,8 @@
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>

--- a/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
+++ b/opm/parser/eclipse/Parser/tests/MessageContainerTest.cpp
@@ -20,9 +20,7 @@
 
 #define BOOST_TEST_MODULE MessageContainerTest
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -20,9 +20,7 @@
 
 #define BOOST_TEST_MODULE ParserTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/json/JsonObject.hpp>
 

--- a/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
+++ b/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
@@ -19,9 +19,7 @@
 
 #define BOOST_TEST_MODULE COMPSEGUNITS
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>

--- a/opm/parser/eclipse/Utility/tests/FunctionalTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/FunctionalTests.cpp
@@ -22,9 +22,7 @@
 #include <vector>
 #include <map>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Utility/Functional.hpp>
 

--- a/opm/parser/eclipse/Utility/tests/StringTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/StringTests.cpp
@@ -1,8 +1,6 @@
 #define BOOST_TEST_MODULE StringTests
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Utility/String.hpp>
 #include <opm/parser/eclipse/Utility/Stringview.hpp>

--- a/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
+++ b/opm/parser/eclipse/Utility/tests/StringviewTests.cpp
@@ -3,9 +3,7 @@
 #include <sstream>
 #include <string>
 
-#include <opm/common/utility/platform_dependent/disable_warnings.h>
 #include <boost/test/unit_test.hpp>
-#include <opm/common/utility/platform_dependent/reenable_warnings.h>
 
 #include <opm/parser/eclipse/Utility/Stringview.hpp>
 


### PR DESCRIPTION
Severs the code dependency on opm-commmon. There was no actual
functional dependency here, with the exception of some enable/disable
warning headers. To properly make opm-parser a stand-alone module the
usage of these headers have been removed and the dependency on
opm-common is gone.