### PR TITLE
Removing some use of shared_ptr

### DIFF
--- a/opm/parser/eclipse/Applications/opmi.cpp
+++ b/opm/parser/eclipse/Applications/opmi.cpp
@@ -51,7 +51,7 @@ inline void loadDeck( const char * deck_file) {
     std::cout << "Loading deck: " << deck_file << " ..... "; std::cout.flush();
     deck = parser->parseFile(deck_file, parseContext);
     std::cout << "parse complete - creating EclipseState .... ";  std::cout.flush();
-    state = std::make_shared<Opm::EclipseState>( deck , parseContext );
+    state = std::make_shared<Opm::EclipseState>( *deck , parseContext );
     std::cout << "complete." << std::endl;
 
     dumpMessages( deck->getMessageContainer() );

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -39,8 +39,8 @@ namespace Opm {
                                  const Schedule& schedule,
                                  const ParseContext& parseContext) :
             m_ioConfig(        std::make_shared<IOConfig>(deck)),
-            m_initConfig(      std::make_shared<const InitConfig>(deck)),
-            m_simulationConfig(std::make_shared<const SimulationConfig>(deck, eclipse3DProperties)),
+            m_initConfig(      deck),
+            m_simulationConfig(deck, eclipse3DProperties),
             m_summaryConfig(   deck, schedule, eclipse3DProperties, parseContext , inputGrid.getNXYZ())
     {
         m_ioConfig->initFirstRFTOutput(schedule);
@@ -58,11 +58,11 @@ namespace Opm {
         return m_ioConfig;
     }
 
-    InitConfigConstPtr EclipseConfig::getInitConfig() const {
+    const InitConfig& EclipseConfig::getInitConfig() const {
         return m_initConfig;
     }
 
-    SimulationConfigConstPtr EclipseConfig::getSimulationConfig() const {
+    const SimulationConfig& EclipseConfig::getSimulationConfig() const {
         return m_simulationConfig;
     }
 }

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -46,8 +46,30 @@ namespace Opm {
         m_ioConfig->initFirstRFTOutput(schedule);
     }
 
-    const SummaryConfig& EclipseConfig::getSummaryConfig() const {
+
+    const InitConfig& EclipseConfig::init() const {
+        return m_initConfig;
+    }
+
+    const IOConfig& EclipseConfig::io() const {
+        return *m_ioConfig;
+    }
+
+    IOConfig& EclipseConfig::io() {
+        return *m_ioConfig;
+    }
+
+    const SimulationConfig& EclipseConfig::simulation() const {
+        return m_simulationConfig;
+    }
+
+    const SummaryConfig& EclipseConfig::summary() const {
         return m_summaryConfig;
+    }
+
+    // [[deprecated]] --- use summary()
+    const SummaryConfig& EclipseConfig::getSummaryConfig() const {
+        return summary();
     }
 
     IOConfigConstPtr EclipseConfig::getIOConfigConst() const {
@@ -58,11 +80,13 @@ namespace Opm {
         return m_ioConfig;
     }
 
+    // [[deprecated]] --- use init()
     const InitConfig& EclipseConfig::getInitConfig() const {
-        return m_initConfig;
+        return init();
     }
 
+    // [[deprecated]] --- use simulation()
     const SimulationConfig& EclipseConfig::getSimulationConfig() const {
-        return m_simulationConfig;
+        return simulation();
     }
 }

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -43,8 +43,14 @@ namespace Opm {
                       const Schedule& schedule,
                       const ParseContext& parseContext);
 
-        std::shared_ptr< const IOConfig > getIOConfigConst() const;
-        std::shared_ptr< IOConfig > getIOConfig() const;
+        const InitConfig& init() const;
+        const IOConfig& io() const;
+        IOConfig& io();
+        const SimulationConfig & simulation() const;
+        const SummaryConfig& summary() const;
+
+        std::shared_ptr<const IOConfig> getIOConfigConst() const;
+        std::shared_ptr<IOConfig> getIOConfig() const;
         const InitConfig& getInitConfig() const;
         const SimulationConfig & getSimulationConfig() const;
         const SummaryConfig& getSummaryConfig() const;

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -23,6 +23,8 @@
 #include <memory>
 
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 
 namespace Opm {
 
@@ -30,8 +32,6 @@ namespace Opm {
     class GridDims;
     class Eclipse3DProperties;
     class IOConfig;
-    class InitConfig;
-    class SimulationConfig;
     class ParseContext;
 
     class EclipseConfig
@@ -45,14 +45,14 @@ namespace Opm {
 
         std::shared_ptr< const IOConfig > getIOConfigConst() const;
         std::shared_ptr< IOConfig > getIOConfig() const;
-        std::shared_ptr< const InitConfig > getInitConfig() const;
-        std::shared_ptr< const SimulationConfig > getSimulationConfig() const;
+        const InitConfig& getInitConfig() const;
+        const SimulationConfig & getSimulationConfig() const;
         const SummaryConfig& getSummaryConfig() const;
 
     private:
         std::shared_ptr<IOConfig> m_ioConfig;
-        std::shared_ptr<const InitConfig> m_initConfig;
-        std::shared_ptr<const SimulationConfig> m_simulationConfig;
+        const InitConfig m_initConfig;
+        const SimulationConfig m_simulationConfig;
         SummaryConfig m_summaryConfig;
     };
 }

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -145,7 +145,7 @@ namespace Opm {
         return m_eclipseConfig.getIOConfig();
     }
 
-    InitConfigConstPtr EclipseState::getInitConfig() const {
+    const InitConfig& EclipseState::getInitConfig() const {
         return m_eclipseConfig.getInitConfig();
     }
 
@@ -153,7 +153,7 @@ namespace Opm {
         return m_eclipseConfig;
     }
 
-    SimulationConfigConstPtr EclipseState::getSimulationConfig() const {
+    const SimulationConfig& EclipseState::getSimulationConfig() const {
         return m_eclipseConfig.getSimulationConfig();
     }
 

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -137,22 +137,31 @@ namespace Opm {
         return m_schedule;
     }
 
+    /// [[deprecated]] --- use cfg().io()
     IOConfigConstPtr EclipseState::getIOConfigConst() const {
         return m_eclipseConfig.getIOConfigConst();
     }
 
+    /// [[deprecated]] --- use cfg().io()
     IOConfigPtr EclipseState::getIOConfig() const {
         return m_eclipseConfig.getIOConfig();
     }
 
+    /// [[deprecated]] --- use cfg().init()
     const InitConfig& EclipseState::getInitConfig() const {
         return m_eclipseConfig.getInitConfig();
     }
 
+    /// [[deprecated]] --- use cfg()
     const EclipseConfig& EclipseState::getEclipseConfig() const {
+        return cfg();
+    }
+
+    const EclipseConfig& EclipseState::cfg() const {
         return m_eclipseConfig;
     }
 
+    /// [[deprecated]] --- use cfg().simulation()
     const SimulationConfig& EclipseState::getSimulationConfig() const {
         return m_eclipseConfig.getSimulationConfig();
     }

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -92,6 +92,7 @@ namespace Opm {
 
         const TableManager& getTableManager() const;
         const EclipseConfig& getEclipseConfig() const;
+        const EclipseConfig& cfg() const;
 
         // the unit system used by the deck. note that it is rarely needed to convert
         // units because internally to opm-parser everything is represented by SI

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -72,8 +72,9 @@ namespace Opm {
         std::shared_ptr< const Schedule > getSchedule() const;
         std::shared_ptr< const IOConfig > getIOConfigConst() const;
         std::shared_ptr< IOConfig > getIOConfig() const;
-        std::shared_ptr< const InitConfig > getInitConfig() const;
-        std::shared_ptr< const SimulationConfig > getSimulationConfig() const;
+
+        const InitConfig& getInitConfig() const;
+        const SimulationConfig& getSimulationConfig() const;
         const SummaryConfig& getSummaryConfig() const;
 
         std::shared_ptr< const EclipseGrid > getInputGrid() const;

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -50,7 +51,6 @@ namespace Opm {
     class Section;
     class SimulationConfig;
     class TableManager;
-    class TransMult;
     class UnitSystem;
 
     class EclipseState {
@@ -80,7 +80,7 @@ namespace Opm {
         std::shared_ptr< EclipseGrid > getInputGridCopy() const;
 
         const FaultCollection& getFaults() const;
-        std::shared_ptr<const TransMult> getTransMult() const;
+        const TransMult& getTransMult() const;
 
         /// non-neighboring connections
         /// the non-standard adjacencies as specified in input deck
@@ -102,8 +102,6 @@ namespace Opm {
         MessageContainer& getMessageContainer();
         std::string getTitle() const;
 
-        /// [deprecated]
-        void applyModifierDeck(std::shared_ptr<const Deck>);
         void applyModifierDeck(const Deck& deck);
 
     private:
@@ -120,13 +118,13 @@ namespace Opm {
         const TableManager m_tables;
         const GridDims m_gridDims;
         std::shared_ptr<EclipseGrid> m_inputGrid;
+        TransMult m_transMult;
         std::shared_ptr< const Schedule > m_schedule;
         Eclipse3DProperties m_eclipseProperties;
         EclipseConfig m_eclipseConfig;
         NNC m_inputNnc;
         UnitSystem m_deckUnitSystem;
 
-        std::shared_ptr<TransMult> m_transMult;
         FaultCollection m_faults;
         std::string m_title;
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/ADDREGTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/ADDREGTests.cpp
@@ -234,31 +234,31 @@ static Opm::DeckPtr createValidPERMXDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::DeckPtr deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::DeckPtr deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedRegionThrows) {
     Opm::DeckPtr deck = createDeckUnInitializedRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitializedVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/CopyRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/CopyRegTests.cpp
@@ -183,19 +183,19 @@ static Opm::DeckPtr createValidIntDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows1) {
     Opm::DeckPtr deck = createDeckInvalidArray1();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows2) {
     Opm::DeckPtr deck = createDeckInvalidArray2();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
@@ -203,13 +203,13 @@ BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(TypeMismatchThrows) {
     Opm::DeckPtr deck = createDeckInvalidTypeMismatch();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EclipseGridTests.cpp
@@ -919,7 +919,7 @@ static Opm::DeckPtr createActnumBoxDeck() {
 
 BOOST_AUTO_TEST_CASE(GridBoxActnum) {
     Opm::DeckConstPtr deck = createActnumBoxDeck();
-    Opm::EclipseState es(deck, Opm::ParseContext());
+    Opm::EclipseState es(*deck, Opm::ParseContext());
     auto ep = es.get3DProperties();
     auto grid = es.getInputGrid();
 
@@ -970,7 +970,7 @@ BOOST_AUTO_TEST_CASE(GridBoxActnum) {
 BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
     Opm::DeckConstPtr deck = createActnumDeck();
 
-    Opm::EclipseState es(deck, Opm::ParseContext());
+    Opm::EclipseState es(*deck, Opm::ParseContext());
     auto ep = es.get3DProperties();
     auto grid = es.getInputGrid();
     Opm::EclipseGrid grid2( *grid );
@@ -986,8 +986,8 @@ BOOST_AUTO_TEST_CASE(GridActnumVia3D) {
 BOOST_AUTO_TEST_CASE(GridActnumViaState) {
     Opm::DeckConstPtr deck = createActnumDeck();
 
-    BOOST_CHECK_NO_THROW(Opm::EclipseState(deck, Opm::ParseContext()));
-    Opm::EclipseState es(deck, Opm::ParseContext());
+    BOOST_CHECK_NO_THROW(Opm::EclipseState(*deck, Opm::ParseContext()));
+    Opm::EclipseState es(*deck, Opm::ParseContext());
     BOOST_CHECK_EQUAL(es.getInputGrid()->getNumActive(), 2 * 2 * 2 - 1);
 }
 

--- a/opm/parser/eclipse/EclipseState/Grid/tests/EqualRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/EqualRegTests.cpp
@@ -211,23 +211,23 @@ static Opm::DeckPtr createValidPERMXDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::DeckPtr deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::DeckPtr deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {

--- a/opm/parser/eclipse/EclipseState/Grid/tests/MultiRegTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/MultiRegTests.cpp
@@ -187,29 +187,29 @@ static Opm::DeckPtr createValidIntDeck() {
 
 BOOST_AUTO_TEST_CASE(InvalidArrayThrows) {
     Opm::DeckPtr deck = createDeckInvalidArray();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(InvalidRegionThrows) {
     Opm::DeckPtr deck = createDeckInvalidRegion();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 
 BOOST_AUTO_TEST_CASE(ExpectedIntThrows) {
     Opm::DeckPtr deck = createDeckInvalidValue();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(MissingRegionVectorThrows) {
     Opm::DeckPtr deck = createDeckMissingVector();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(UnInitializedVectorThrows) {
     Opm::DeckPtr deck = createDeckUnInitialized();
-    BOOST_CHECK_THROW( new Opm::EclipseState( deck, Opm::ParseContext()) , std::invalid_argument );
+    BOOST_CHECK_THROW( new Opm::EclipseState( *deck, Opm::ParseContext()) , std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(IntSetCorrectly) {

--- a/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
@@ -385,7 +385,7 @@ static Opm::DeckPtr createDeckWithPOROZero() {
 BOOST_AUTO_TEST_CASE(PORO_ZERO_ACTNUM_CORRECT) {
     /* Check that MULTIPLE Boxed PORV and MULTPV statements work and NTG */
     Opm::DeckPtr deck = createDeckWithPOROZero();
-    Opm::EclipseState state( deck , Opm::ParseContext());
+    Opm::EclipseState state( *deck , Opm::ParseContext());
     auto grid = state.getInputGrid( );
 
     /* Top layer is active */

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -212,7 +212,7 @@ namespace Opm {
         m_output_enabled = enabled;
     }
 
-    std::string IOConfig::getOutputDir() {
+    std::string IOConfig::getOutputDir() const {
         return m_output_dir;
     }
 

--- a/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -147,7 +147,7 @@ namespace Opm {
         bool getOutputEnabled();
         void setOutputEnabled(bool enabled);
 
-        std::string getOutputDir();
+        std::string getOutputDir() const;
         void setOutputDir(const std::string& outputDir);
 
         const std::string& getBaseName() const;

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -163,10 +163,10 @@ static DeckPtr createDeck(const std::string& input) {
 BOOST_AUTO_TEST_CASE( RFT_TIME) {
     DeckPtr deck = createDeck(deckStr_RFT);
     EclipseState state( *deck , Opm::ParseContext() );
-    std::shared_ptr<const IOConfig> ioConfig = state.getIOConfigConst();
+    const IOConfig& ioConfig = state.cfg().io();
 
 
-    BOOST_CHECK_EQUAL( ioConfig->getFirstRFTStep() , 2 );
+    BOOST_CHECK_EQUAL( ioConfig.getFirstRFTStep() , 2 );
 }
 
 BOOST_AUTO_TEST_CASE(RPTRST_mixed_mnemonics_int_list) {

--- a/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/tests/IOConfigTest.cpp
@@ -162,7 +162,7 @@ static DeckPtr createDeck(const std::string& input) {
 
 BOOST_AUTO_TEST_CASE( RFT_TIME) {
     DeckPtr deck = createDeck(deckStr_RFT);
-    EclipseState state( deck , Opm::ParseContext() );
+    EclipseState state( *deck , Opm::ParseContext() );
     std::shared_ptr<const IOConfig> ioConfig = state.getIOConfigConst();
 
 

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -98,7 +98,7 @@ static std::vector< std::string > sorted_key_names( const SummaryConfig& summary
 
 static SummaryConfig createSummary( std::string input , const ParseContext& parseContext = ParseContext()) {
     auto deck = createDeck( input );
-    EclipseState state( deck, parseContext );
+    EclipseState state( *deck, parseContext );
     return state.getEclipseConfig().getSummaryConfig();
 }
 

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -95,7 +95,7 @@ return parser->parseString(deckData, ParseContext()) ;
 
 BOOST_AUTO_TEST_CASE(GetPOROTOPBased) {
     DeckPtr deck = createDeckTOP();
-    EclipseState state(deck , ParseContext());
+    EclipseState state(*deck , ParseContext());
     const Eclipse3DProperties& props = state.get3DProperties();
 
     const GridProperty<double>& poro  = props.getDoubleGridProperty( "PORO" );
@@ -194,14 +194,13 @@ ParserPtr parser(new Parser());
 return parser->parseString(deckData, ParseContext()) ;
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateSchedule) {
-DeckPtr deck = createDeck();
-EclipseState state(deck , ParseContext());
-ScheduleConstPtr schedule = state.getSchedule();
-EclipseGridConstPtr eclipseGrid = state.getInputGrid();
+    DeckPtr deck = createDeck();
+    EclipseState state(*deck, ParseContext());
+    ScheduleConstPtr schedule = state.getSchedule();
+    EclipseGridConstPtr eclipseGrid = state.getInputGrid();
 
-BOOST_CHECK_EQUAL( schedule->getStartTime() , boost::posix_time::ptime(boost::gregorian::date(1998 , 3 , 8 )));
+    BOOST_CHECK_EQUAL(schedule->getStartTime(), boost::posix_time::ptime(boost::gregorian::date(1998, 3, 8)));
 }
 
 
@@ -239,24 +238,23 @@ ParserPtr parser(new Parser());
 return parser->parseString(inputStr, ParseContext()) ;
 }
 
-
 BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
 
-DeckPtr deck = createDeckSimConfig();
-EclipseState state(deck, ParseContext());
-SimulationConfigConstPtr simConf = state.getSimulationConfig();
+    DeckPtr deck = createDeckSimConfig();
+    EclipseState state(*deck, ParseContext());
+    SimulationConfigConstPtr simConf = state.getSimulationConfig();
 
-BOOST_CHECK( simConf->hasThresholdPressure() );
+    BOOST_CHECK(simConf->hasThresholdPressure());
 
-std::shared_ptr<const ThresholdPressure> thresholdPressure = simConf->getThresholdPressure();
-BOOST_CHECK_EQUAL(thresholdPressure->size(), 3);
+    std::shared_ptr<const ThresholdPressure> thresholdPressure = simConf->getThresholdPressure();
+    BOOST_CHECK_EQUAL(thresholdPressure->size(), 3);
 }
 
 
 
 BOOST_AUTO_TEST_CASE(PhasesCorrect) {
     DeckPtr deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( *deck, ParseContext() );
     const auto& tm = state.getTableManager();
     BOOST_CHECK(   tm.hasPhase( Phase::PhaseEnum::OIL ));
     BOOST_CHECK(   tm.hasPhase( Phase::PhaseEnum::GAS ));
@@ -265,14 +263,14 @@ BOOST_AUTO_TEST_CASE(PhasesCorrect) {
 
 BOOST_AUTO_TEST_CASE(TitleCorrect) {
     DeckPtr deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( *deck, ParseContext() );
 
     BOOST_CHECK_EQUAL( state.getTitle(), "The title" );
 }
 
 BOOST_AUTO_TEST_CASE(IntProperties) {
     DeckPtr deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( *deck, ParseContext() );
 
     BOOST_CHECK_EQUAL( false, state.get3DProperties().supportsGridProperty( "NONO" ) );
     BOOST_CHECK_EQUAL( true,  state.get3DProperties().supportsGridProperty( "SATNUM" ) );
@@ -282,7 +280,7 @@ BOOST_AUTO_TEST_CASE(IntProperties) {
 
 BOOST_AUTO_TEST_CASE(GetProperty) {
     DeckPtr deck = createDeck();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(*deck, ParseContext());
 
     const auto& satNUM = state.get3DProperties().getIntGridProperty( "SATNUM" );
 
@@ -295,16 +293,16 @@ BOOST_AUTO_TEST_CASE(GetProperty) {
 
 BOOST_AUTO_TEST_CASE(GetTransMult) {
     DeckPtr deck = createDeck();
-    EclipseState state( deck, ParseContext() );
-    std::shared_ptr<const TransMult> transMult = state.getTransMult();
+    EclipseState state( *deck, ParseContext() );
+    const auto& transMult = state.getTransMult();
 
-    BOOST_CHECK_EQUAL( 1.0, transMult->getMultiplier( 1, 0, 0, FaceDir::XPlus ) );
-    BOOST_CHECK_THROW( transMult->getMultiplier( 1000, FaceDir::XPlus ), std::invalid_argument );
+    BOOST_CHECK_EQUAL( 1.0, transMult.getMultiplier( 1, 0, 0, FaceDir::XPlus ) );
+    BOOST_CHECK_THROW( transMult.getMultiplier( 1000, FaceDir::XPlus ), std::invalid_argument );
 }
 
 BOOST_AUTO_TEST_CASE(GetFaults) {
     DeckPtr deck = createDeck();
-    EclipseState state( deck, ParseContext() );
+    EclipseState state( *deck, ParseContext() );
     const auto& faults = state.getFaults();
 
     BOOST_CHECK( faults.hasFault( "F1" ) );
@@ -316,50 +314,50 @@ BOOST_AUTO_TEST_CASE(GetFaults) {
     BOOST_CHECK_EQUAL( 0.50, F1.getTransMult() );
     BOOST_CHECK_EQUAL( 0.25, F2.getTransMult() );
 
-    std::shared_ptr<const TransMult> transMult = state.getTransMult();
-    BOOST_CHECK_EQUAL( transMult->getMultiplier( 0, 0, 0, FaceDir::XPlus ), 0.50 );
-    BOOST_CHECK_EQUAL( transMult->getMultiplier( 4, 3, 0, FaceDir::XMinus ), 0.25 );
-    BOOST_CHECK_EQUAL( transMult->getMultiplier( 4, 3, 0, FaceDir::ZPlus ), 1.00 );
+    const auto& transMult = state.getTransMult();
+    BOOST_CHECK_EQUAL( transMult.getMultiplier( 0, 0, 0, FaceDir::XPlus ), 0.50 );
+    BOOST_CHECK_EQUAL( transMult.getMultiplier( 4, 3, 0, FaceDir::XMinus ), 0.25 );
+    BOOST_CHECK_EQUAL( transMult.getMultiplier( 4, 3, 0, FaceDir::ZPlus ), 1.00 );
 }
 
 
 BOOST_AUTO_TEST_CASE(FaceTransMults) {
     DeckPtr deck = createDeckNoFaults();
-    EclipseState state(deck, ParseContext());
-    std::shared_ptr<const TransMult> transMult = state.getTransMult();
+    EclipseState state(*deck, ParseContext());
+    const auto& transMult = state.getTransMult();
 
     for (int i = 0; i < 10; ++ i) {
         for (int j = 0; j < 10; ++ j) {
             for (int k = 0; k < 10; ++ k) {
                 if (k == 1)
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::XPlus), 10.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::XPlus), 10.0);
                 else
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::XPlus), 1.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::XPlus), 1.0);
 
                 if (k == 2)
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::XMinus), 11.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::XMinus), 11.0);
                 else
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::XMinus), 1.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::XMinus), 1.0);
 
                 if (k == 3)
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::YPlus), 12.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::YPlus), 12.0);
                 else
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::YPlus), 1.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::YPlus), 1.0);
 
                 if (k == 4)
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::YMinus), 13.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::YMinus), 13.0);
                 else
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::YMinus), 1.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::YMinus), 1.0);
 
                 if (k == 5)
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::ZPlus), 14.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::ZPlus), 14.0);
                 else
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::ZPlus), 1.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::ZPlus), 1.0);
 
                 if (k == 6)
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::ZMinus), 15.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::ZMinus), 15.0);
                 else
-                    BOOST_CHECK_EQUAL(transMult->getMultiplier(i, j, k, FaceDir::ZMinus), 1.0);
+                    BOOST_CHECK_EQUAL(transMult.getMultiplier(i, j, k, FaceDir::ZMinus), 1.0);
             }
         }
     }
@@ -420,7 +418,7 @@ static DeckPtr createDeckWithGridOpts() {
 
 BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
     DeckPtr deck = createDeckNoGridOpts();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(*deck, ParseContext());
     const auto& props   = state.get3DProperties();
     const auto& multnum = props.getIntGridProperty("MULTNUM");
     const auto& fluxnum = props.getIntGridProperty("FLUXNUM");
@@ -434,7 +432,7 @@ BOOST_AUTO_TEST_CASE(NoGridOptsDefaultRegion) {
 
 BOOST_AUTO_TEST_CASE(WithGridOptsDefaultRegion) {
     DeckPtr deck = createDeckWithGridOpts();
-    EclipseState state(deck, ParseContext());
+    EclipseState state(*deck, ParseContext());
     const auto& props   = state.get3DProperties();
     const auto& multnum = props.getIntGridProperty("MULTNUM");
     const auto& fluxnum = props.getIntGridProperty("FLUXNUM");
@@ -495,7 +493,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
 
     ParserPtr parser(new Parser());
     DeckPtr deck = parser->parseString(deckData, ParseContext()) ;
-    EclipseState state(deck , ParseContext());
+    EclipseState state(*deck , ParseContext());
 
     IOConfigConstPtr ioConfig = state.getIOConfigConst();
     const RestartConfig& rstConfig = ioConfig->restartConfig();
@@ -547,7 +545,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
     ParseContext parseContext;
     ParserPtr parser(new Parser());
     DeckPtr deck = parser->parseString(deckData, parseContext) ;
-    EclipseState state(deck, parseContext);
+    EclipseState state(*deck, parseContext);
 
     IOConfigConstPtr ioConfig = state.getIOConfigConst();
     const RestartConfig& rstConfig = ioConfig->restartConfig();
@@ -639,7 +637,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
 
     {   //mnemnonics
         DeckPtr deck = parser->parseString(deckData, parseContext) ;
-        EclipseState state(deck, parseContext);
+        EclipseState state(*deck, parseContext);
 
         IOConfigConstPtr ioConfig = state.getIOConfigConst();
         const RestartConfig& rstConfig = ioConfig->restartConfig();
@@ -649,7 +647,7 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
 
     {   //old fashion integer mnemonics
         DeckPtr deck = parser->parseString(deckData2, parseContext) ;
-        EclipseState state(deck, parseContext);
+        EclipseState state(*deck, parseContext);
 
         IOConfigConstPtr ioConfig = state.getIOConfigConst();
         const RestartConfig& rstConfig = ioConfig->restartConfig();

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -448,14 +448,16 @@ BOOST_AUTO_TEST_CASE(TestIOConfigBaseName) {
     ParserPtr parser(new Parser());
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE1CASE2.DATA", parseContext);
     EclipseState state(*deck, parseContext);
-    BOOST_CHECK_EQUAL(state.getIOConfig()->getBaseName(), "SPE1CASE2");
-    BOOST_CHECK_EQUAL(state.getIOConfig()->getOutputDir(), "testdata/integration_tests/IOConfig");
+    const auto& io = state.cfg().io();
+    BOOST_CHECK_EQUAL(io.getBaseName(), "SPE1CASE2");
+    BOOST_CHECK_EQUAL(io.getOutputDir(), "testdata/integration_tests/IOConfig");
 
     ParserPtr parser2(new Parser());
     DeckConstPtr deck2 = createDeckWithGridOpts();
     EclipseState state2(*deck2, parseContext);
-    BOOST_CHECK_EQUAL(state2.getIOConfig()->getBaseName(), "");
-    BOOST_CHECK_EQUAL(state2.getIOConfig()->getOutputDir(), ".");
+    const auto& io2 = state2.cfg().io();
+    BOOST_CHECK_EQUAL(io2.getBaseName(), "");
+    BOOST_CHECK_EQUAL(io2.getOutputDir(), ".");
 }
 
 BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
@@ -495,8 +497,8 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreation) {
     DeckPtr deck = parser->parseString(deckData, ParseContext()) ;
     EclipseState state(*deck , ParseContext());
 
-    IOConfigConstPtr ioConfig = state.getIOConfigConst();
-    const RestartConfig& rstConfig = ioConfig->restartConfig();
+    const IOConfig& ioConfig = state.cfg().io();
+    const RestartConfig& rstConfig = ioConfig.restartConfig();
 
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false, rstConfig.getWriteRestartFile(1));
@@ -547,8 +549,8 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTRST) {
     DeckPtr deck = parser->parseString(deckData, parseContext) ;
     EclipseState state(*deck, parseContext);
 
-    IOConfigConstPtr ioConfig = state.getIOConfigConst();
-    const RestartConfig& rstConfig = ioConfig->restartConfig();
+    const IOConfig& ioConfig = state.cfg().io();
+    const RestartConfig& rstConfig = ioConfig.restartConfig();
 
     BOOST_CHECK_EQUAL(true  ,  rstConfig.getWriteRestartFile(0));
     BOOST_CHECK_EQUAL(false ,  rstConfig.getWriteRestartFile(1));
@@ -639,8 +641,8 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
         DeckPtr deck = parser->parseString(deckData, parseContext) ;
         EclipseState state(*deck, parseContext);
 
-        IOConfigConstPtr ioConfig = state.getIOConfigConst();
-        const RestartConfig& rstConfig = ioConfig->restartConfig();
+        const IOConfig& ioConfig = state.cfg().io();
+        const RestartConfig& rstConfig = ioConfig.restartConfig();
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }
@@ -649,8 +651,8 @@ BOOST_AUTO_TEST_CASE(TestIOConfigCreationWithSolutionRPTSOL) {
         DeckPtr deck = parser->parseString(deckData2, parseContext) ;
         EclipseState state(*deck, parseContext);
 
-        IOConfigConstPtr ioConfig = state.getIOConfigConst();
-        const RestartConfig& rstConfig = ioConfig->restartConfig();
+        const IOConfig& ioConfig = state.cfg().io();
+        const RestartConfig& rstConfig = ioConfig.restartConfig();
 
         BOOST_CHECK_EQUAL(true, rstConfig.getWriteRestartFile(0));
     }

--- a/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/EclipseStateTests.cpp
@@ -242,11 +242,11 @@ BOOST_AUTO_TEST_CASE(CreateSimulationConfig) {
 
     DeckPtr deck = createDeckSimConfig();
     EclipseState state(*deck, ParseContext());
-    SimulationConfigConstPtr simConf = state.getSimulationConfig();
+    const auto& simConf = state.getSimulationConfig();
 
-    BOOST_CHECK(simConf->hasThresholdPressure());
+    BOOST_CHECK(simConf.hasThresholdPressure());
 
-    std::shared_ptr<const ThresholdPressure> thresholdPressure = simConf->getThresholdPressure();
+    std::shared_ptr<const ThresholdPressure> thresholdPressure = simConf.getThresholdPressure();
     BOOST_CHECK_EQUAL(thresholdPressure->size(), 3);
 }
 

--- a/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/BoxTest.cpp
@@ -42,7 +42,7 @@ EclipseState makeState(const std::string& fileName) {
     ParserPtr parser(new Parser( ));
     boost::filesystem::path boxFile(fileName);
     DeckPtr deck =  parser->parseFile(boxFile.string(), ParseContext());
-    EclipseState state(deck , ParseContext());
+    EclipseState state(*deck , ParseContext());
     return state;
 }
 

--- a/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/EclipseGridCreateFromDeck.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE(CreateCPGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    EclipseState es(*deck, ParseContext());
     auto grid = es.getInputGrid();
 
     BOOST_CHECK_EQUAL( 10U  , grid->getNX( ));
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE(CreateCPActnumGrid) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    EclipseState es(*deck, ParseContext());
     auto grid = es.getInputGrid();
 
     BOOST_CHECK_EQUAL(  10U , grid->getNX( ));
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridAllActive) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    EclipseState es(*deck, ParseContext());
     auto grid = es.getInputGrid();
 
     std::vector<int> actnum;
@@ -85,7 +85,7 @@ BOOST_AUTO_TEST_CASE(ExportFromCPGridACTNUM) {
     ParserPtr parser(new Parser());
     boost::filesystem::path scheduleFile("testdata/integration_tests/GRID/CORNERPOINT_ACTNUM.DATA");
     DeckPtr deck =  parser->parseFile(scheduleFile.string(), ParseContext());
-    EclipseState es(deck, ParseContext());
+    EclipseState es(*deck, ParseContext());
     auto grid = es.getInputGrid();
 
     std::vector<double> coord;

--- a/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -338,7 +338,7 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     ParseContext parseContext;
     ParserPtr parser(new Parser());
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/RPT_TEST2.DATA", parseContext);
-    EclipseState state( deck , parseContext );
+    EclipseState state( *deck , parseContext );
     std::shared_ptr<const IOConfig> ioConfig = state.getIOConfigConst();
     verifyRestartConfig(ioConfig, rptConfig);
 
@@ -351,5 +351,5 @@ BOOST_AUTO_TEST_CASE( SPE9END ) {
     ParseContext parseContext;
     ParserPtr parser(new Parser());
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/SPE9_END.DATA", parseContext);
-    BOOST_CHECK_NO_THROW( EclipseState state( deck , parseContext ) );
+    BOOST_CHECK_NO_THROW( EclipseState state( *deck , parseContext ) );
 }

--- a/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/opm/parser/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -36,16 +36,16 @@
 
 using namespace Opm;
 
-inline void verifyRestartConfig(IOConfigConstPtr ioconfig, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
+inline void verifyRestartConfig(const IOConfig& io, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
 
     for (auto rptrst : rptConfig) {
         int report_step                    = std::get<0>(rptrst);
         bool save                          = std::get<1>(rptrst);
         boost::gregorian::date report_date = std::get<2>(rptrst);
 
-        BOOST_CHECK_EQUAL( save , ioconfig->restartConfig().getWriteRestartFile( report_step ));
+        BOOST_CHECK_EQUAL( save , io.restartConfig().getWriteRestartFile( report_step ));
         if (save) {
-            BOOST_CHECK_EQUAL( report_date, ioconfig->getTimestepDate( report_step ));
+            BOOST_CHECK_EQUAL( report_date, io.getTimestepDate( report_step ));
         }
     }
 }
@@ -297,7 +297,7 @@ BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
 
 
     auto state = Parser::parse("testdata/integration_tests/IOConfig/RPTRST_DECK.DATA");
-    verifyRestartConfig(state.getIOConfigConst(), rptConfig);
+    verifyRestartConfig(state.cfg().io(), rptConfig);
 }
 
 
@@ -339,10 +339,10 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     ParserPtr parser(new Parser());
     DeckConstPtr deck = parser->parseFile("testdata/integration_tests/IOConfig/RPT_TEST2.DATA", parseContext);
     EclipseState state( *deck , parseContext );
-    std::shared_ptr<const IOConfig> ioConfig = state.getIOConfigConst();
+    const IOConfig& ioConfig = state.cfg().io();
     verifyRestartConfig(ioConfig, rptConfig);
 
-    BOOST_CHECK_EQUAL( ioConfig->getFirstRestartStep() , 0 );
+    BOOST_CHECK_EQUAL( ioConfig.getFirstRestartStep() , 0 );
 }
 
 

--- a/opm/parser/eclipse/IntegrationTests/ParseMULTREGT.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseMULTREGT.cpp
@@ -51,50 +51,50 @@ BOOST_AUTO_TEST_CASE( MULTREGT_ECLIPSE_STATE ) {
     ParseContext parseContext;
     ParserPtr parser(new Parser());
     DeckPtr deck =  parser->parseFile("testdata/integration_tests/MULTREGT/MULTREGT.DATA", parseContext);
-    EclipseState state(deck , parseContext);
+    EclipseState state(*deck , parseContext);
     auto transMult = state.getTransMult();
 
     // Test NONNC
     // cell 0 and 1 are neigbours
-    BOOST_CHECK_EQUAL( 0.10 , transMult->getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 0.10 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XPlus));
     // cell 0 and 3 are not neigbours ==> 1
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 0 , 3 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 3 , FaceDir::DirEnum::XPlus));
 
     // Test NNC
     // cell 4 and 5 are neigbours ==> 1
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 4 , 5 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 4 , 5 , FaceDir::DirEnum::XPlus));
     // cell 4 and 7 are not neigbours
-    BOOST_CHECK_EQUAL( 0.50 , transMult->getRegionMultiplier( 4 , 7 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 0.50 , transMult.getRegionMultiplier( 4 , 7 , FaceDir::DirEnum::XPlus));
 
     // Test direction X, returns 1 for directions other than +-X
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::YPlus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::ZPlus));
-    BOOST_CHECK_EQUAL( 0.10 , transMult->getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XMinus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::YMinus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::ZMinus));
-    BOOST_CHECK_EQUAL( 0.20 , transMult->getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::XPlus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::YPlus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::ZPlus));
-    BOOST_CHECK_EQUAL( 0.20 , transMult->getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::XMinus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::YMinus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::ZMinus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::YPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::ZPlus));
+    BOOST_CHECK_EQUAL( 0.10 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::XMinus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::YMinus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 1 , FaceDir::DirEnum::ZMinus));
+    BOOST_CHECK_EQUAL( 0.20 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::YPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::ZPlus));
+    BOOST_CHECK_EQUAL( 0.20 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::XMinus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::YMinus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 1 , 0 , FaceDir::DirEnum::ZMinus));
 
     // Multipliers between cells of the same region should return 1
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 0 , 2 , FaceDir::DirEnum::XPlus));
-    BOOST_CHECK_EQUAL( 1.00 , transMult->getRegionMultiplier( 2 , 0 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 0 , 2 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.00 , transMult.getRegionMultiplier( 2 , 0 , FaceDir::DirEnum::XPlus));
 
     // Test direcion XYZ, returns values for all directions
-    BOOST_CHECK_EQUAL( 1.50 , transMult->getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::XPlus));
-    BOOST_CHECK_EQUAL( 1.50 , transMult->getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::YPlus));
-    BOOST_CHECK_EQUAL( 1.50 , transMult->getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::ZPlus));
-    BOOST_CHECK_EQUAL( 1.50 , transMult->getRegionMultiplier( 4 , 0 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.50 , transMult.getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 1.50 , transMult.getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::YPlus));
+    BOOST_CHECK_EQUAL( 1.50 , transMult.getRegionMultiplier( 0 , 4 , FaceDir::DirEnum::ZPlus));
+    BOOST_CHECK_EQUAL( 1.50 , transMult.getRegionMultiplier( 4 , 0 , FaceDir::DirEnum::XPlus));
 
     // The first record is overwritten by the second
-    BOOST_CHECK_EQUAL( 2.50 , transMult->getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::XPlus));
-    BOOST_CHECK_EQUAL( 2.50 , transMult->getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::YPlus));
+    BOOST_CHECK_EQUAL( 2.50 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 2.50 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::YPlus));
 
     // The 2 4 0.75 Z input is overwritten by 2 4 2.5 XY, ==) that 2 4 Z returns the 4 2 value = 0.6
-    BOOST_CHECK_EQUAL( 0.60 , transMult->getRegionMultiplier( 7 , 3 , FaceDir::DirEnum::XPlus));
-    BOOST_CHECK_EQUAL( 0.60 , transMult->getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::ZPlus));
+    BOOST_CHECK_EQUAL( 0.60 , transMult.getRegionMultiplier( 7 , 3 , FaceDir::DirEnum::XPlus));
+    BOOST_CHECK_EQUAL( 0.60 , transMult.getRegionMultiplier( 3 , 7 , FaceDir::DirEnum::ZPlus));
 
 }

--- a/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseTOPS.cpp
@@ -40,7 +40,7 @@ BOOST_AUTO_TEST_CASE( PARSE_TOPS_OK) {
     std::string deckFile("testdata/integration_tests/GRID/TOPS.DATA");
     ParseContext parseContext;
     DeckPtr deck =  parser->parseFile(deckFile, parseContext);
-    EclipseState state(deck , parseContext);
+    EclipseState state(*deck , parseContext);
     EclipseGridConstPtr grid = state.getInputGrid();
 
     BOOST_CHECK_EQUAL( grid->getNX() , 9 );

--- a/opm/parser/eclipse/IntegrationTests/TransMultIntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/TransMultIntegrationTests.cpp
@@ -42,19 +42,19 @@ BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {
     ParserPtr parser(new Parser());
     std::string scheduleFile("testdata/integration_tests/TRANS/Deck1");
     ParseContext parseContext;
-    DeckPtr deck =  parser->parseFile(scheduleFile, parseContext);
-    std::shared_ptr<EclipseState> eclState = std::make_shared<EclipseState>( deck , parseContext );
-    std::shared_ptr<const TransMult> trans = eclState->getTransMult();
-    std::shared_ptr<const Schedule> schedule = eclState->getSchedule();
+    DeckPtr deck = parser->parseFile(scheduleFile, parseContext);
+    EclipseState state(*deck, parseContext);
+    const auto& trans = state.getTransMult();
+    std::shared_ptr<const Schedule> schedule = state.getSchedule();
     const Events& events = schedule->getEvents();
 
-    BOOST_CHECK_EQUAL( 0.10 , trans->getMultiplier( 3,2,0,FaceDir::XPlus ));
-    BOOST_CHECK_EQUAL( 0.10 , trans->getMultiplier( 2,2,0,FaceDir::XPlus ));
+    BOOST_CHECK_EQUAL( 0.10 , trans.getMultiplier( 3,2,0,FaceDir::XPlus ));
+    BOOST_CHECK_EQUAL( 0.10 , trans.getMultiplier( 2,2,0,FaceDir::XPlus ));
     BOOST_CHECK( events.hasEvent( ScheduleEvents::GEO_MODIFIER , 3 ) );
     {
         std::shared_ptr<const Deck> mini_deck = schedule->getModifierDeck(3);
-        eclState->applyModifierDeck( *mini_deck );
+        state.applyModifierDeck( *mini_deck );
     }
-    BOOST_CHECK_EQUAL( 2.00 , trans->getMultiplier( 2,2,0,FaceDir::XPlus ));
-    BOOST_CHECK_EQUAL( 0.10 , trans->getMultiplier( 3,2,0,FaceDir::XPlus ));
+    BOOST_CHECK_EQUAL( 2.00 , trans.getMultiplier( 2,2,0,FaceDir::XPlus ));
+    BOOST_CHECK_EQUAL( 0.10 , trans.getMultiplier( 3,2,0,FaceDir::XPlus ));
 }

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -625,8 +625,9 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
     EclipseState Parser::parse(const std::string &filename, const ParseContext& context) {
         assertFullDeck(context);
         Parser p;
-        auto deck = p.parseFile(filename, context);
-        return EclipseState(deck, context);
+        DeckPtr deck = p.parseFile(filename, context);
+        EclipseState es(deck, context);
+        return es;
     }
 
     EclipseState Parser::parse(const Deck& deck, const ParseContext& context) {


### PR DESCRIPTION
Remove returning of shared_ptr.  The opm-parser and opm-output are moving towards a shared_ptr-free state (except from the cases where we actually use shared ownership)

* TransMult, InitConfig, SimulationConfig are now returned as references, and not as shared_ptr's.
* The method `applyModifierDeck` takes a reference, not shared_ptr

This PR has downstream dependencies:
* OPM/opm-output#73
* OPM/opm-core#1056
* OPM/opm-simulators#783
* OPM/ewoms#63