### PR TITLE
add bare-bones support for the MULTREGP keyword

### DIFF
--- a/opm/parser/share/keywords/000_Eclipse100/M/MULTREGP
+++ b/opm/parser/share/keywords/000_Eclipse100/M/MULTREGP
@@ -1,0 +1,8 @@
+{"name": "MULTREGP",
+ "sections": ["GRID", "EDIT"],
+ "items": [
+    {"name": "REGION", "value_type": "INT"},
+    {"name": "MULTIPLIER", "value_type": "DOUBLE"},
+    {"name": "REGION_TYPE", "value_type": "STRING", "default": "M"}
+  ]
+}


### PR DESCRIPTION
it is parsed and put into the deck, but it is not internalized in any
way. (Note that, given that this keyword is quite simple, adding
sophisticated code to absorb it into EclipseState would be overkill
in my not so humble opinion.)