### PR TITLE
Appveyor support

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,36 @@
+version: 1.0.{build}
+clone_depth: 1
+
+configuration:
+    - Debug
+    - Release
+
+os: Visual Studio 2015
+image: Visual Studio 2015
+
+platform:
+    - x64
+
+environment:
+    BOOST_ROOT: C:\Libraries\boost_1_59_0\boost
+    BOOST_INCLUDEDIR: C:\Libraries\boost_1_59_0
+    BOOST_LIBRARYDIR: C:\Libraries\boost_1_59_0\lib64-msvc-14.0
+    BOOST_FLAGS: -DBoost_USE_MULTITHREAD=ON -DBUILD_SHARED_LIBS=OFF -DBoost_USE_STATIC_LIBS=TRUE -DBOOST_ALL_DYN_LINK=OFF
+    BOOST_OPTIONS: -DBOOST_ROOT=%BOOST_ROOT% -DBOOST_LIBRARYDIR=%BOOST_LIBRARYDIR% -DBOOST_INCLUDEDIR=%BOOST_INCLUDEDIR% %BOOST_FLAGS%
+    COMMON_ROOT: "C:/Program Files/Project/share/opm/"
+    ERT_ROOT: "C:/Program Files/ERT"
+    GEN: "Visual Studio 14 2015 Win64"
+
+build_script:
+    - git clone https://github.com/OPM/opm-common.git
+    - git clone https://github.com/Ensembles/ert.git
+    - cd ert
+    - cmake C:\projects\opm-parser\ert\devel -G"%GEN%" -DCMAKE_BUILD_TYPE=%configuration% -DERT_BUILD_CXX=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_PYTHON=OFF
+    - cmake --build . --target install --config %configuration%
+    - cd ../opm-common
+    - cmake C:\projects\opm-parser\opm-common -G"%GEN%" %BOOST_OPTIONS% -DCMAKE_BUILD_TYPE=%configuration% -DBUILD_TESTING=OFF
+    - cmake --build . --config %configuration% --target install
+    - cd ..
+    - cmake C:\projects\opm-parser -G"%GEN%" %BOOST_OPTIONS% -DOPM_COMMON_ROOT="%COMMON_ROOT%" -DCMAKE_PREFIX_PATH="%ERT_ROOT%" -DCMAKE_BUILD_TYPE=%configuration%
+    - cmake --build . --config %configuration%
+    - ctest -C %configuration% --output-on-failure

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -585,7 +585,7 @@ namespace Opm {
 
         fs::path dir( m_output_dir );
         fs::path base( m_base_name );
-        fs::path full_path = dir / base;
+        fs::path full_path = dir.make_preferred() / base.make_preferred();
 
         return full_path.string();
     }

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -902,12 +902,15 @@ BOOST_AUTO_TEST_CASE(OutputPaths) {
     BOOST_CHECK_EQUAL( output_dir2,  config2.getOutputDir() );
     BOOST_CHECK_EQUAL( "testString", config2.getBaseName() );
 
+    namespace fs = boost::filesystem;
+
     Deck deck3;
     deck3.setDataFile( "/path/to/testString.DATA" );
     IOConfig config3( deck3 );
     std::string output_dir3 =  "/path/to";
     config3.setOutputDir( output_dir3 );
+    auto testpath = fs::path( "/path/to/testString" ).make_preferred().string();
     BOOST_CHECK_EQUAL( output_dir3,  config3.getOutputDir() );
     BOOST_CHECK_EQUAL( "testString", config3.getBaseName() );
-    BOOST_CHECK_EQUAL( "/path/to/testString" , config3.fullBasePath( ));
+    BOOST_CHECK_EQUAL( testpath, config3.fullBasePath() );
 }

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -234,7 +234,7 @@ BOOST_AUTO_TEST_CASE( merge_move ) {
             well_names.begin(), well_names.end() );
 }
 
-constexpr auto ALL_keywords =  {
+static const auto ALL_keywords = {
     "FAQR",  "FAQRG", "FAQT", "FAQTG", "FGIP", "FGIPG", "FGIPL",
     "FGIR",  "FGIT",  "FGOR", "FGPR",  "FGPT", "FOIP",  "FOIPG",
     "FOIPL", "FOIR",  "FOIT", "FOPR",  "FOPT", "FPR",   "FVIR",

--- a/opm/parser/eclipse/Generator/tests/KeywordLoaderTests.cpp
+++ b/opm/parser/eclipse/Generator/tests/KeywordLoaderTests.cpp
@@ -84,9 +84,11 @@ BOOST_AUTO_TEST_CASE(DirectorySort) {
     BOOST_CHECK_THROW( Opm::KeywordLoader::sortSubdirectories( "testdata/parser/keyword-generator/loader/ZCORN") , std::invalid_argument );
     std::vector<std::string> dir_list = Opm::KeywordLoader::sortSubdirectories( "testdata/parser/keyword-generator/loader");
 
+    namespace fs = boost::filesystem;
+
     BOOST_CHECK_EQUAL( 2U , dir_list.size());
-    BOOST_CHECK_EQUAL( dir_list[0] , "testdata/parser/keyword-generator/loader/001_ECLIPSE100");
-    BOOST_CHECK_EQUAL( dir_list[1] , "testdata/parser/keyword-generator/loader/002_ECLIPSE300");
+    BOOST_CHECK_EQUAL( fs::path( dir_list[0] ), fs::path( "testdata/parser/keyword-generator/loader/001_ECLIPSE100" ) );
+    BOOST_CHECK_EQUAL( fs::path( dir_list[1] ), fs::path( "testdata/parser/keyword-generator/loader/002_ECLIPSE300" ) );
 }
 
 

--- a/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IncludeTest.cpp
@@ -40,7 +40,8 @@ using namespace boost::filesystem;
 static void
 createDeckWithInclude(path& datafile, std::string addEndKeyword)
 {
-    path root = unique_path("/tmp/%%%%-%%%%");
+    path tmpdir = temp_directory_path();
+    path root = tmpdir / unique_path("%%%%-%%%%");
     path absoluteInclude = root / "absolute.include";
     path includePath1 = root / "include";
     path includePath2 = root / "include2";


### PR DESCRIPTION
Appveyor http://appveyor.com/ is a CI service for Windows. Since parser is meant to be Windows compatible we need this feature. Like travis and gitlab, it is driven by an yml file.

In addition, this PR fixes tests that break on Windows.