### PR TITLE
Implement support for MULTREGP

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/PORVTests.cpp
@@ -228,6 +228,39 @@ static Opm::DeckPtr createDeckWithNTG() {
     return parser->parseString(deckData, Opm::ParseContext()) ;
 }
 
+static Opm::DeckPtr createDeckWithMULTREGP() {
+    const char *deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " 10 10 10 /\n"
+        "GRID\n"
+        "DX\n"
+        "1000*0.25 /\n"
+        "DYV\n"
+        "10*0.25 /\n"
+        "DZ\n"
+        "1000*0.25 /\n"
+        "TOPS\n"
+        "100*0.25 /\n"
+        "PORV\n"
+        "1000*77 /\n"
+        "MULTNUM\n"
+        "100*1 700*2 200*3 / \n"
+        "FLUXNUM\n"
+        "200*1 700*2 100*3  / \n"
+        "MULTREGP\n"
+        "1 10.0 / \n"
+        "1 2.0 F/ \n"
+        "0 123.0 F/ \n" // ignored
+        "2 20.0 M / \n"
+        "/\n"
+        "\n";
+
+    Opm::ParserPtr parser(new Opm::Parser());
+    return parser->parseString(deckData, Opm::ParseContext()) ;
+}
+
 BOOST_AUTO_TEST_CASE(PORV_cartesianDeck) {
     /* Check that an exception is raised if we try to create a PORV field without PORO. */
     Opm::DeckPtr deck = createCARTDeck();
@@ -324,6 +357,29 @@ BOOST_AUTO_TEST_CASE(PORV_multpvAndNtg) {
     BOOST_CHECK_CLOSE( cell_volume * poro*multpv*NTG , porv.iget(9,9,9) , 0.001);
 }
 
+BOOST_AUTO_TEST_CASE(PORV_multregp) {
+    Opm::DeckPtr deck = createDeckWithMULTREGP();
+    const auto props = getProps(deck);
+    const auto& porv = props.getDoubleGridProperty("PORV");
+    const auto& porvData = porv.getData();
+    double basePorv = 77.0;
+
+    // the cumlative effect of the base pore volume is multiplied 2 for the cells in
+    // region 1 of FLUXNUM and by 20 for region 2 of MULTNUM. This means that the first
+    // 100 cels are multiplied by 2, then follow 100 cells multiplied by 2*20, then
+    // 600 cells multiplied by 20 while the last 200 cells are not modified at all.
+    for (int i=0; i < 100; ++i)
+        BOOST_CHECK_CLOSE(porvData[i], basePorv*2, 1e-8);
+
+    for (int i=100; i < 200; ++i)
+        BOOST_CHECK_CLOSE(porvData[i], basePorv*2*20, 1e-8);
+
+    for (int i=200; i < 800; ++i)
+        BOOST_CHECK_CLOSE(porvData[i], basePorv*20, 1e-8);
+
+    for (int i=800; i < 1000; ++i)
+        BOOST_CHECK_CLOSE(porvData[i], basePorv, 1e-8);
+}
 
 
 static Opm::DeckPtr createDeckNakedGRID() {


### PR DESCRIPTION
This PR implements full support for the MULTREGP keyword. It tries to faithfully implement the documented ECLIPSE bugs w.r.t. this keyword, but lacking the real thing, I cannot check if MULTREGP is considered when removing cells due to MINPV. (I assume that it is considered, but somebody should check to make sure.)

Finally, for this to be consistent within `flow`, the simulator must retrieve the pore volume of the active cells from opm-parser (i.e., it requires a small patch for opm-simulators).