### PR TITLE
Do not use constexpr pair constructor.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -95,7 +95,7 @@ namespace Opm {
 
         namespace wp = WellProducer;
         using mode = std::pair< const char*, wp::ControlModeEnum >;
-        static constexpr mode modes[] = {
+        static const mode modes[] = {
             { "ORAT", wp::ORAT }, { "WRAT", wp::WRAT }, { "GRAT", wp::GRAT },
             { "LRAT", wp::LRAT }, { "RESV", wp::RESV }, { "BHP", wp::BHP },
             { "THP", wp::THP }


### PR DESCRIPTION
That constructor is not available in C++11, only from C++14 on.

(Causes compile error with -std=c++11 for me.)