### PR TITLE
Unit system unit name

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -77,6 +77,29 @@ namespace {
         Metric::ReservoirVolume / Metric::Time,
         Metric::Transmissibility,
         Metric::Mass,
+        1, /* gas-oil ratio */
+        1, /* oil-gas ratio */
+        1, /* water cut */
+    };
+
+    static constexpr const char* metric_names[] = {
+        "",
+        "M",
+        "DAY",
+        "KG/M3",
+        "BARSA",
+        "K",
+        "C",
+        "CP",
+        "MD",
+        "SM3",
+        "SM3",
+        "RM3",
+        "SM3/DAY",
+        "SM3/DAY",
+        "RM3/DAY",
+        "CPR3/DAY/BARS",
+        "KG"
     };
 
     static const double to_field[] = {
@@ -119,6 +142,25 @@ namespace {
          Field::Mass,
     };
 
+    static constexpr const char* field_names[] = {
+        "",
+        "FT",
+        "DAY",
+        "LB/FT3",
+        "PSIA",
+        "R",
+        "F",
+        "CP",
+        "MD",
+        "STB",
+        "MSCF",
+        "RB",
+        "STB/DAY",
+        "MSCF/DAY",
+        "RB/DAY",
+        "CPRB/DAY/PSI",
+        "LB"
+    };
 }
 
     UnitSystem::UnitSystem(const UnitType unit) :
@@ -129,11 +171,13 @@ namespace {
                 m_name = "Metric";
                 this->measure_table_from_si = to_metric;
                 this->measure_table_to_si = from_metric;
+                this->unit_name_table = metric_names;
                 break;
             case(UNIT_TYPE_FIELD):
                 m_name = "Field";
                 this->measure_table_from_si = to_field;
                 this->measure_table_to_si = from_field;
+                this->unit_name_table = field_names;
                 break;
             case(UNIT_TYPE_LAB):
                 m_name = "Lab";
@@ -261,6 +305,10 @@ namespace {
 
     double UnitSystem::to_si( measure m, double val ) const {
         return this->measure_table_to_si[ static_cast< int >( m ) ] * val;
+    }
+
+    const char* UnitSystem::name( measure m ) const {
+        return this->unit_name_table[ static_cast< int >( m ) ];
     }
 
     UnitSystem * UnitSystem::newMETRIC() {

--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -57,6 +57,9 @@ namespace {
         1 / ( Metric::ReservoirVolume / Metric::Time ),
         1 / Metric::Transmissibility,
         1 / Metric::Mass,
+        1, /* gas-oil ratio */
+        1, /* oil-gas ratio */
+        1, /* water cut */
     };
 
     static const double from_metric[] = {
@@ -99,7 +102,10 @@ namespace {
         "SM3/DAY",
         "RM3/DAY",
         "CPR3/DAY/BARS",
-        "KG"
+        "KG",
+        "SM3/SM3",
+        "SM3/SM3",
+        "SM3/SM3",
     };
 
     static const double to_field[] = {
@@ -120,6 +126,9 @@ namespace {
         1 / ( Field::ReservoirVolume / Field::Time ),
         1 / Field::Transmissibility,
         1 / Field::Mass,
+        1, /* gas-oil ratio */
+        1, /* oil-gas ratio */
+        1, /* water cut */
     };
 
     static const double from_field[] = {
@@ -140,6 +149,9 @@ namespace {
          Field::ReservoirVolume / Field::Time,
          Field::Transmissibility,
          Field::Mass,
+         1, /* gas-oil ratio */
+         1, /* oil-gas ratio */
+         1, /* water cut */
     };
 
     static constexpr const char* field_names[] = {
@@ -159,7 +171,10 @@ namespace {
         "MSCF/DAY",
         "RB/DAY",
         "CPRB/DAY/PSI",
-        "LB"
+        "LB",
+        "MSCF/STB",
+        "STB/MSCF",
+        "STB/STB",
     };
 }
 

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -54,6 +54,9 @@ namespace Opm {
             rate,
             transmissibility,
             mass,
+            gas_oil_ratio,
+            oil_gas_ratio,
+            water_cut,
         };
 
         UnitSystem(UnitType unit);

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -72,6 +72,7 @@ namespace Opm {
 
         double from_si( measure, double ) const;
         double to_si( measure, double ) const;
+        const char* name( measure ) const;
 
         static UnitSystem * newMETRIC();
         static UnitSystem * newFIELD();
@@ -83,6 +84,7 @@ namespace Opm {
         std::map<std::string , std::shared_ptr<const Dimension> > m_dimensions;
         const double* measure_table_from_si;
         const double* measure_table_to_si;
+        const char* const*  unit_name_table;
     };
 }
 


### PR DESCRIPTION
Extends unit system support by adding three new units, all ratios, which are non-scaling. The more major feature is the ability to look up a string representation of the unit (M, M3, KG, FT, BARSA etc) from a `measure`.

The need is largely driven from opm-output.