### PR TITLE
Do not apply the MAPAXES transform.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -76,7 +76,7 @@ namespace Opm {
           m_pinchoutMode(PinchMode::ModeEnum::TOPBOT),
           m_multzMode(PinchMode::ModeEnum::TOP)
     {
-        ecl_grid_type * new_ptr = ecl_grid_load_case( filename.c_str() );
+        ecl_grid_type * new_ptr = ecl_grid_load_case__( filename.c_str() , false );
         if (new_ptr)
             m_grid.reset( new_ptr );
         else
@@ -310,6 +310,7 @@ namespace Opm {
                                                  zcorn_float.data() ,
                                                  coord_float.data() ,
                                                  actnum ,
+                                                 false,  // We do not apply the MAPAXES transformations
                                                  mapaxes_float) );
 
         if (mapaxes)


### PR DESCRIPTION
With this PR we will not at all apply the MAPEXES transform when creating the EclipseGrid / simulation grid. However - if a MAPAXES is specified in the input deck that will be retained, and written out to disk when the EGRID file is saved again.

Depends on: https://github.com/Ensembles/ert/pull/1221

Unless something pops up I intend to merge this - and https://github.com/Ensembles/ert/pull/1221 together on monday.