### PR TITLE
Well matching returns empty list when no wells are found; Summary/Completion use Well matching

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -55,8 +55,9 @@ static DeckPtr createDeck( const std::string& summary ) {
             "/\n"
             "COMPDAT\n"
             "'PRODUCER'   5  5  1  1 'OPEN' 1* -1  0.5  / \n"
-            "'W_1'   3    7    1    3      'OPEN'  1*     32.948      0.311   3047.839  2*         'X'     22.100 / \n"
             "'W_1'   3    7    2    2      'OPEN'  1*          *      0.311   4332.346  2*         'X'     22.123 / \n"
+            "'W_1'   2    2    1    1      /\n"
+            "'WX2'   2    2    1    1      /\n"
             "/\n"
             "SUMMARY\n"
             + summary;
@@ -170,18 +171,26 @@ BOOST_AUTO_TEST_CASE(regions) {
 }
 
 BOOST_AUTO_TEST_CASE(completions) {
-    const auto input = "CWIR\n"
+    const auto input = "CWIR\n" // all specified
                        "'PRODUCER'  /\n"
                        "'WX2' 1 1 1 /\n"
-                       "'WX2' 2 2 2 /\n"
+                       "'WX2' 2 2 1 /\n"
                        "/\n"
-                       "CWIT\n"
+                       "CWIT\n" // block defaulted
                        "'W_1' /\n"
+                       "/\n"
+                       "CGIT\n" // well defaulted
+                       "* 2 2 1 /\n"
+                       "/\n"
+                       "CGIR\n" // all defaulted
+                       " '*' /\n"
                        "/\n";
 
     const auto summary = createSummary( input );
-    const auto keywords = { "CWIR", "CWIR", "CWIR",
-                            "CWIT", "CWIT", "CWIT" };
+    const auto keywords = { "CGIR", "CGIR", "CGIR", "CGIR",
+                            "CGIT", "CGIT",
+                            "CWIR", "CWIR",
+                            "CWIT", "CWIT" };
     const auto names = sorted_keywords( summary );
 
     BOOST_CHECK_EQUAL_COLLECTIONS(


### PR DESCRIPTION
**BEHAVIOURAL CHANGE**

The "soft" change here is that instead of simply accepting well names or * for well identifiers in the Completion family of summary keywords, patterns are accepted. This covers the documented behaviour *and more*, so hopefully everyone are pleased.

The more radical change, however, is  the modification to the well matching algorithm. It **used** to expand and check wild cards (denoted by *) and then include every well matching, returning possibly the empty list. However, when looking up a well by name (a set pattern, if you will) it would *throw* if the well wasn't found. This has been changed to, in the case of an invalid well name, returning an empty list.

This is consistent to the matching behaviour, but some code (in particular WELTARG) relied on the throwing behaviour. This behaviour has been preserved by checking if the list of matched wells is empty or not.