### PR TITLE
Remove EclipseGrid::fwriteEGRID()

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -29,6 +29,9 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
 #include <opm/parser/eclipse/Parser/ParserKeywords/A.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/C.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/D.hpp>
@@ -37,6 +40,7 @@
 #include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/Z.hpp>
+
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 
 #include <ert/ecl/ecl_grid.h>
@@ -688,11 +692,6 @@ namespace Opm {
 
     void EclipseGrid::resetACTNUM( const int * actnum) {
         ecl_grid_reset_actnum( m_grid.get() , actnum );
-    }
-
-
-    void EclipseGrid::fwriteEGRID( const std::string& filename, bool output_metric ) const {
-        ecl_grid_fwrite_EGRID( m_grid.get() , filename.c_str(), output_metric );
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -85,7 +85,7 @@ namespace Opm {
 
         MinpvMode::ModeEnum getMinpvMode() const;
         double getMinpvValue( ) const;
-      
+
         /// Will return a vector a length num_active;
         /// where the value of each element is the corresponding global index.
         std::vector<int> getActiveMap() const;
@@ -109,7 +109,6 @@ namespace Opm {
         void exportACTNUM( std::vector<int>& actnum) const;
         void resetACTNUM( const int * actnum);
         bool equal(const EclipseGrid& other) const;
-        void fwriteEGRID( const std::string& filename, bool output_metric ) const;
         const ecl_grid_type * c_ptr() const;
         const MessageContainer& getMessageContainer() const;
         MessageContainer& getMessageContainer();

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -30,6 +30,8 @@
 #include <opm/parser/eclipse/Deck/DeckKeyword.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
 
+#include <opm/parser/eclipse/Units/UnitSystem.hpp>
+
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
@@ -757,32 +759,6 @@ BOOST_AUTO_TEST_CASE(LoadFromBinary) {
 }
 
 
-
-BOOST_AUTO_TEST_CASE(Fwrite) {
-    const char *deckData =
-        "RUNSPEC\n"
-        "\n"
-        "DIMENS\n"
-        " 10 10 10 /\n"
-        "GRID\n"
-        "COORD\n"
-        "  726*1 / \n"
-        "ZCORN \n"
-        "  8000*1 / \n"
-        "EDIT\n"
-        "\n";
-
-    Opm::ParserPtr parser(new Opm::Parser());
-    Opm::DeckConstPtr deck = parser->parseString(deckData, Opm::ParseContext()) ;
-    Opm::EclipseGrid grid1(deck );
-
-    grid1.fwriteEGRID( "TEST.EGRID" , true);
-
-    Opm::EclipseGrid grid2( "TEST.EGRID" );
-
-    BOOST_CHECK( grid1.equal( grid2 ));
-    remove("TEST.EGRID");
-}
 
 
 


### PR DESCRIPTION
With this PR the EclipseGrid::fwriteEGRID() method is removed; writing is initiated and handled in the opm-output module.