### PR TITLE
Remove warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ enable_language(C)
 include(CTest)
 include(TestCXXAcceptsFlag)
 
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+    message(STATUS "No build type specified - defaulting to 'Debug'.")
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose build type." FORCE)
+    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Release" "Debug" "RelWithDebInfo" "MinSizeRel")
+endif()
+
 # project information is in dune.module. Read this file and set variables.
 # we cannot generate dune.module since it is read by dunecontrol before
 # the build starts, so it makes sense to keep the data there then.
@@ -77,20 +83,19 @@ endif (USE_RUNPATH)
 
 if (MSVC)
   add_definitions( "/W3 /D_CRT_SECURE_NO_WARNINGS /wd4996 /wd4244 /wd4267")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+  set(CMAKE_CXX_FLAGS "/MP ${CMAKE_CXX_FLAGS}")
 else()
-  if (NOT DEFINED CMAKE_CXX_FLAGS)
-    SET( CMAKE_CXX_FLAGS "-pipe -std=c++0x -pedantic -Wall -Wextra -Wformat-nonliteral -Wcast-align -Wpointer-arith -Wmissing-declarations -Wcast-qual -Wshadow -Wwrite-strings -Wchar-subscripts -Wredundant-decls")
-  endif()
-  SET( CMAKE_CXX_FLAGS_DEBUG   "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}   -O0 -DDEBUG  -ggdb3")
-  SET( CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE} -O3 -DNDEBUG -mtune=native")
+  # The cmake macros are expanded *after* our flags so that options can be
+  # overriden via -DCMAKE_FLAGS from the command line or ccmake
+  SET( CMAKE_CXX_FLAGS "-pipe -std=c++0x  ${CMAKE_CXX_FLAGS}")
+  SET( CMAKE_CXX_FLAGS_DEBUG   "-pedantic -Wall -Wextra -Wformat-nonliteral -Wcast-align -Wpointer-arith -Wmissing-declarations -Wcast-qual -Wshadow -Wwrite-strings -Wchar-subscripts -Wredundant-decls ${CMAKE_CXX_FLAGS_DEBUG}")
+  SET( CMAKE_CXX_FLAGS_DEBUG   "-O0 -DDEBUG  -ggdb3        ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}  ")
+  SET( CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -mtune=native ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
 endif(MSVC)
 
-if (NOT DEFINED CMAKE_C_FLAGS)
-  SET( CMAKE_C_FLAGS "-pipe -Wall -Wno-unknown-pragmas -std=c99")
-endif()
-SET( CMAKE_C_FLAGS_DEBUG   "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}   -O0 -DDEBUG -ggdb3")
-SET( CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE} -O3 -DNDEBUG -mtune=native")
+SET( CMAKE_C_FLAGS "-pipe -Wall -Wno-unknown-pragmas -std=c99 ${CMAKE_C_FLAGS}")
+SET( CMAKE_C_FLAGS_DEBUG   "-O0 -DDEBUG -ggdb3         ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}  ")
+SET( CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -mtune=native ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
 
 
 if (BOOST_ROOT AND NOT DEFINED Boost_NO_SYSTEM_PATHS)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,7 @@ add_definitions(-DOPM_PARSER_DECK_API=1)
 # Requires BOOST filesystem version 3, thus 1.44 is necessary.
 add_definitions(-DBOOST_FILESYSTEM_VERSION=3)
 find_package(Boost 1.44.0 COMPONENTS filesystem date_time system unit_test_framework regex REQUIRED)
-include_directories(${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
 
 include_directories(BEFORE ${PROJECT_SOURCE_DIR})
 include_directories(${PROJECT_BINARY_DIR})

--- a/opm/parser/eclipse/Applications/opmi.cpp
+++ b/opm/parser/eclipse/Applications/opmi.cpp
@@ -27,7 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 
 
-void dumpMessages( const Opm::MessageContainer& messageContainer) {
+inline void dumpMessages( const Opm::MessageContainer& messageContainer) {
     auto extractMessage = [](const Opm::Message& msg) {
         const auto& location = msg.location;
         if (location)
@@ -42,7 +42,7 @@ void dumpMessages( const Opm::MessageContainer& messageContainer) {
 }
 
 
-void loadDeck( const char * deck_file) {
+inline void loadDeck( const char * deck_file) {
     Opm::ParseContext parseContext;
     Opm::ParserPtr parser(new Opm::Parser());
     std::shared_ptr<const Opm::Deck> deck;

--- a/opm/parser/eclipse/Deck/Deck.cpp
+++ b/opm/parser/eclipse/Deck/Deck.cpp
@@ -139,10 +139,10 @@ namespace Opm {
     void Deck::addKeyword( DeckKeyword&& keyword ) {
         this->keywordList.push_back( std::move( keyword ) );
 
-        auto first = this->keywordList.begin();
-        auto last = this->keywordList.end();
+        auto fst = this->keywordList.begin();
+        auto lst = this->keywordList.end();
 
-        this->add( &this->keywordList.back(), first, last );
+        this->add( &this->keywordList.back(), fst, lst );
     }
 
     void Deck::addKeyword( const DeckKeyword& keyword ) {

--- a/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -111,12 +111,12 @@ namespace Opm {
 
 
     template< typename T >
-    DeckTypeItem< T >::DeckTypeItem( const std::string& name, size_t size ) :
+    DeckTypeItem< T >::DeckTypeItem( const std::string& nm, size_t sz ) :
         DeckItemBase( type_to_tag< T >() ),
-        item_name( name )
+        item_name( nm )
     {
-        this->dataPointDefaulted.reserve( size );
-        this->data.reserve( size );
+        this->dataPointDefaulted.reserve( sz );
+        this->data.reserve( sz );
     }
 
     template< typename T >
@@ -223,10 +223,10 @@ namespace Opm {
          * This is an unobservable state change - SIData is lazily converted to
          * SI units, so externally the object still behaves as const
          */
-        const auto size = this->size();
-        this->SIdata.resize( size );
+        const auto sz = this->size();
+        this->SIdata.resize( sz );
 
-        for( size_t index = 0; index < size; index++ ) {
+        for( size_t index = 0; index < sz; index++ ) {
             const auto dimIndex = index % dim_size;
             this->SIdata[ index ] = this->dimensions[ dimIndex ]
                                           ->convertRawToSi( this->get( index ) );

--- a/opm/parser/eclipse/Deck/DeckRecord.cpp
+++ b/opm/parser/eclipse/Deck/DeckRecord.cpp
@@ -29,8 +29,8 @@
 namespace Opm {
 
 
-    DeckRecord::DeckRecord( size_t size ) {
-        this->m_items.reserve( size );
+    DeckRecord::DeckRecord( size_t sz ) {
+        this->m_items.reserve( sz );
     }
 
     size_t DeckRecord::size() const {

--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -36,10 +36,7 @@
 
 namespace Opm {
 
-
-
-
-    namespace GridPropertyPostProcessor {
+    namespace {
 
         void distTopLayer( std::vector<double>&    values,
                            const EclipseGrid*      eclipseGrid )
@@ -188,7 +185,7 @@ namespace Opm {
 
         const auto tempLookup = std::bind( temperature_lookup, _1, tableManager, eclipseGrid, intGridProperties );
 
-        const auto distributeTopLayer = std::bind( &GridPropertyPostProcessor::distTopLayer, _1, eclipseGrid );
+        const auto distributeTopLayer = std::bind( &distTopLayer, _1, eclipseGrid );
 
         std::vector< GridProperties< double >::SupportedKeywordInfo > supportedDoubleKeywords;
 
@@ -397,19 +394,19 @@ namespace Opm {
 
 
         {
-            auto initPORV = std::bind(&GridPropertyPostProcessor::initPORV,
+            auto initPORVProcessor =  std::bind(&initPORV,
                                       std::placeholders::_1,
                                       &eclipseGrid,
                                       &m_doubleGridProperties);
 
             m_doubleGridProperties.postAddKeyword( "PORV",
                                                    std::numeric_limits<double>::quiet_NaN(),
-                                                   initPORV,
+                                                   initPORVProcessor,
                                                    "Volume" );
         }
 
         {
-            auto actnumPP = std::bind(&GridPropertyPostProcessor::ACTNUMPostProcessor,
+            auto actnumPP = std::bind(&ACTNUMPostProcessor,
                                       std::placeholders::_1,
                                       &m_doubleGridProperties);
 

--- a/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
@@ -103,11 +103,11 @@ namespace Opm {
     }
 
     // keyword must be DIMENS or SPECGRID
-    std::vector<int> readDims(const DeckKeyword& keyword) {
+    inline std::array< int, 3 > readDims(const DeckKeyword& keyword) {
         const auto& record = keyword.getRecord(0);
-        return std::vector<int> { record.getItem("NX").get<int>(0),
-                                  record.getItem("NY").get<int>(0),
-                                  record.getItem("NZ").get<int>(0) };
+        return { { record.getItem("NX").get<int>(0),
+                   record.getItem("NY").get<int>(0),
+                   record.getItem("NZ").get<int>(0) } };
     }
 
     void GridDims::init(const DeckKeyword& keyword) {

--- a/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridProperty.cpp
@@ -36,32 +36,32 @@ namespace Opm {
     template< typename T >
     static std::function< std::vector< T >( size_t ) > constant( T val ) {
         return [=]( size_t size ) { return std::vector< T >( size, val ); };
-    };
+    }
 
     template< typename T >
     static std::function< void( std::vector< T >& ) > noop() {
         return []( std::vector< T >& ) { return; };
-    };
+    }
 
     template< typename T >
     GridPropertySupportedKeywordInfo< T >::GridPropertySupportedKeywordInfo(
             const std::string& name,
-            std::function< std::vector< T >( size_t ) > initializer,
-            std::function< void( std::vector< T >& ) > postProcessor,
+            std::function< std::vector< T >( size_t ) > init,
+            std::function< void( std::vector< T >& ) > post,
             const std::string& dimString ) :
         m_keywordName( name ),
-        m_initializer( initializer ),
-        m_postProcessor( postProcessor ),
+        m_initializer( init ),
+        m_postProcessor( post ),
         m_dimensionString( dimString )
     {}
 
     template< typename T >
     GridPropertySupportedKeywordInfo< T >::GridPropertySupportedKeywordInfo(
             const std::string& name,
-            std::function< std::vector< T >( size_t ) > initializer,
+            std::function< std::vector< T >( size_t ) > init,
             const std::string& dimString ) :
         m_keywordName( name ),
-        m_initializer( initializer ),
+        m_initializer( init ),
         m_postProcessor( noop< T >() ),
         m_dimensionString( dimString )
     {}
@@ -81,11 +81,11 @@ namespace Opm {
     GridPropertySupportedKeywordInfo< T >::GridPropertySupportedKeywordInfo(
             const std::string& name,
             const T defaultValue,
-            std::function< void( std::vector< T >& ) > postProcessor,
+            std::function< void( std::vector< T >& ) > post,
             const std::string& dimString ) :
         m_keywordName( name ),
         m_initializer( constant( defaultValue ) ),
-        m_postProcessor( postProcessor ),
+        m_postProcessor( post ),
         m_dimensionString( dimString )
     {}
 

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
@@ -44,8 +44,7 @@ namespace Opm
         const auto& nncs = deck.getKeywordList<ParserKeywords::NNC>();
         for (size_t idx_nnc = 0; idx_nnc<nncs.size(); ++idx_nnc) {
             const auto& nnc = *nncs[idx_nnc];
-            size_t numNNC = nnc.size();
-            for (size_t i = 0; i<numNNC; ++i) {
+            for (size_t i = 0; i < nnc.size(); ++i) {
                 std::array<size_t, 3> ijk1;
                 ijk1[0] = static_cast<size_t>(nnc.getRecord(i).getItem(0).get< int >(0)-1);
                 ijk1[1] = static_cast<size_t>(nnc.getRecord(i).getItem(1).get< int >(0)-1);
@@ -71,11 +70,11 @@ namespace Opm
 
 
     void NNC::addNNC(const size_t cell1, const size_t cell2, const double trans) {
-        NNCdata nncdata;
-        nncdata.cell1 = cell1;
-        nncdata.cell2 = cell2;
-        nncdata.trans = trans;
-        m_nnc.push_back(nncdata);
+        NNCdata tmp;
+        tmp.cell1 = cell1;
+        tmp.cell2 = cell2;
+        tmp.trans = trans;
+        m_nnc.push_back(tmp);
     }
 
     size_t NNC::numNNC() const {

--- a/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/GridPropertyTests.cpp
@@ -383,7 +383,7 @@ BOOST_AUTO_TEST_CASE(GridPropertyInitialization) {
 }
 
 
-void TestPostProcessorMul(std::vector< double >& values,
+inline void TestPostProcessorMul(std::vector< double >& values,
         const Opm::TableManager*,
         const Opm::EclipseGrid*,
         Opm::GridProperties<int>*,

--- a/opm/parser/eclipse/EclipseState/Grid/tests/SatfuncPropertyInitializersTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/SatfuncPropertyInitializersTests.cpp
@@ -34,14 +34,16 @@
 
 using namespace Opm;
 
-void check_property(const Eclipse3DProperties& props1, const Eclipse3DProperties& props2, const std::string& propertyName) {
+inline void check_property(const Eclipse3DProperties& props1,
+                           const Eclipse3DProperties& props2,
+                           const std::string& propertyName) {
     auto& data1 = props1.getDoubleGridProperty(propertyName).getData();
     auto& data2 = props2.getDoubleGridProperty(propertyName).getData();
 
     BOOST_CHECK_CLOSE(data1[0], data2[0], 1e-12);
 }
 
-static Opm::Eclipse3DProperties getProps(Opm::DeckPtr deck) {
+inline Opm::Eclipse3DProperties getProps(Opm::DeckPtr deck) {
     return Opm::Eclipse3DProperties(*deck, *new Opm::TableManager(*deck), *new Opm::EclipseGrid(deck));
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
@@ -78,17 +78,23 @@ namespace Opm {
                 throw std::runtime_error("this way to obtain DISTANCE_END not implemented yet!");
             }
 
-            WellCompletion::DirectionEnum direction;
-            if (record.getItem<ParserKeywords::COMPSEGS::DIRECTION>().hasValue(0)) {
-                direction = WellCompletion::DirectionEnumFromString(record.getItem<ParserKeywords::COMPSEGS::DIRECTION>().get< std::string >(0));
-            } else if (!record.getItem<ParserKeywords::COMPSEGS::DISTANCE_END>().hasValue(0)) {
+            if( !record.getItem< ParserKeywords::COMPSEGS::DIRECTION >().hasValue( 0 ) &&
+                !record.getItem< ParserKeywords::COMPSEGS::DISTANCE_END >().hasValue( 0 ) ) {
                 throw std::runtime_error("the direction has to be specified when DISTANCE_END in the record is not specified");
             }
 
-            if (record.getItem<ParserKeywords::COMPSEGS::END_IJK>().hasValue(0)) {
-                if (!record.getItem<ParserKeywords::COMPSEGS::DIRECTION>().hasValue(0)) {
-                    throw std::runtime_error("the direction has to be specified when END_IJK in the record is specified");
-                }
+            if( record.getItem< ParserKeywords::COMPSEGS::END_IJK >().hasValue( 0 ) &&
+               !record.getItem< ParserKeywords::COMPSEGS::DIRECTION >().hasValue( 0 ) ) {
+                throw std::runtime_error("the direction has to be specified when END_IJK in the record is specified");
+            }
+
+            /*
+             * Defaulted well completion. Must be non-defaulted if DISTANCE_END
+             * is set or a range is specified. If not this is effectively ignored.
+             */
+            WellCompletion::DirectionEnum direction = WellCompletion::X;
+            if( record.getItem< ParserKeywords::COMPSEGS::DIRECTION >().hasValue( 0 ) ) {
+                direction = WellCompletion::DirectionEnumFromString(record.getItem<ParserKeywords::COMPSEGS::DIRECTION>().get< std::string >(0));
             }
 
             double center_depth;

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -408,20 +408,13 @@ namespace Opm {
     }
 
     bool Well::canOpen(size_t currentStep) const {
-        bool canOpen = true;
-        if (!getAllowCrossFlow()) {
-            if ( isInjector(currentStep) ) {
-                if (getInjectionProperties(currentStep).surfaceInjectionRate == 0) {;
-                    canOpen = false;
-                }
-            } else {
-                if ( (getProductionProperties(currentStep).WaterRate + getProductionProperties(currentStep).OilRate +
-                      getProductionProperties(currentStep).GasRate) == 0) {
-                    canOpen = false;
-                }
-            }
-        }
-        return canOpen;
+        if( getAllowCrossFlow() ) return true;
+
+        if( isInjector( currentStep ) )
+            return getInjectionProperties( currentStep ).surfaceInjectionRate != 0;
+
+        const auto& prod = getProductionProperties( currentStep );
+        return (prod.WaterRate + prod.OilRate + prod.GasRate) != 0;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -342,9 +342,9 @@ SummaryConfig& SummaryConfig::merge( const SummaryConfig& other ) {
 }
 
 SummaryConfig& SummaryConfig::merge( SummaryConfig&& other ) {
-    auto begin = std::make_move_iterator( other.keywords.begin() );
-    auto end = std::make_move_iterator( other.keywords.end() );
-    this->keywords.insert( this->keywords.end(), begin, end );
+    auto fst = std::make_move_iterator( other.keywords.begin() );
+    auto lst = std::make_move_iterator( other.keywords.end() );
+    this->keywords.insert( this->keywords.end(), fst, lst );
     other.keywords.clear();
 
     uniq( this->keywords );

--- a/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/ColumnSchema.cpp
@@ -23,8 +23,8 @@
 
 namespace Opm {
 
-    ColumnSchema::ColumnSchema(const std::string& name , Table::ColumnOrderEnum order , Table::DefaultAction defaultAction) :
-        m_name( name ),
+    ColumnSchema::ColumnSchema(const std::string& nm, Table::ColumnOrderEnum order, Table::DefaultAction defaultAction) :
+        m_name( nm ),
         m_order( order ),
         m_defaultAction( defaultAction )
     {
@@ -32,8 +32,8 @@ namespace Opm {
     }
 
 
-    ColumnSchema::ColumnSchema(const std::string& name , Table::ColumnOrderEnum order , double defaultValue ) :
-        m_name( name ),
+    ColumnSchema::ColumnSchema(const std::string& nm, Table::ColumnOrderEnum order, double defaultValue ) :
+        m_name( nm ),
         m_order( order ),
         m_defaultAction( Table::DEFAULT_CONST ),
         m_defaultValue( defaultValue )

--- a/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -639,10 +639,10 @@ GasvisctTable::GasvisctTable( const Deck& deck, const DeckItem& deckItem ) {
         throw std::runtime_error("Number of columns in the data file is inconsistent "
                 "with the expected number for keyword GASVISCT");
 
-        size_t numRows = deckItem.size() / m_schema->size();
+        size_t rows = deckItem.size() / m_schema->size();
         for (size_t columnIndex=0; columnIndex < m_schema->size(); columnIndex++) {
             auto& column = getColumn( columnIndex );
-            for (size_t rowIdx = 0; rowIdx < numRows; rowIdx++) {
+            for (size_t rowIdx = 0; rowIdx < rows; rowIdx++) {
                 size_t deckIndex = rowIdx * m_schema->size() + columnIndex;
 
                 if (deckItem.defaultApplied( deckIndex ))

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
@@ -31,7 +31,9 @@
 
 namespace Opm {
 
-static VFPProdTable::FLO_TYPE getFloType( const DeckItem& item) {
+namespace {
+
+VFPProdTable::FLO_TYPE getFloType( const DeckItem& item) {
     const std::string& flo_string = item.getTrimmedString(0);
     if (flo_string == "OIL") {
         return VFPProdTable::FLO_OIL;
@@ -116,6 +118,9 @@ VFPProdTable::ALQ_TYPE getALQType( const DeckItem& item) {
         return VFPProdTable::ALQ_INVALID;
     }
 }
+
+}
+
 void VFPProdTable::init(int table_num,
         double datum_depth,
         FLO_TYPE flo_type,

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -32,7 +32,7 @@
 #include <string>
 #include <memory>
 
-std::shared_ptr<const Opm::Deck> createSWOFDeck() {
+inline std::shared_ptr<const Opm::Deck> createSWOFDeck() {
     const char *deckData =
         "TABDIMS\n"
         " 2 /\n"

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -45,6 +45,7 @@
 #include <stdexcept>
 #include <iostream>
 
+namespace {
 
 std::shared_ptr<const Opm::Deck> createSingleRecordDeck() {
     const char *deckData =
@@ -91,6 +92,7 @@ std::shared_ptr<const Opm::Deck> createSingleRecordDeckWithVd() {
     return deck;
 }
 
+}
 
 BOOST_AUTO_TEST_CASE( CreateTables ) {
     std::shared_ptr<const Opm::Deck> deck = createSingleRecordDeck();

--- a/opm/parser/eclipse/Generator/KeywordGenerator.cpp
+++ b/opm/parser/eclipse/Generator/KeywordGenerator.cpp
@@ -30,50 +30,45 @@
 #include <opm/parser/eclipse/Generator/KeywordGenerator.hpp>
 #include <opm/parser/eclipse/Generator/KeywordLoader.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeyword.hpp>
+
+
+namespace {
+
+const std::string testHeader =
+    "#define BOOST_TEST_MODULE ParserRecordTests\n"
+    "#include <boost/filesystem.hpp>\n"
+    "#include <boost/test/unit_test.hpp>\n"
+    "#include <memory>\n"
+    "#include <opm/json/JsonObject.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserIntItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserStringItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserDoubleItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserRecord.hpp>\n"
+    "#include <opm/parser/eclipse/Units/UnitSystem.hpp>\n"
+    "using namespace Opm;\n"
+    "std::shared_ptr<UnitSystem> unitSystem( UnitSystem::newMETRIC() );\n";
+
+const std::string sourceHeader =
+    "#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserIntItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserStringItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserDoubleItem.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserRecord.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/Parser.hpp>\n"
+    "#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>\n\n\n"
+    "namespace Opm {\n"
+    "namespace ParserKeywords {\n\n";
+}
+
 namespace Opm {
 
     KeywordGenerator::KeywordGenerator(bool verbose)
         : m_verbose( verbose )
     {
-    }
-
-
-
-
-    std::string testHeader() {
-        std::string header = "#define BOOST_TEST_MODULE ParserRecordTests\n"
-            "#include <boost/filesystem.hpp>\n"
-            "#include <boost/test/unit_test.hpp>\n"
-            "#include <memory>\n"
-            "#include <opm/json/JsonObject.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserIntItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserStringItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserDoubleItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserRecord.hpp>\n"
-            "#include <opm/parser/eclipse/Units/UnitSystem.hpp>\n"
-            "using namespace Opm;\n"
-            "std::shared_ptr<UnitSystem> unitSystem( UnitSystem::newMETRIC() );\n";
-
-        return header;
-    }
-
-
-    std::string KeywordGenerator::sourceHeader() {
-        std::string header = "#include <opm/parser/eclipse/Parser/ParserKeyword.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserIntItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserStringItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserDoubleItem.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserRecord.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/Parser.hpp>\n"
-            "#include <opm/parser/eclipse/Parser/ParserKeywords.hpp>\n\n\n"
-            "namespace Opm {\n"
-            "namespace ParserKeywords {\n\n";
-
-        return header;
     }
 
     std::string KeywordGenerator::headerHeader(const std::string& suffix) {
@@ -136,7 +131,8 @@ namespace Opm {
 
         std::vector< std::stringstream > streams( blocks );
         for( unsigned int i = 0; i < streams.size(); ++i )
-            streams[ i ] << sourceHeader() << std::endl
+            streams[ i ] << sourceHeader << std::endl
+                << "void addDefaultKeywords" << i << "(Parser& p);" << std::endl
                 << "void addDefaultKeywords" << i << "(Parser& p) {" << std::endl;
 
         int bi = 0;
@@ -153,7 +149,7 @@ namespace Opm {
             updateFile( streams[i], srcfile.insert( srcfile.size() - 4, std::to_string( i ) ) );
         }
 
-        newSource << sourceHeader();
+        newSource << sourceHeader;
         for (auto iter = loader.keyword_begin(); iter != loader.keyword_end(); ++iter) {
             std::shared_ptr<ParserKeyword> keyword = (*iter).second;
             newSource << keyword->createCode() << std::endl;
@@ -226,7 +222,7 @@ namespace Opm {
     bool KeywordGenerator::updateTest(const KeywordLoader& loader , const std::string& testFile) const {
         std::stringstream stream;
 
-        stream << testHeader();
+        stream << testHeader;
         for (auto iter = loader.keyword_begin(); iter != loader.keyword_end(); ++iter) {
             const std::string& keywordName = (*iter).first;
             std::shared_ptr<ParserKeyword> keyword = (*iter).second;

--- a/opm/parser/eclipse/Generator/KeywordGenerator.hpp
+++ b/opm/parser/eclipse/Generator/KeywordGenerator.hpp
@@ -35,7 +35,6 @@ namespace Opm {
         static void ensurePath( const std::string& file_name);
         static std::string endTest();
         static std::string startTest(const std::string& test_name);
-        static std::string sourceHeader();
         static std::string headerHeader( const std::string& );
         static bool updateFile(const std::stringstream& newContent, const std::string& filename);
 

--- a/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -36,8 +36,7 @@
 
 using namespace Opm;
 
-
-void verifyRestartConfig(IOConfigConstPtr ioconfig, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
+inline void verifyRestartConfig(IOConfigConstPtr ioconfig, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
 
     for (auto rptrst : rptConfig) {
         int report_step                    = std::get<0>(rptrst);
@@ -50,8 +49,6 @@ void verifyRestartConfig(IOConfigConstPtr ioconfig, std::vector<std::tuple<int ,
         }
     }
 }
-
-
 
 BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
     std::vector<std::tuple<int , bool, boost::gregorian::date> > rptConfig;

--- a/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IntegrationTests.cpp
@@ -37,6 +37,8 @@
 
 using namespace Opm;
 
+namespace {
+
 std::unique_ptr< ParserKeyword > createFixedSized(const std::string& kw , size_t size) {
     std::unique_ptr< ParserKeyword > pkw( new ParserKeyword( kw ) );
     pkw->setFixedSize( size );
@@ -49,7 +51,7 @@ std::unique_ptr< ParserKeyword > createDynamicSized(const std::string& kw) {
     return pkw;
 }
 
-static ParserPtr createWWCTParser() {
+ParserPtr createWWCTParser() {
     auto parserKeyword = createDynamicSized("WWCT");
     {
         std::shared_ptr<ParserRecord> record = std::make_shared<ParserRecord>();
@@ -62,6 +64,8 @@ static ParserPtr createWWCTParser() {
     parser->addParserKeyword( std::move( parserKeyword ) );
     parser->addParserKeyword( std::move( summaryKeyword ) );
     return parser;
+}
+
 }
 
 BOOST_AUTO_TEST_CASE(parse_fileWithWWCTKeyword_deckReturned) {

--- a/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/NNCTests.cpp
@@ -25,11 +25,6 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Units/ConversionFactors.hpp>
 
-#if HAVE_DYNAMIC_BOOST_TEST
-#define BOOST_TEST_DYN_LINK
-#endif
-#define NVERBOSE // to suppress our messages when throwing
-
 #define BOOST_TEST_MODULE NNCTests
 
 #include <boost/test/unit_test.hpp>

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -267,12 +267,12 @@ bool ParserState::done() const {
 }
 
 string_view ParserState::getline() {
-    string_view line;
+    string_view ln;
 
-    Opm::getline( this->input_stack.top().input, line );
+    Opm::getline( this->input_stack.top().input, ln );
     this->input_stack.top().lineNR++;
 
-    return line;
+    return ln;
 }
 
 void ParserState::closeFile() {
@@ -331,10 +331,10 @@ void ParserState::loadFile(const boost::filesystem::path& inputFile) {
     std::fseek( fp, 0, SEEK_END );
     buffer.resize( std::ftell( fp ) + 1 );
     std::rewind( fp );
-    std::fread( &buffer[ 0 ], 1, buffer.size() - 1, fp );
+    const auto readc = std::fread( &buffer[ 0 ], 1, buffer.size() - 1, fp );
     buffer.back() = '\n';
 
-    if( std::ferror( fp ) )
+    if( std::ferror( fp ) || readc != buffer.size() - 1 )
         throw std::runtime_error( "Error when reading input file '"
                                 + inputFileCanonical.string() + "'" );
 
@@ -617,7 +617,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         return parserState.deck;
     }
 
-    void assertFullDeck(const ParseContext& context) {
+    inline void assertFullDeck(const ParseContext& context) {
         if (context.hasKey(ParseContext::PARSE_MISSING_SECTIONS))
             throw new std::logic_error("Cannot construct a state in partial deck context");
     }

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -38,6 +38,7 @@
 
 using namespace Opm;
 
+namespace {
 
 std::shared_ptr<ParserKeyword> createFixedSized(const std::string& kw , size_t size) {
     std::shared_ptr<ParserKeyword> pkw = std::make_shared<ParserKeyword>(kw);
@@ -62,6 +63,7 @@ std::shared_ptr<ParserKeyword> createTable(const std::string& name,
     return pkw;
 }
 
+}
 
 BOOST_AUTO_TEST_CASE(construct_withname_nameSet) {
     ParserKeywordConstPtr parserKeyword = createDynamicSized("BPR");

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -39,7 +39,7 @@
 
 using namespace Opm;
 
-std::unique_ptr< ParserKeyword > createDynamicSized(const std::string& kw) {
+inline std::unique_ptr< ParserKeyword > createDynamicSized(const std::string& kw) {
     std::unique_ptr< ParserKeyword > pkw( new ParserKeyword( kw ) );
     pkw->setSizeType(SLASH_TERMINATED);
     return pkw;

--- a/opm/parser/eclipse/RawDeck/StarToken.cpp
+++ b/opm/parser/eclipse/RawDeck/StarToken.cpp
@@ -105,7 +105,7 @@ namespace Opm {
             "Maximum 'double' length is " + std::to_string( width )
         );
 
-        std::array< char, width > buffer {};
+        std::array< char, width > buffer {{}};
         std::copy( view.begin(), view.end(), buffer.begin() );
 
 

--- a/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
+++ b/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
@@ -31,7 +31,7 @@
 
 using namespace Opm;
 
-std::shared_ptr<const Deck> createCOMPSEGSDeck() {
+inline std::shared_ptr<const Deck> createCOMPSEGSDeck() {
     const char *deckData =
         "COMPSEGS\n"
         " WELL /\n"

--- a/opm/parser/eclipse/Utility/Functional.cpp
+++ b/opm/parser/eclipse/Utility/Functional.cpp
@@ -21,9 +21,9 @@
 namespace Opm {
 namespace fun {
 
-    iota::iota( int begin, int end ) : first( begin ), last( end ) {}
+    iota::iota( int fst, int lst ) : first( fst ), last( lst ) {}
 
-    iota::iota( int end ) : iota( 0, end ) {}
+    iota::iota( int lst ) : iota( 0, lst ) {}
 
     size_t iota::size() const {
         return this->last - this->first;

--- a/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/opm/parser/eclipse/Utility/Stringview.hpp
@@ -147,16 +147,16 @@ namespace Opm {
 
     // Member functions of string_view.
 
-    inline string_view::string_view( const_iterator begin,
-                                     const_iterator end ) :
-        fst( begin ),
-        lst( end )
+    inline string_view::string_view( const_iterator first,
+                                     const_iterator last ) :
+        fst( first ),
+        lst( last )
     {}
 
-    inline string_view::string_view( const_iterator begin,
+    inline string_view::string_view( const_iterator first ,
                                      size_t count ) :
-        fst( begin ),
-        lst( begin + count )
+        fst( first ),
+        lst( first + count )
     {}
 
     inline string_view::string_view( const std::string& str ) :


### PR DESCRIPTION
This PR accomplishes two things:

1. It increases the warning level significantly. The previous warning level wasn't properly set because `CMAKE_CXX_FLAGS` typically was defined. The warnings have been made default by unconditionally setting them (when not microsoft), but only in debug mode. Debug mode is now the default build configuration.
2. I've gone through all warnings generated by this new warning set and fixed them.