### PR TITLE
[Summary] W-keywords accept patterns

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -125,6 +125,16 @@ BOOST_AUTO_TEST_CASE(wells_select) {
             names.begin(), names.end() );
 }
 
+BOOST_AUTO_TEST_CASE(wells_pattern) {
+    const auto input = "WWCT\n'W*' /\n";
+    const auto summary = createSummary( input );
+    const auto wells = { "WX2", "W_1", "W_3" };
+    const auto names = sorted_names( summary );
+
+    BOOST_CHECK_EQUAL_COLLECTIONS(
+            wells.begin(), wells.end(),
+            names.begin(), names.end() );
+}
 
 BOOST_AUTO_TEST_CASE(fields) {
     const auto input = "FOPT\n";


### PR DESCRIPTION
The W-family of keywords accept a pattern to expand, rather than just
names or defaulted-all. This is the actual behaviour, according to the
manual.