### PR TITLE
UnitSystem: Add skeleton implementation of LAB conventions

### DIFF
--- a/opm/parser/eclipse/Units/ConversionFactors.hpp
+++ b/opm/parser/eclipse/Units/ConversionFactors.hpp
@@ -112,6 +112,7 @@ namespace Opm {
             /// \name Mass
             /// @{
             constexpr const double kilogram = 1;
+            constexpr const double gram     = 1.0e-3 * kilogram;
             // http://en.wikipedia.org/wiki/Pound_(mass)#Avoirdupois_pound
             constexpr const double pound    = 0.45359237 * kilogram;
             /// @}
@@ -235,6 +236,31 @@ namespace Opm {
         constexpr const double Salinity             = pound/stb;
         constexpr const double Viscosity            = centi*Poise;
         constexpr const double Timestep             = day;
+    }
+
+
+    namespace Lab {
+        using namespace details::prefix;
+        using namespace details::unit;
+        constexpr const double Pressure             = atm;
+        constexpr const double Temperature          = degCelsius;
+        constexpr const double TemperatureOffset    = degCelsiusOffset;
+        constexpr const double AbsoluteTemperature  = degCelsius; // actually [K], but the these two are identical
+        constexpr const double Length               = centi*meter;
+        constexpr const double Time                 = hour;
+        constexpr const double Mass                 = gram;
+        constexpr const double Permeability         = milli*darcy;
+        constexpr const double Transmissibility     = centi*Poise*cubic(centi*meter)/(hour*atm);
+        constexpr const double LiquidSurfaceVolume  = cubic(centi*meter);
+        constexpr const double GasSurfaceVolume     = cubic(centi*meter);
+        constexpr const double ReservoirVolume      = cubic(centi*meter);
+        constexpr const double GasDissolutionFactor = GasSurfaceVolume/LiquidSurfaceVolume;
+        constexpr const double OilDissolutionFactor = LiquidSurfaceVolume/GasSurfaceVolume;
+        constexpr const double Density              = gram/cubic(centi*meter);
+        constexpr const double PolymerDensity       = gram/cubic(centi*meter);
+        constexpr const double Salinity             = gram/cubic(centi*meter);
+        constexpr const double Viscosity            = centi*Poise;
+        constexpr const double Timestep             = hour;
     }
 
 }

--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -176,6 +176,75 @@ namespace {
         "STB/MSCF",
         "STB/STB",
     };
+
+    static const double to_lab[] = {
+        1,
+        1 / Lab::Length,
+        1 / Lab::Time,
+        1 / Lab::Density,
+        1 / Lab::Pressure,
+        1 / Lab::AbsoluteTemperature,
+        1 / Lab::Temperature,
+        1 / Lab::Viscosity,
+        1 / Lab::Permeability,
+        1 / Lab::LiquidSurfaceVolume,
+        1 / Lab::GasSurfaceVolume,
+        1 / Lab::ReservoirVolume,
+        1 / ( Lab::LiquidSurfaceVolume / Lab::Time ),
+        1 / ( Lab::GasSurfaceVolume / Lab::Time ),
+        1 / ( Lab::ReservoirVolume / Lab::Time ),
+        1 / Lab::Transmissibility,
+        1 / Lab::Mass,
+        1 / Lab::GasDissolutionFactor, /* gas-oil ratio */
+        1 / Lab::OilDissolutionFactor, /* oil-gas ratio */
+        1, /* water cut */
+    };
+
+    static const double from_lab[] = {
+        1,
+        Lab::Length,
+        Lab::Time,
+        Lab::Density,
+        Lab::Pressure,
+        Lab::AbsoluteTemperature,
+        Lab::Temperature,
+        Lab::Viscosity,
+        Lab::Permeability,
+        Lab::LiquidSurfaceVolume,
+        Lab::GasSurfaceVolume,
+        Lab::ReservoirVolume,
+        Lab::LiquidSurfaceVolume / Lab::Time,
+        Lab::GasSurfaceVolume / Lab::Time,
+        Lab::ReservoirVolume / Lab::Time,
+        Lab::Transmissibility,
+        Lab::Mass,
+        Lab::GasDissolutionFactor,  /* gas-oil ratio */
+        Lab::OilDissolutionFactor,  /* oil-gas ratio */
+        1, /* water cut */
+    };
+
+    static constexpr const char* lab_names[] = {
+        "",
+        "CM",
+        "H",
+        "G/CC",
+        "ATM",
+        "K",
+        "C",
+        "CP",
+        "MD",
+        "SCC",
+        "SCC",
+        "RCC",
+        "SCC/H",
+        "SCC/H",
+        "RCC/H",
+        "CPRCC/H/ATM",
+        "G",
+        "SCC/SCC",
+        "SCC/SCC",
+        "SCC/SCC",
+    };
 }
 
     UnitSystem::UnitSystem(const UnitType unit) :
@@ -196,7 +265,9 @@ namespace {
                 break;
             case(UNIT_TYPE_LAB):
                 m_name = "Lab";
-                throw std::runtime_error( "Lab unit system is not supported" );
+                this->measure_table_from_si = to_lab;
+                this->measure_table_to_si = from_lab;
+                this->unit_name_table = lab_names;
                 break;
             default:
                 //do nothing
@@ -376,6 +447,34 @@ namespace {
         system->addDimension("Salinity", Field::Salinity);
         system->addDimension("Viscosity", Field::Viscosity);
         system->addDimension("Timestep", Field::Timestep);
+        system->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
+        return system;
+    }
+
+
+
+    UnitSystem * UnitSystem::newLAB() {
+        UnitSystem * system = new UnitSystem(UNIT_TYPE_LAB);
+
+        system->addDimension("1"    , 1.0);
+        system->addDimension("Pressure", Lab::Pressure );
+        system->addDimension("Temperature", Lab::Temperature, Lab::TemperatureOffset);
+        system->addDimension("AbsoluteTemperature", Lab::AbsoluteTemperature);
+        system->addDimension("Length", Lab::Length);
+        system->addDimension("Time" , Lab::Time);
+        system->addDimension("Mass", Lab::Mass);
+        system->addDimension("Permeability", Lab::Permeability );
+        system->addDimension("Transmissibility", Lab::Transmissibility );
+        system->addDimension("GasDissolutionFactor" , Lab::GasDissolutionFactor);
+        system->addDimension("OilDissolutionFactor", Lab::OilDissolutionFactor);
+        system->addDimension("LiquidSurfaceVolume", Lab::LiquidSurfaceVolume );
+        system->addDimension("GasSurfaceVolume", Lab::GasSurfaceVolume );
+        system->addDimension("ReservoirVolume", Lab::ReservoirVolume );
+        system->addDimension("Density", Lab::Density );
+        system->addDimension("PolymerDensity", Lab::PolymerDensity);
+        system->addDimension("Salinity", Lab::Salinity);
+        system->addDimension("Viscosity", Lab::Viscosity);
+        system->addDimension("Timestep", Lab::Timestep);
         system->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         return system;
     }

--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -79,6 +79,7 @@ namespace Opm {
 
         static UnitSystem * newMETRIC();
         static UnitSystem * newFIELD();
+        static UnitSystem * newLAB();
     private:
         std::shared_ptr<const Dimension> parseFactor(const std::string& dimension) const;
 

--- a/opm/parser/eclipse/Units/tests/UnitTests.cpp
+++ b/opm/parser/eclipse/Units/tests/UnitTests.cpp
@@ -188,3 +188,28 @@ BOOST_AUTO_TEST_CASE(UnitSystemEqual) {
 
 
 
+BOOST_AUTO_TEST_CASE(LabUnitConversions) {
+    using Meas = UnitSystem::measure;
+
+    auto lab = std::unique_ptr<UnitSystem>( UnitSystem::newLAB() );
+
+    {
+        const auto furlong = 660*details::unit::feet;
+        BOOST_CHECK_CLOSE( 2.01168e4 , lab->from_si( Meas::length , furlong ) , 1.0e-10 );
+        BOOST_CHECK_CLOSE( furlong   , lab->to_si( Meas::length , 2.01168e4 ) , 1.0e-10 );
+    }
+
+    struct Factor { Meas m; double f; };
+
+    for (const auto& q : { Factor{ Meas::density               , 1.0e3  }   ,
+                           Factor{ Meas::pressure              , 101325.0 } ,
+                           Factor{ Meas::viscosity             , 1.0e-3 }   ,
+                           Factor{ Meas::liquid_surface_volume , 1.0e-6 }   ,
+                           Factor{ Meas::gas_surface_volume    , 1.0e-6 }   ,
+                           Factor{ Meas::time                  , 3600.0 }   ,
+                           Factor{ Meas::mass                  , 1.0e-3 }   })
+    {
+        BOOST_CHECK_CLOSE( q.f , lab->to_si( q.m , 1.0 )   , 1.0e-10 );
+        BOOST_CHECK_CLOSE( 1.0 , lab->from_si( q.m , q.f ) , 1.0e-10 );
+    }
+}


### PR DESCRIPTION
This commit adds conversion factors for the ECL LAB unit conventions--notably Atmospheres for pressures, Hours for time, Grams for mass, and cubic centimetres for volumes.

I am not sure if the unit names in [`lab_names`](https://github.com/OPM/opm-parser/blob/ba69320b528d20aabeff0a5f061495a3eb962428/opm/parser/eclipse/Units/UnitSystem.cpp#L226-L246) match those of ECL, but this is my best suggestions at present.

On a second note, if I may be so bold as to suggest an interface change, I'd propose that the `UnitSystem::new*()` constructor methods at some point be modified to return either `std::unique_ptr<>`s or even objects by value.