### PR TITLE
Remove shared ptrs from schedule

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -91,14 +91,8 @@ namespace Opm {
         }
 
 
-        T get(size_t index) const {
-            if (index >= m_timeMap->size())
-                throw std::range_error("Index value is out range.");
-
-            if (index >= m_data.size())
-                return m_currentValue;
-
-            return m_data[index];
+        const T& get(size_t index) const {
+            return this->at( index );
         }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Group.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group.cpp
@@ -40,7 +40,7 @@ namespace Opm {
             std::shared_ptr<DynamicState<double> > liquidTarget;
             std::shared_ptr<DynamicState<double> > reservoirVolumeTarget;
             std::shared_ptr<DynamicState<double> > efficiencyFactor;
-            std::shared_ptr<DynamicState<bool> >   transferEfficiencyFactor;
+            std::shared_ptr<DynamicState<int> >    transferEfficiencyFactor;
 
         };
 
@@ -53,7 +53,7 @@ namespace Opm {
             liquidTarget( new DynamicState<double>(timeMap , INVALID_GROUP_RATE)),
             reservoirVolumeTarget( new DynamicState<double>(timeMap , INVALID_GROUP_RATE)),
             efficiencyFactor( new DynamicState<double>(timeMap, INVALID_EFFICIENCY_FACTOR)),
-            transferEfficiencyFactor( new DynamicState<bool>(timeMap, false))
+            transferEfficiencyFactor( new DynamicState<int>(timeMap, false))
         {
 
         }
@@ -118,11 +118,11 @@ namespace Opm {
     }
 
     bool Group::isProductionGroup(size_t timeStep) const {
-        return m_isProductionGroup.get(timeStep);
+        return bool( m_isProductionGroup.get(timeStep) );
     }
 
     bool Group::isInjectionGroup(size_t timeStep) const {
-        return m_isInjectionGroup.get(timeStep);
+        return bool( m_isInjectionGroup.get(timeStep) );
     }
 
     void Group::setProductionGroup(size_t timeStep, bool isProductionGroup_) {

--- a/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
@@ -114,8 +114,8 @@ namespace Opm {
         std::shared_ptr<GroupInjection::InjectionData> m_injection;
         std::shared_ptr<GroupProduction::ProductionData> m_production;
         std::shared_ptr<DynamicState<std::shared_ptr< const WellSet >> > m_wells;
-        DynamicState<bool> m_isProductionGroup;
-        DynamicState<bool> m_isInjectionGroup;
+        DynamicState<int> m_isProductionGroup;
+        DynamicState<int> m_isInjectionGroup;
     };
     typedef std::shared_ptr<Group> GroupPtr;
     typedef std::shared_ptr<const Group> GroupConstPtr;

--- a/opm/parser/eclipse/EclipseState/Schedule/GroupTree.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/GroupTree.cpp
@@ -30,6 +30,11 @@ namespace Opm {
         m_root = GroupTreeNode::createFieldNode();
     }
 
+    GroupTree::GroupTree( const GroupTree& x ) :
+        m_root( GroupTreeNode::createFieldNode() ) {
+        deepCopy( x.m_root, this->m_root );
+    }
+
     void GroupTree::updateTree(const std::string& childName) {
         updateTree(childName, m_root->name());
     }

--- a/opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp
@@ -32,6 +32,7 @@ namespace Opm {
     class GroupTree {
     public:
         GroupTree();
+        GroupTree( const GroupTree& );
         void updateTree(const std::string& childName);
         void updateTree(const std::string& childName, const std::string& parentName);
 
@@ -41,6 +42,14 @@ namespace Opm {
 
         std::shared_ptr<GroupTree> deepCopy() const;
         void printTree(std::ostream &os) const;
+
+        bool operator==( const GroupTree& rhs ) {
+            return this->m_root == rhs.m_root;
+        }
+
+        bool operator!=( const GroupTree& rhs ) {
+            return !(*this == rhs );
+        }
 
 
     private:

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
@@ -20,11 +20,6 @@
 
 namespace Opm {
 
-
-    OilVaporizationProperties::OilVaporizationProperties(){
-
-    }
-
     double OilVaporizationProperties::getMaxDRVDT() const{
         if (m_type == Opm::OilVaporizationEnum::DRVDT){
             return m_maxDRVDT;
@@ -69,35 +64,60 @@ namespace Opm {
         }
     }
 
-    OilVaporizationPropertiesPtr OilVaporizationProperties::createOilVaporizationPropertiesDRSDT(double maximum, std::string option){
-        auto ovp = OilVaporizationPropertiesPtr(new OilVaporizationProperties());
-        ovp->m_type = Opm::OilVaporizationEnum::DRSDT;
-        ovp->m_maxDRSDT = maximum;
+    OilVaporizationProperties OilVaporizationProperties::createDRSDT(double maximum, std::string option){
+        OilVaporizationProperties ovp;
+        ovp.m_type = Opm::OilVaporizationEnum::DRSDT;
+        ovp.m_maxDRSDT = maximum;
         if (option == "ALL"){
-            ovp->m_maxDRSDT_allCells = true;
+            ovp.m_maxDRSDT_allCells = true;
         }else if (option == "FREE") {
-            ovp->m_maxDRSDT_allCells = false;
+            ovp.m_maxDRSDT_allCells = false;
         }else{
             throw std::invalid_argument("Only ALL or FREE is allowed as option string");
         }
         return ovp;
     }
 
-    OilVaporizationPropertiesPtr OilVaporizationProperties::createOilVaporizationPropertiesDRVDT(double maximum){
-        auto ovp = OilVaporizationPropertiesPtr(new OilVaporizationProperties());
-        ovp->m_type = Opm::OilVaporizationEnum::DRVDT;
-        ovp->m_maxDRVDT = maximum;
+    OilVaporizationProperties OilVaporizationProperties::createDRVDT(double maximum){
+        OilVaporizationProperties ovp;
+        ovp.m_type = Opm::OilVaporizationEnum::DRVDT;
+        ovp.m_maxDRVDT = maximum;
         return ovp;
-
     }
 
-    OilVaporizationPropertiesPtr OilVaporizationProperties::createOilVaporizationPropertiesVAPPARS(double vap1, double vap2){
-        auto ovp = OilVaporizationPropertiesPtr(new OilVaporizationProperties());
-        ovp->m_type = Opm::OilVaporizationEnum::VAPPARS;
-        ovp->m_vap1 = vap1;
-        ovp->m_vap2 = vap2;
+    OilVaporizationProperties OilVaporizationProperties::createVAPPARS(double vap1, double vap2){
+        OilVaporizationProperties ovp;
+        ovp.m_type = Opm::OilVaporizationEnum::VAPPARS;
+        ovp.m_vap1 = vap1;
+        ovp.m_vap2 = vap2;
         return ovp;
-
     }
 
+    bool OilVaporizationProperties::operator==( const OilVaporizationProperties& rhs ) const {
+        if( this->m_type == OilVaporizationEnum::UNDEF
+         || rhs.m_type   == OilVaporizationEnum::UNDEF
+         || this->m_type != rhs.m_type ) return false;
+
+        switch( this->m_type ) {
+            case OilVaporizationEnum::DRSDT:
+                return this->m_maxDRSDT == rhs.m_maxDRSDT
+                    && this->m_maxDRSDT_allCells == rhs.m_maxDRSDT_allCells;
+
+            case OilVaporizationEnum::DRVDT:
+                return this->m_maxDRVDT == rhs.m_maxDRVDT;
+
+            case OilVaporizationEnum::VAPPARS:
+                return this->m_vap1 == rhs.m_vap1
+                    && this->m_vap2 == rhs.m_vap2;
+
+            default:
+                throw std::logic_error( "UNDEF Oil vaporization property; this should never happen" );
+        }
+    }
+
+    bool OilVaporizationProperties::operator!=( const OilVaporizationProperties& rhs ) const {
+        return this->m_type == OilVaporizationEnum::UNDEF
+            || rhs.m_type == OilVaporizationEnum::UNDEF
+            || this->m_type != rhs.m_type;
+    }
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -53,7 +53,7 @@ namespace Opm
         bool operator!=( const OilVaporizationProperties& ) const;
 
     private:
-        Opm::OilVaporizationEnum m_type = OilVaporizationEnum::UNDEF;;
+        Opm::OilVaporizationEnum m_type = OilVaporizationEnum::UNDEF;
         double m_vap1;
         double m_vap2;
         double m_maxDRSDT;

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -32,14 +32,12 @@ namespace Opm
      * Any one of the three keywords {VAPPARS, DRSDT, DRVDT} will cancel previous settings of the other keywords.
      * Ask for type first and the ask for the correct values for this type, asking for values not valid for the current type will throw a logic exception.
      */
-    class OilVaporizationProperties
-    {
+    class OilVaporizationProperties {
     public:
+        static OilVaporizationProperties createDRSDT(double maxDRSDT, std::string option);
+        static OilVaporizationProperties createDRVDT(double maxDRVDT);
+        static OilVaporizationProperties createVAPPARS(double vap1, double vap2);
 
-
-        static std::shared_ptr<OilVaporizationProperties> createOilVaporizationPropertiesDRSDT(double maxDRSDT, std::string option);
-        static std::shared_ptr<OilVaporizationProperties> createOilVaporizationPropertiesDRVDT(double maxDRVDT);
-        static std::shared_ptr<OilVaporizationProperties> createOilVaporizationPropertiesVAPPARS(double vap1, double vap2);
         Opm::OilVaporizationEnum getType() const;
         double getVap1() const;
         double getVap2() const;
@@ -47,16 +45,20 @@ namespace Opm
         double getMaxDRVDT() const;
         bool getOption() const;
 
+        /*
+         * if either argument was default constructed == will always be false
+         * and != will always be true
+         */
+        bool operator==( const OilVaporizationProperties& ) const;
+        bool operator!=( const OilVaporizationProperties& ) const;
+
     private:
-        OilVaporizationProperties();
-        Opm::OilVaporizationEnum m_type;
+        Opm::OilVaporizationEnum m_type = OilVaporizationEnum::UNDEF;;
         double m_vap1;
         double m_vap2;
         double m_maxDRSDT;
         double m_maxDRVDT;
         bool m_maxDRSDT_allCells;
     };
-    typedef std::shared_ptr<OilVaporizationProperties> OilVaporizationPropertiesPtr;
-    typedef std::shared_ptr<const OilVaporizationProperties> OilVaporizationPropertiesConstPtr;
 }
 #endif // DRSDT_H

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -76,9 +76,9 @@ namespace Opm {
     Schedule::Schedule( const ParseContext& parseContext,
                         const EclipseGrid& grid,
                         const Deck& deck ) :
-        m_timeMap( std::make_shared< TimeMap>( deck ))
+        m_timeMap( std::make_shared< TimeMap>( deck )),
+        m_tuning( m_timeMap )
     {
-        m_tuning.reset(new Tuning(m_timeMap));
         m_events.reset(new Events(m_timeMap));
         m_modifierDeck.reset( new DynamicVector<std::shared_ptr<Deck> >( m_timeMap , std::shared_ptr<Deck>( 0 ) ));
         m_controlModeWHISTCTL = WellProducer::CMODE_UNDEFINED;
@@ -1051,36 +1051,36 @@ namespace Opm {
             const auto& record1 = keyword.getRecord(0);
 
             double TSINIT = record1.getItem("TSINIT").getSIDouble(0);
-            m_tuning->setTSINIT(currentStep, TSINIT);
+            this->m_tuning.setTSINIT(currentStep, TSINIT);
 
             double TSMAXZ = record1.getItem("TSMAXZ").getSIDouble(0);
-            m_tuning->setTSMAXZ(currentStep, TSMAXZ);
+            this->m_tuning.setTSMAXZ(currentStep, TSMAXZ);
 
             double TSMINZ = record1.getItem("TSMINZ").getSIDouble(0);
-            m_tuning->setTSMINZ(currentStep, TSMINZ);
+            this->m_tuning.setTSMINZ(currentStep, TSMINZ);
 
             double TSMCHP = record1.getItem("TSMCHP").getSIDouble(0);
-            m_tuning->setTSMCHP(currentStep, TSMCHP);
+            this->m_tuning.setTSMCHP(currentStep, TSMCHP);
 
             double TSFMAX = record1.getItem("TSFMAX").get< double >(0);
-            m_tuning->setTSFMAX(currentStep, TSFMAX);
+            this->m_tuning.setTSFMAX(currentStep, TSFMAX);
 
             double TSFMIN = record1.getItem("TSFMIN").get< double >(0);
-            m_tuning->setTSFMIN(currentStep, TSFMIN);
+            this->m_tuning.setTSFMIN(currentStep, TSFMIN);
 
             double TSFCNV = record1.getItem("TSFCNV").get< double >(0);
-            m_tuning->setTSFCNV(currentStep, TSFCNV);
+            this->m_tuning.setTSFCNV(currentStep, TSFCNV);
 
             double TFDIFF = record1.getItem("TFDIFF").get< double >(0);
-            m_tuning->setTFDIFF(currentStep, TFDIFF);
+            this->m_tuning.setTFDIFF(currentStep, TFDIFF);
 
             double THRUPT = record1.getItem("THRUPT").get< double >(0);
-            m_tuning->setTHRUPT(currentStep, THRUPT);
+            this->m_tuning.setTHRUPT(currentStep, THRUPT);
 
             const auto& TMAXWCdeckItem = record1.getItem("TMAXWC");
             if (TMAXWCdeckItem.hasValue(0)) {
                 double TMAXWC = TMAXWCdeckItem.getSIDouble(0);
-                m_tuning->setTMAXWC(currentStep, TMAXWC);
+                this->m_tuning.setTMAXWC(currentStep, TMAXWC);
             }
         }
 
@@ -1089,46 +1089,46 @@ namespace Opm {
             const auto& record2 = keyword.getRecord(1);
 
             double TRGTTE = record2.getItem("TRGTTE").get< double >(0);
-            m_tuning->setTRGTTE(currentStep, TRGTTE);
+            this->m_tuning.setTRGTTE(currentStep, TRGTTE);
 
             double TRGCNV = record2.getItem("TRGCNV").get< double >(0);
-            m_tuning->setTRGCNV(currentStep, TRGCNV);
+            this->m_tuning.setTRGCNV(currentStep, TRGCNV);
 
             double TRGMBE = record2.getItem("TRGMBE").get< double >(0);
-            m_tuning->setTRGMBE(currentStep, TRGMBE);
+            this->m_tuning.setTRGMBE(currentStep, TRGMBE);
 
             double TRGLCV = record2.getItem("TRGLCV").get< double >(0);
-            m_tuning->setTRGLCV(currentStep, TRGLCV);
+            this->m_tuning.setTRGLCV(currentStep, TRGLCV);
 
             double XXXTTE = record2.getItem("XXXTTE").get< double >(0);
-            m_tuning->setXXXTTE(currentStep, XXXTTE);
+            this->m_tuning.setXXXTTE(currentStep, XXXTTE);
 
             double XXXCNV = record2.getItem("XXXCNV").get< double >(0);
-            m_tuning->setXXXCNV(currentStep, XXXCNV);
+            this->m_tuning.setXXXCNV(currentStep, XXXCNV);
 
             double XXXMBE = record2.getItem("XXXMBE").get< double >(0);
-            m_tuning->setXXXMBE(currentStep, XXXMBE);
+            this->m_tuning.setXXXMBE(currentStep, XXXMBE);
 
             double XXXLCV = record2.getItem("XXXLCV").get< double >(0);
-            m_tuning->setXXXLCV(currentStep, XXXLCV);
+            this->m_tuning.setXXXLCV(currentStep, XXXLCV);
 
             double XXXWFL = record2.getItem("XXXWFL").get< double >(0);
-            m_tuning->setXXXWFL(currentStep, XXXWFL);
+            this->m_tuning.setXXXWFL(currentStep, XXXWFL);
 
             double TRGFIP = record2.getItem("TRGFIP").get< double >(0);
-            m_tuning->setTRGFIP(currentStep, TRGFIP);
+            this->m_tuning.setTRGFIP(currentStep, TRGFIP);
 
             const auto& TRGSFTdeckItem = record2.getItem("TRGSFT");
             if (TRGSFTdeckItem.hasValue(0)) {
                 double TRGSFT = TRGSFTdeckItem.get< double >(0);
-                m_tuning->setTRGSFT(currentStep, TRGSFT);
+                this->m_tuning.setTRGSFT(currentStep, TRGSFT);
             }
 
             double THIONX = record2.getItem("THIONX").get< double >(0);
-            m_tuning->setTHIONX(currentStep, THIONX);
+            this->m_tuning.setTHIONX(currentStep, THIONX);
 
             int TRWGHT = record2.getItem("TRWGHT").get< int >(0);
-            m_tuning->setTRWGHT(currentStep, TRWGHT);
+            this->m_tuning.setTRWGHT(currentStep, TRWGHT);
         }
 
 
@@ -1136,36 +1136,36 @@ namespace Opm {
             const auto& record3 = keyword.getRecord(2);
 
             int NEWTMX = record3.getItem("NEWTMX").get< int >(0);
-            m_tuning->setNEWTMX(currentStep, NEWTMX);
+            this->m_tuning.setNEWTMX(currentStep, NEWTMX);
 
             int NEWTMN = record3.getItem("NEWTMN").get< int >(0);
-            m_tuning->setNEWTMN(currentStep, NEWTMN);
+            this->m_tuning.setNEWTMN(currentStep, NEWTMN);
 
             int LITMAX = record3.getItem("LITMAX").get< int >(0);
-            m_tuning->setLITMAX(currentStep, LITMAX);
+            this->m_tuning.setLITMAX(currentStep, LITMAX);
 
             int LITMIN = record3.getItem("LITMIN").get< int >(0);
-            m_tuning->setLITMIN(currentStep, LITMIN);
+            this->m_tuning.setLITMIN(currentStep, LITMIN);
 
             int MXWSIT = record3.getItem("MXWSIT").get< int >(0);
-            m_tuning->setMXWSIT(currentStep, MXWSIT);
+            this->m_tuning.setMXWSIT(currentStep, MXWSIT);
 
             int MXWPIT = record3.getItem("MXWPIT").get< int >(0);
-            m_tuning->setMXWPIT(currentStep, MXWPIT);
+            this->m_tuning.setMXWPIT(currentStep, MXWPIT);
 
             double DDPLIM = record3.getItem("DDPLIM").getSIDouble(0);
-            m_tuning->setDDPLIM(currentStep, DDPLIM);
+            this->m_tuning.setDDPLIM(currentStep, DDPLIM);
 
             double DDSLIM = record3.getItem("DDSLIM").get< double >(0);
-            m_tuning->setDDSLIM(currentStep, DDSLIM);
+            this->m_tuning.setDDSLIM(currentStep, DDSLIM);
 
             double TRGDPR = record3.getItem("TRGDPR").getSIDouble(0);
-            m_tuning->setTRGDPR(currentStep, TRGDPR);
+            this->m_tuning.setTRGDPR(currentStep, TRGDPR);
 
             const auto& XXXDPRdeckItem = record3.getItem("XXXDPR");
             if (XXXDPRdeckItem.hasValue(0)) {
                 double XXXDPR = XXXDPRdeckItem.getSIDouble(0);
-                m_tuning->setXXXDPR(currentStep, XXXDPR);
+                this->m_tuning.setXXXDPR(currentStep, XXXDPR);
             }
         }
     }
@@ -1551,8 +1551,8 @@ namespace Opm {
       return ncwmax;
     }
 
-    TuningPtr Schedule::getTuning() const {
-      return m_tuning;
+    const Tuning& Schedule::getTuning() const {
+      return this->m_tuning;
     }
 
     std::shared_ptr<const Deck> Schedule::getModifierDeck(size_t timeStep) const {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -78,10 +78,10 @@ namespace Opm {
                         const Deck& deck ) :
         m_timeMap( std::make_shared< TimeMap>( deck )),
         m_events( m_timeMap ),
+        m_modifierDeck( m_timeMap, nullptr ),
         m_tuning( m_timeMap )
 
     {
-        m_modifierDeck.reset( new DynamicVector<std::shared_ptr<Deck> >( m_timeMap , std::shared_ptr<Deck>( 0 ) ));
         m_controlModeWHISTCTL = WellProducer::CMODE_UNDEFINED;
         addGroup( "FIELD", 0 );
         initRootGroupTreeNode(getTimeMap());
@@ -242,10 +242,10 @@ namespace Opm {
                       index currentstep; then we fetch the deck (newly created - or old)
                       from the container and add the keyword.
                     */
-                    if (!m_modifierDeck->iget(currentStep))
-                        m_modifierDeck->iset( currentStep , std::make_shared<Deck>( ));
+                    if (!m_modifierDeck.iget(currentStep))
+                        m_modifierDeck.iset( currentStep , std::make_shared<Deck>( ));
 
-                    m_modifierDeck->iget( currentStep )->addKeyword( keyword );
+                    m_modifierDeck.iget( currentStep )->addKeyword( keyword );
                     m_events.addEvent( ScheduleEvents::GEO_MODIFIER , currentStep);
 
                 } else {
@@ -1557,7 +1557,7 @@ namespace Opm {
     }
 
     std::shared_ptr<const Deck> Schedule::getModifierDeck(size_t timeStep) const {
-        return m_modifierDeck->iget( timeStep );
+        return m_modifierDeck.iget( timeStep );
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -77,6 +77,7 @@ namespace Opm {
                         const EclipseGrid& grid,
                         const Deck& deck ) :
         m_timeMap( std::make_shared< TimeMap>( deck )),
+        m_oilvaporizationproperties( m_timeMap, nullptr ),
         m_events( m_timeMap ),
         m_modifierDeck( m_timeMap, nullptr ),
         m_tuning( m_timeMap )
@@ -85,7 +86,6 @@ namespace Opm {
         m_controlModeWHISTCTL = WellProducer::CMODE_UNDEFINED;
         addGroup( "FIELD", 0 );
         initRootGroupTreeNode(getTimeMap());
-        initOilVaporization(getTimeMap());
 
         if (Section::hasSCHEDULE(deck)) {
             std::shared_ptr<SCHEDULESection> scheduleSection = std::make_shared<SCHEDULESection>(deck);
@@ -105,10 +105,6 @@ namespace Opm {
         return posixTime( this->m_timeMap->getEndTime() );
     }
 
-
-    void Schedule::initOilVaporization(TimeMapConstPtr timeMap) {
-        m_oilvaporizationproperties.reset(new DynamicState<OilVaporizationPropertiesPtr>(timeMap, OilVaporizationPropertiesPtr()));
-    }
 
     void Schedule::initRootGroupTreeNode(TimeMapConstPtr timeMap) {
         m_rootGroupTree.reset(new DynamicState<GroupTreePtr>(timeMap, GroupTreePtr(new GroupTree())));
@@ -1576,15 +1572,15 @@ namespace Opm {
     }
 
     OilVaporizationPropertiesConstPtr Schedule::getOilVaporizationProperties(size_t timestep){
-        return m_oilvaporizationproperties->get(timestep);
+        return m_oilvaporizationproperties.get(timestep);
     }
 
     void Schedule::setOilVaporizationProperties(const OilVaporizationPropertiesPtr vapor, size_t timestep){
-        m_oilvaporizationproperties->update(timestep, vapor);
+        m_oilvaporizationproperties.update(timestep, vapor);
     }
 
     bool Schedule::hasOilVaporizationProperties(){
-        return m_oilvaporizationproperties->size() > 0;
+        return m_oilvaporizationproperties.size() > 0;
     }
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
@@ -41,7 +42,6 @@ namespace Opm
     class DeckRecord;
     class EclipseGrid;
     class Group;
-    class OilVaporizationProperties;
     class ParseContext;
     class SCHEDULESection;
     class TimeMap;
@@ -77,7 +77,7 @@ namespace Opm
         std::vector< const Well* > getWells() const;
         std::vector< const Well* > getWells(size_t timeStep) const;
         std::vector< const Well* > getWellsMatching( const std::string& ) const;
-        std::shared_ptr< const OilVaporizationProperties > getOilVaporizationProperties(size_t timestep);
+        const OilVaporizationProperties& getOilVaporizationProperties(size_t timestep);
 
         const GroupTree& getGroupTree(size_t t) const;
         size_t numGroups() const;
@@ -98,7 +98,7 @@ namespace Opm
         OrderedMap<std::shared_ptr< Well >> m_wells;
         std::map<std::string , std::shared_ptr< Group >> m_groups;
         DynamicState< GroupTree > m_rootGroupTree;
-        DynamicState<std::shared_ptr< OilVaporizationProperties > > m_oilvaporizationproperties;
+        DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;
         Events m_events;
         DynamicVector<std::shared_ptr<Deck> > m_modifierDeck;
         Tuning m_tuning;
@@ -147,9 +147,6 @@ namespace Opm
         static double convertInjectionRateToSI(double rawRate, WellInjector::TypeEnum wellType, const Opm::UnitSystem &unitSystem);
         static double convertInjectionRateToSI(double rawRate, Phase::PhaseEnum wellPhase, const Opm::UnitSystem &unitSystem);
         static bool convertEclipseStringToBool(const std::string& eclipseString);
-
-
-        void setOilVaporizationProperties(const std::shared_ptr< OilVaporizationProperties > vapor, size_t timestep);
 
     };
     typedef std::shared_ptr<Schedule> SchedulePtr;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -98,7 +98,7 @@ namespace Opm
         OrderedMap<std::shared_ptr< Well >> m_wells;
         std::map<std::string , std::shared_ptr< Group >> m_groups;
         std::shared_ptr<DynamicState<std::shared_ptr< GroupTree >> > m_rootGroupTree;
-        std::shared_ptr<DynamicState<std::shared_ptr< OilVaporizationProperties > > > m_oilvaporizationproperties;
+        DynamicState<std::shared_ptr< OilVaporizationProperties > > m_oilvaporizationproperties;
         Events m_events;
         DynamicVector<std::shared_ptr<Deck> > m_modifierDeck;
         Tuning m_tuning;
@@ -109,7 +109,6 @@ namespace Opm
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
         void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
-        void initOilVaporization(std::shared_ptr< const TimeMap > timeMap);
         void iterateScheduleSection(const ParseContext& parseContext ,  const SCHEDULESection& , const EclipseGrid& grid);
         bool handleGroupFromWELSPECS(const std::string& groupName, std::shared_ptr< GroupTree > newTree) const;
         void addGroup(const std::string& groupName , size_t timeStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -25,6 +25,7 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
@@ -39,7 +40,6 @@ namespace Opm
     class DeckKeyword;
     class DeckRecord;
     class EclipseGrid;
-    class Events;
     class Group;
     class GroupTree;
     class OilVaporizationProperties;
@@ -100,7 +100,7 @@ namespace Opm
         std::map<std::string , std::shared_ptr< Group >> m_groups;
         std::shared_ptr<DynamicState<std::shared_ptr< GroupTree >> > m_rootGroupTree;
         std::shared_ptr<DynamicState<std::shared_ptr< OilVaporizationProperties > > > m_oilvaporizationproperties;
-        std::shared_ptr<Events> m_events;
+        Events m_events;
         std::shared_ptr<DynamicVector<std::shared_ptr<Deck> > > m_modifierDeck;
         Tuning m_tuning;
         MessageContainer m_messages;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
@@ -41,7 +42,6 @@ namespace Opm
     class DeckKeyword;
     class DeckRecord;
     class EclipseGrid;
-    class Group;
     class ParseContext;
     class SCHEDULESection;
     class TimeMap;
@@ -82,7 +82,7 @@ namespace Opm
         const GroupTree& getGroupTree(size_t t) const;
         size_t numGroups() const;
         bool hasGroup(const std::string& groupName) const;
-        const Group* getGroup(const std::string& groupName) const;
+        const Group& getGroup(const std::string& groupName) const;
         std::vector< const Group* > getGroups() const;
         const Tuning& getTuning() const;
 
@@ -96,7 +96,7 @@ namespace Opm
     private:
         std::shared_ptr< TimeMap > m_timeMap;
         OrderedMap<std::shared_ptr< Well >> m_wells;
-        std::map<std::string , std::shared_ptr< Group >> m_groups;
+        std::map<std::string, Group > m_groups;
         DynamicState< GroupTree > m_rootGroupTree;
         DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;
         Events m_events;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -27,6 +27,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
@@ -40,7 +41,6 @@ namespace Opm
     class DeckRecord;
     class EclipseGrid;
     class Group;
-    class GroupTree;
     class OilVaporizationProperties;
     class ParseContext;
     class SCHEDULESection;
@@ -79,7 +79,7 @@ namespace Opm
         std::vector< const Well* > getWellsMatching( const std::string& ) const;
         std::shared_ptr< const OilVaporizationProperties > getOilVaporizationProperties(size_t timestep);
 
-        std::shared_ptr< GroupTree > getGroupTree(size_t t) const;
+        const GroupTree& getGroupTree(size_t t) const;
         size_t numGroups() const;
         bool hasGroup(const std::string& groupName) const;
         const Group* getGroup(const std::string& groupName) const;
@@ -97,7 +97,7 @@ namespace Opm
         std::shared_ptr< TimeMap > m_timeMap;
         OrderedMap<std::shared_ptr< Well >> m_wells;
         std::map<std::string , std::shared_ptr< Group >> m_groups;
-        std::shared_ptr<DynamicState<std::shared_ptr< GroupTree >> > m_rootGroupTree;
+        DynamicState< GroupTree > m_rootGroupTree;
         DynamicState<std::shared_ptr< OilVaporizationProperties > > m_oilvaporizationproperties;
         Events m_events;
         DynamicVector<std::shared_ptr<Deck> > m_modifierDeck;
@@ -108,9 +108,8 @@ namespace Opm
         std::vector< Well* > getWells(const std::string& wellNamePattern);
         void updateWellStatus( Well& well, size_t reportStep , WellCommon::StatusEnum status);
         void addWellToGroup( Group& newGroup , Well& well , size_t timeStep);
-        void initRootGroupTreeNode(std::shared_ptr< const TimeMap > timeMap);
         void iterateScheduleSection(const ParseContext& parseContext ,  const SCHEDULESection& , const EclipseGrid& grid);
-        bool handleGroupFromWELSPECS(const std::string& groupName, std::shared_ptr< GroupTree > newTree) const;
+        bool handleGroupFromWELSPECS(const std::string& groupName, GroupTree& newTree) const;
         void addGroup(const std::string& groupName , size_t timeStep);
         void addWell(const std::string& wellName, const DeckRecord& record, size_t timeStep, WellCompletion::CompletionOrderEnum wellCompletionOrder);
         void handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -25,6 +25,7 @@
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/DynamicVector.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Events.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
@@ -33,8 +34,6 @@
 
 namespace Opm
 {
-
-    template< typename > class DynamicVector;
 
     class Deck;
     class DeckKeyword;
@@ -101,7 +100,7 @@ namespace Opm
         std::shared_ptr<DynamicState<std::shared_ptr< GroupTree >> > m_rootGroupTree;
         std::shared_ptr<DynamicState<std::shared_ptr< OilVaporizationProperties > > > m_oilvaporizationproperties;
         Events m_events;
-        std::shared_ptr<DynamicVector<std::shared_ptr<Deck> > > m_modifierDeck;
+        DynamicVector<std::shared_ptr<Deck> > m_modifierDeck;
         Tuning m_tuning;
         MessageContainer m_messages;
         WellProducer::ControlModeEnum m_controlModeWHISTCTL;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -24,14 +24,15 @@
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 
 namespace Opm
 {
 
-    template< typename > class DynamicState;
     template< typename > class DynamicVector;
 
     class Deck;
@@ -45,7 +46,6 @@ namespace Opm
     class ParseContext;
     class SCHEDULESection;
     class TimeMap;
-    class Tuning;
     class UnitSystem;
     class Well;
 
@@ -85,7 +85,7 @@ namespace Opm
         bool hasGroup(const std::string& groupName) const;
         const Group* getGroup(const std::string& groupName) const;
         std::vector< const Group* > getGroups() const;
-        std::shared_ptr< Tuning > getTuning() const;
+        const Tuning& getTuning() const;
 
         const Events& getEvents() const;
         bool hasOilVaporizationProperties();
@@ -102,7 +102,7 @@ namespace Opm
         std::shared_ptr<DynamicState<std::shared_ptr< OilVaporizationProperties > > > m_oilvaporizationproperties;
         std::shared_ptr<Events> m_events;
         std::shared_ptr<DynamicVector<std::shared_ptr<Deck> > > m_modifierDeck;
-        std::shared_ptr< Tuning > m_tuning;
+        Tuning m_tuning;
         MessageContainer m_messages;
         WellProducer::ControlModeEnum m_controlModeWHISTCTL;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp
@@ -242,6 +242,7 @@ namespace Opm {
     }
 
     enum OilVaporizationEnum{
+        UNDEF = 0,
         VAPPARS = 1,
         DRSDT = 2,
         DRVDT = 3

--- a/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Tuning.cpp
@@ -37,7 +37,7 @@ namespace Opm {
         m_TFDIFF( new DynamicState<double>(timemap, 1.25)),
         m_THRUPT( new DynamicState<double>(timemap, 1.0E20)),
         m_TMAXWC( new DynamicState<double>(timemap, 0.0   * Metric::Time)),
-        m_TMAXWC_has_value( new DynamicState<bool>(timemap, false)),
+        m_TMAXWC_has_value( new DynamicState<int>(timemap, false)),
         m_TRGTTE( new DynamicState<double>(timemap, 0.1)),
         m_TRGCNV( new DynamicState<double>(timemap, 0.001)),
         m_TRGMBE( new DynamicState<double>(timemap, 1.0E-7)),
@@ -49,7 +49,7 @@ namespace Opm {
         m_XXXWFL( new DynamicState<double>(timemap, 0.001)),
         m_TRGFIP( new DynamicState<double>(timemap, 0.025)),
         m_TRGSFT( new DynamicState<double>(timemap, 0.0)),
-        m_TRGSFT_has_value( new DynamicState<bool>(timemap, false)),
+        m_TRGSFT_has_value( new DynamicState<int>(timemap, false)),
         m_THIONX( new DynamicState<double>(timemap, 0.01)),
         m_TRWGHT( new DynamicState<int>(timemap, 1)),
         m_NEWTMX( new DynamicState<int>(timemap, 12)),
@@ -62,7 +62,7 @@ namespace Opm {
         m_DDSLIM( new DynamicState<double>(timemap, 1.0E6)),
         m_TRGDPR( new DynamicState<double>(timemap, 1.0E6 * Metric::Pressure)),
         m_XXXDPR( new DynamicState<double>(timemap, 0.0   * Metric::Pressure)),
-        m_XXXDPR_has_value( new DynamicState<bool>(timemap, false))
+        m_XXXDPR_has_value( new DynamicState<int>(timemap, false))
     {
     }
 
@@ -196,11 +196,11 @@ namespace Opm {
         return values->get(timestep);
     }
 
-    bool Tuning::getBoolValue(const std::string tuningItem, std::shared_ptr<DynamicState<bool>> values, size_t timestep) const{
+    bool Tuning::getBoolValue(const std::string tuningItem, std::shared_ptr<DynamicState<int>> values, size_t timestep) const{
         if(m_ResetValue.find(tuningItem)!= m_ResetValue.end()){
             timestep = 0;
         }
-        return values->get(timestep);
+        return bool( values->get(timestep) );
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
@@ -139,7 +139,7 @@ namespace Opm {
         std::shared_ptr<DynamicState<double>> m_TFDIFF;
         std::shared_ptr<DynamicState<double>> m_THRUPT;
         std::shared_ptr<DynamicState<double>> m_TMAXWC;
-        std::shared_ptr<DynamicState<bool>>   m_TMAXWC_has_value;
+        std::shared_ptr<DynamicState<int>>    m_TMAXWC_has_value;
         /* Record 2 */
         std::shared_ptr<DynamicState<double>> m_TRGTTE;
         std::shared_ptr<DynamicState<double>> m_TRGCNV;
@@ -152,7 +152,7 @@ namespace Opm {
         std::shared_ptr<DynamicState<double>> m_XXXWFL;
         std::shared_ptr<DynamicState<double>> m_TRGFIP;
         std::shared_ptr<DynamicState<double>> m_TRGSFT;
-        std::shared_ptr<DynamicState<bool>>   m_TRGSFT_has_value;
+        std::shared_ptr<DynamicState<int>>    m_TRGSFT_has_value;
         std::shared_ptr<DynamicState<double>> m_THIONX;
         std::shared_ptr<DynamicState<int>>    m_TRWGHT;
         /* Record 3 */
@@ -166,12 +166,12 @@ namespace Opm {
         std::shared_ptr<DynamicState<double>> m_DDSLIM;
         std::shared_ptr<DynamicState<double>> m_TRGDPR;
         std::shared_ptr<DynamicState<double>> m_XXXDPR;
-        std::shared_ptr<DynamicState<bool>>   m_XXXDPR_has_value;
+        std::shared_ptr<DynamicState<int>>    m_XXXDPR_has_value;
         std::map<std::string, bool> m_ResetValue;
 
         double getDoubleValue(const std::string tuningItem, std::shared_ptr<DynamicState<double>> values, size_t timestep) const;
         int getIntValue(const std::string tuningItem, std::shared_ptr<DynamicState<int>> values, size_t timestep) const;
-        bool getBoolValue(const std::string tuningItem, std::shared_ptr<DynamicState<bool>> values, size_t timestep) const;
+        bool getBoolValue(const std::string tuningItem, std::shared_ptr<DynamicState<int>> values, size_t timestep) const;
 
     };
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -38,11 +38,11 @@ namespace Opm {
                WellCompletion::CompletionOrderEnum completionOrdering,
                bool allowCrossFlow, bool automaticShutIn)
         : m_status(new DynamicState<WellCommon::StatusEnum>(timeMap, WellCommon::SHUT)),
-          m_isAvailableForGroupControl(new DynamicState<bool>(timeMap, true)),
+          m_isAvailableForGroupControl(new DynamicState<int>(timeMap, true)),
           m_guideRate(new DynamicState<double>(timeMap, -1.0)),
           m_guideRatePhase(new DynamicState<GuideRate::GuideRatePhaseEnum>(timeMap, GuideRate::UNDEFINED)),
           m_guideRateScalingFactor(new DynamicState<double>(timeMap, 1.0)),
-          m_isProducer(new DynamicState<bool>(timeMap, true)) ,
+          m_isProducer(new DynamicState<int>(timeMap, true)) ,
           m_completions( new DynamicState<CompletionSetConstPtr>( timeMap , CompletionSetConstPtr( new CompletionSet()) )),
           m_productionProperties( new DynamicState<WellProductionProperties>(timeMap, WellProductionProperties() )),
           m_injectionProperties( new DynamicState<WellInjectionProperties>(timeMap, WellInjectionProperties() )),
@@ -50,8 +50,8 @@ namespace Opm {
           m_econproductionlimits( new DynamicState<WellEconProductionLimits>(timeMap, WellEconProductionLimits()) ),
           m_solventFraction( new DynamicState<double>(timeMap, 0.0 )),
           m_groupName( new DynamicState<std::string>( timeMap , "" )),
-          m_rft( new DynamicState<bool>(timeMap,false)),
-          m_plt( new DynamicState<bool>(timeMap,false)),
+          m_rft( new DynamicState<int>(timeMap,false)),
+          m_plt( new DynamicState<int>(timeMap,false)),
           m_timeMap( timeMap ),
           m_headI(headI),
           m_headJ(headJ),
@@ -206,11 +206,11 @@ namespace Opm {
         return m_messages;
     }
     bool Well::isProducer(size_t timeStep) const {
-        return m_isProducer->get(timeStep);
+        return bool( m_isProducer->get(timeStep) );
     }
 
     bool Well::isInjector(size_t timeStep) const {
-        return !isProducer(timeStep);
+        return !bool( isProducer(timeStep) );
     }
 
     bool Well::isAvailableForGroupControl(size_t timeStep) const {
@@ -327,11 +327,11 @@ namespace Opm {
     }
 
     bool Well::getRFTActive(size_t time_step) const{
-        return m_rft->get(time_step);
+        return bool( m_rft->get(time_step) );
     }
 
     bool Well::getPLTActive(size_t time_step) const{
-     return m_plt->get(time_step);
+     return bool( m_plt->get(time_step) );
     }
     void Well::setPLTActive(size_t time_step, bool value){
         m_plt->update(time_step, value);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -142,12 +142,12 @@ namespace Opm {
 
         std::shared_ptr<DynamicState<WellCommon::StatusEnum> > m_status;
 
-        std::shared_ptr<DynamicState<bool> > m_isAvailableForGroupControl;
+        std::shared_ptr<DynamicState<int> > m_isAvailableForGroupControl;
         std::shared_ptr<DynamicState<double> > m_guideRate;
         std::shared_ptr<DynamicState<GuideRate::GuideRatePhaseEnum> > m_guideRatePhase;
         std::shared_ptr<DynamicState<double> > m_guideRateScalingFactor;
 
-        std::shared_ptr<DynamicState<bool> > m_isProducer;
+        std::shared_ptr<DynamicState<int> > m_isProducer;
         std::shared_ptr<DynamicState<std::shared_ptr< const CompletionSet >> > m_completions;
         std::shared_ptr<DynamicState<WellProductionProperties> > m_productionProperties;
         std::shared_ptr<DynamicState<WellInjectionProperties> > m_injectionProperties;
@@ -155,8 +155,8 @@ namespace Opm {
         std::shared_ptr<DynamicState<WellEconProductionLimits> > m_econproductionlimits;
         std::shared_ptr<DynamicState<double> > m_solventFraction;
         std::shared_ptr<DynamicState<std::string> > m_groupName;
-        std::shared_ptr<DynamicState<bool> > m_rft;
-        std::shared_ptr<DynamicState<bool> > m_plt;
+        std::shared_ptr<DynamicState<int> > m_rft;
+        std::shared_ptr<DynamicState<int> > m_plt;
 
         // WELSPECS data - assumes this is not dynamic
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -289,9 +289,9 @@ BOOST_AUTO_TEST_CASE(createDeckWithGEFAC) {
     EclipseGrid grid(10,10,10);
     Opm::Schedule schedule(parseContext , grid, deck );
 
-    const auto* group1 = schedule.getGroup("PRODUC");
-    BOOST_CHECK_EQUAL(group1->getGroupEfficiencyFactor(0), 0.85);
-    BOOST_CHECK_EQUAL(group1->getTransferGroupEfficiencyFactor(0), true);
+    const auto& group1 = schedule.getGroup("PRODUC");
+    BOOST_CHECK_EQUAL(group1.getGroupEfficiencyFactor(0), 0.85);
+    BOOST_CHECK(group1.getTransferGroupEfficiencyFactor(0));
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -241,7 +241,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithoutGRUPTREE_HasRootGroupTreeNodeForT
     EclipseGrid grid(10,10,10);
     DeckPtr deck = createDeck();
     Schedule schedule(ParseContext() , grid , deck );
-    BOOST_CHECK_EQUAL("FIELD", schedule.getGroupTree(0)->getNode("FIELD")->name());
+    BOOST_CHECK_EQUAL("FIELD", schedule.getGroupTree(0).getNode("FIELD")->name());
 }
 
 static std::shared_ptr< Deck > deckWithGRUPTREE() {
@@ -266,7 +266,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_DeckWithGRUPTREE_HasRootGroupTreeNodeForTime
     EclipseGrid grid(10,10,10);
     auto deck = deckWithGRUPTREE();
     Schedule schedule(ParseContext() , grid , deck );
-    GroupTreeNodePtr fieldNode = schedule.getGroupTree(0)->getNode("FIELD");
+    GroupTreeNodePtr fieldNode = schedule.getGroupTree(0).getNode("FIELD");
     BOOST_CHECK_EQUAL("FIELD", fieldNode->name());
     GroupTreeNodePtr FAREN = fieldNode->getChildGroup("FAREN");
     BOOST_CHECK(FAREN->hasChildGroup("BARNET"));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -1021,10 +1021,10 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDT) {
     Schedule schedule(parseContext , grid, deck );
     size_t currentStep = 1;
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
-    OilVaporizationPropertiesConstPtr ovap = schedule.getOilVaporizationProperties(currentStep);
+    const auto& ovap = schedule.getOilVaporizationProperties(currentStep);
 
-    BOOST_CHECK_EQUAL(true,   ovap->getOption());
-    BOOST_CHECK_EQUAL(ovap->getType(), Opm::OilVaporizationEnum::DRSDT);
+    BOOST_CHECK_EQUAL(true,   ovap.getOption());
+    BOOST_CHECK_EQUAL(ovap.getType(), Opm::OilVaporizationEnum::DRSDT);
 }
 
 
@@ -1053,10 +1053,10 @@ BOOST_AUTO_TEST_CASE(createDeckWithDRSDTthenDRVDT) {
     Schedule schedule(parseContext , grid, deck );
     size_t currentStep = 2;
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
-    OilVaporizationPropertiesConstPtr ovap = schedule.getOilVaporizationProperties(currentStep);
-    double value =  ovap->getMaxDRVDT();
+    const OilVaporizationProperties& ovap = schedule.getOilVaporizationProperties(currentStep);
+    double value =  ovap.getMaxDRVDT();
     BOOST_CHECK_EQUAL(1.1574074074074074e-06, value);
-    BOOST_CHECK_EQUAL(ovap->getType(), Opm::OilVaporizationEnum::DRVDT);
+    BOOST_CHECK_EQUAL(ovap.getType(), Opm::OilVaporizationEnum::DRVDT);
 }
 
 BOOST_AUTO_TEST_CASE(createDeckWithVAPPARS) {
@@ -1078,11 +1078,11 @@ BOOST_AUTO_TEST_CASE(createDeckWithVAPPARS) {
     Schedule schedule(parseContext , grid, deck );
     size_t currentStep = 1;
     BOOST_CHECK_EQUAL(schedule.hasOilVaporizationProperties(), true);
-    OilVaporizationPropertiesConstPtr ovap = schedule.getOilVaporizationProperties(currentStep);
-    BOOST_CHECK_EQUAL(ovap->getType(), Opm::OilVaporizationEnum::VAPPARS);
-    double vap1 =  ovap->getVap1();
+    const OilVaporizationProperties& ovap = schedule.getOilVaporizationProperties(currentStep);
+    BOOST_CHECK_EQUAL(ovap.getType(), Opm::OilVaporizationEnum::VAPPARS);
+    double vap1 =  ovap.getVap1();
     BOOST_CHECK_EQUAL(2, vap1);
-    double vap2 =  ovap->getVap2();
+    double vap2 =  ovap.getVap2();
     BOOST_CHECK_EQUAL(0.100, vap2);
 
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/TuningTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/TuningTests.cpp
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   DeckPtr deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   Schedule schedule( ParseContext() , grid , deck );
-  TuningPtr tuning = schedule.getTuning();
+  auto tuning = schedule.getTuning();
 
 
   const double diff = 1.0e-14;
@@ -80,112 +80,112 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   /*** TIMESTEP 4***/
   /********* Record 1 ***********/
   size_t timestep = 4;
-  double TSINIT_default = tuning->getTSINIT(timestep);
+  double TSINIT_default = tuning.getTSINIT(timestep);
   BOOST_CHECK_CLOSE(TSINIT_default, 1 * Metric::Time, diff);
 
-  double TSMAXZ_default = tuning->getTSMAXZ(timestep);
+  double TSMAXZ_default = tuning.getTSMAXZ(timestep);
   BOOST_CHECK_CLOSE(TSMAXZ_default, 365 * Metric::Time, diff);
 
-  double TSMINZ_default = tuning->getTSMINZ(timestep);
+  double TSMINZ_default = tuning.getTSMINZ(timestep);
   BOOST_CHECK_CLOSE(TSMINZ_default, 0.1 * Metric::Time, diff);
 
-  double TSMCHP_default = tuning->getTSMCHP(timestep);
+  double TSMCHP_default = tuning.getTSMCHP(timestep);
   BOOST_CHECK_CLOSE(TSMCHP_default, 0.15 * Metric::Time, diff);
 
-  double TSFMAX_default = tuning->getTSFMAX(timestep);
+  double TSFMAX_default = tuning.getTSFMAX(timestep);
   BOOST_CHECK_CLOSE(TSFMAX_default, 3.0, diff);
 
-  double TSFMIN_default = tuning->getTSFMIN(timestep);
+  double TSFMIN_default = tuning.getTSFMIN(timestep);
   BOOST_CHECK_CLOSE(TSFMIN_default, 0.3, diff);
 
-  double TSFCNV_default = tuning->getTSFCNV(timestep);
+  double TSFCNV_default = tuning.getTSFCNV(timestep);
   BOOST_CHECK_CLOSE(TSFCNV_default, 0.1, diff);
 
-  double TFDIFF_default = tuning->getTFDIFF(timestep);
+  double TFDIFF_default = tuning.getTFDIFF(timestep);
   BOOST_CHECK_CLOSE(TFDIFF_default, 1.25, diff);
 
-  double THRUPT_default = tuning->getTHRUPT(timestep);
+  double THRUPT_default = tuning.getTHRUPT(timestep);
   BOOST_CHECK_CLOSE(THRUPT_default, 1E20, diff);
 
-  bool TMAXWC_has_value = tuning->getTMAXWChasValue(timestep);
-  double TMAXWC_default = tuning->getTMAXWC(timestep);
+  bool TMAXWC_has_value = tuning.getTMAXWChasValue(timestep);
+  double TMAXWC_default = tuning.getTMAXWC(timestep);
   BOOST_CHECK_EQUAL(false, TMAXWC_has_value);
   BOOST_CHECK_CLOSE(TMAXWC_default, 0.0 * Metric::Time, diff);
 
 
   /********* Record 2 ************/
-  double TRGTTE_default = tuning->getTRGTTE(timestep);
+  double TRGTTE_default = tuning.getTRGTTE(timestep);
   BOOST_CHECK_CLOSE(TRGTTE_default, 0.1, diff);
 
-  double TRGCNV_default = tuning->getTRGCNV(timestep);
+  double TRGCNV_default = tuning.getTRGCNV(timestep);
   BOOST_CHECK_CLOSE(TRGCNV_default, 0.001, diff);
 
-  double TRGMBE_default = tuning->getTRGMBE(timestep);
+  double TRGMBE_default = tuning.getTRGMBE(timestep);
   BOOST_CHECK_CLOSE(TRGMBE_default, 1.0E-7, diff);
 
-  double TRGLCV_default = tuning->getTRGLCV(timestep);
+  double TRGLCV_default = tuning.getTRGLCV(timestep);
   BOOST_CHECK_CLOSE(TRGLCV_default, 0.0001, diff);
 
-  double XXXTTE_default = tuning->getXXXTTE(timestep);
+  double XXXTTE_default = tuning.getXXXTTE(timestep);
   BOOST_CHECK_CLOSE(XXXTTE_default, 10.0, diff);
 
-  double XXXCNV_default = tuning->getXXXCNV(timestep);
+  double XXXCNV_default = tuning.getXXXCNV(timestep);
   BOOST_CHECK_CLOSE(XXXCNV_default, 0.01, diff);
 
-  double XXXMBE_default = tuning->getXXXMBE(timestep);
+  double XXXMBE_default = tuning.getXXXMBE(timestep);
   BOOST_CHECK_CLOSE(XXXMBE_default, 1.0E-6, diff);
 
-  double XXXLCV_default = tuning->getXXXLCV(timestep);
+  double XXXLCV_default = tuning.getXXXLCV(timestep);
   BOOST_CHECK_CLOSE(XXXLCV_default, 0.001, diff);
 
-  double XXXWFL_default = tuning->getXXXWFL(timestep);
+  double XXXWFL_default = tuning.getXXXWFL(timestep);
   BOOST_CHECK_CLOSE(XXXWFL_default, 0.001, diff);
 
-  double TRGFIP_default = tuning->getTRGFIP(timestep);
+  double TRGFIP_default = tuning.getTRGFIP(timestep);
   BOOST_CHECK_CLOSE(TRGFIP_default, 0.025, diff);
 
-  bool TRGSFT_has_value = tuning->getTRGSFThasValue(timestep);
-  double TRGSFT_default = tuning->getTRGSFT(timestep);
+  bool TRGSFT_has_value = tuning.getTRGSFThasValue(timestep);
+  double TRGSFT_default = tuning.getTRGSFT(timestep);
   BOOST_CHECK_EQUAL(false, TRGSFT_has_value);
   BOOST_CHECK_CLOSE(TRGSFT_default, 0.0, diff);
 
-  double THIONX_default = tuning->getTHIONX(timestep);
+  double THIONX_default = tuning.getTHIONX(timestep);
   BOOST_CHECK_CLOSE(THIONX_default, 0.01, diff);
 
-  int TRWGHT_default = tuning->getTRWGHT(timestep);
+  int TRWGHT_default = tuning.getTRWGHT(timestep);
   BOOST_CHECK_EQUAL(TRWGHT_default, 1);
 
 
   /********* Record 3 ************/
-  int NEWTMX_default = tuning->getNEWTMX(timestep);
+  int NEWTMX_default = tuning.getNEWTMX(timestep);
   BOOST_CHECK_EQUAL(NEWTMX_default, 12);
 
-  int NEWTMN_default = tuning->getNEWTMN(timestep);
+  int NEWTMN_default = tuning.getNEWTMN(timestep);
   BOOST_CHECK_EQUAL(NEWTMN_default, 1);
 
-  int LITMAX_default = tuning->getLITMAX(timestep);
+  int LITMAX_default = tuning.getLITMAX(timestep);
   BOOST_CHECK_EQUAL(LITMAX_default, 25);
 
-  int LITMIN_default = tuning->getLITMIN(timestep);
+  int LITMIN_default = tuning.getLITMIN(timestep);
   BOOST_CHECK_EQUAL(LITMIN_default, 1);
 
-  int MXWSIT_default = tuning->getMXWSIT(timestep);
+  int MXWSIT_default = tuning.getMXWSIT(timestep);
   BOOST_CHECK_EQUAL(MXWSIT_default, 8);
 
-  int MXWPIT_default = tuning->getMXWPIT(timestep);
+  int MXWPIT_default = tuning.getMXWPIT(timestep);
   BOOST_CHECK_EQUAL(MXWPIT_default, 8);
 
-  double DDPLIM_default = tuning->getDDPLIM(timestep);
+  double DDPLIM_default = tuning.getDDPLIM(timestep);
   BOOST_CHECK_CLOSE(DDPLIM_default, 1.0E6 * Metric::Pressure, diff);
 
-  double DDSLIM_default = tuning->getDDSLIM(timestep);
+  double DDSLIM_default = tuning.getDDSLIM(timestep);
   BOOST_CHECK_CLOSE(DDSLIM_default, 1.0E6, diff);
 
-  double TRGDPR_default = tuning->getTRGDPR(timestep);
+  double TRGDPR_default = tuning.getTRGDPR(timestep);
   BOOST_CHECK_CLOSE(TRGDPR_default, 1.0E6 * Metric::Pressure, diff);
 
-  bool XXXDPR_has_value = tuning->getXXXDPRhasValue(timestep);
-  double XXXDPR_default = tuning->getXXXDPR(timestep);
+  bool XXXDPR_has_value = tuning.getXXXDPRhasValue(timestep);
+  double XXXDPR_default = tuning.getXXXDPR(timestep);
   BOOST_CHECK_EQUAL(false, XXXDPR_has_value);
   BOOST_CHECK_CLOSE(XXXDPR_default, 0.0, diff);
 
@@ -195,110 +195,110 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   /*** TIMESTEP 5***/
   /********* Record 1 ***********/
   timestep = 5;
-  double TSINIT = tuning->getTSINIT(timestep);
+  double TSINIT = tuning.getTSINIT(timestep);
   BOOST_CHECK_CLOSE(TSINIT, 2 * Metric::Time, diff);
 
-  double TSMAXZ = tuning->getTSMAXZ(timestep);
+  double TSMAXZ = tuning.getTSMAXZ(timestep);
   BOOST_CHECK_CLOSE(TSMAXZ, 300 * Metric::Time, diff);
 
-  double TSMINZ = tuning->getTSMINZ(timestep);
+  double TSMINZ = tuning.getTSMINZ(timestep);
   BOOST_CHECK_CLOSE(TSMINZ, 0.3 * Metric::Time, diff);
 
-  double TSMCHP = tuning->getTSMCHP(timestep);
+  double TSMCHP = tuning.getTSMCHP(timestep);
   BOOST_CHECK_CLOSE(TSMCHP, 0.30 * Metric::Time, diff);
 
-  double TSFMAX = tuning->getTSFMAX(timestep);
+  double TSFMAX = tuning.getTSFMAX(timestep);
   BOOST_CHECK_CLOSE(TSFMAX, 6.0, 1.0);
 
-  double TSFMIN = tuning->getTSFMIN(timestep);
+  double TSFMIN = tuning.getTSFMIN(timestep);
   BOOST_CHECK_CLOSE(TSFMIN, 0.6, 1.0);
 
-  double TSFCNV = tuning->getTSFCNV(timestep);
+  double TSFCNV = tuning.getTSFCNV(timestep);
   BOOST_CHECK_CLOSE(TSFCNV, 0.2, diff);
 
-  double TFDIFF = tuning->getTFDIFF(timestep);
+  double TFDIFF = tuning.getTFDIFF(timestep);
   BOOST_CHECK_CLOSE(TFDIFF, 2.25, diff);
 
-  double THRUPT = tuning->getTHRUPT(timestep);
+  double THRUPT = tuning.getTHRUPT(timestep);
   BOOST_CHECK_CLOSE(THRUPT, 2E20, diff);
 
-  TMAXWC_has_value = tuning->getTMAXWChasValue(timestep);
-  TMAXWC_default = tuning->getTMAXWC(timestep);
+  TMAXWC_has_value = tuning.getTMAXWChasValue(timestep);
+  TMAXWC_default = tuning.getTMAXWC(timestep);
   BOOST_CHECK_EQUAL(false, TMAXWC_has_value);
   BOOST_CHECK_CLOSE(TMAXWC_default, 0.0 * Metric::Time, diff);
 
   /********* Record 2 ***********/
-  double TRGTTE = tuning->getTRGTTE(timestep);
+  double TRGTTE = tuning.getTRGTTE(timestep);
   BOOST_CHECK_CLOSE(TRGTTE, 0.2, diff);
 
-  double TRGCNV = tuning->getTRGCNV(timestep);
+  double TRGCNV = tuning.getTRGCNV(timestep);
   BOOST_CHECK_CLOSE(TRGCNV, 0.002, diff);
 
-  double TRGMBE = tuning->getTRGMBE(timestep);
+  double TRGMBE = tuning.getTRGMBE(timestep);
   BOOST_CHECK_CLOSE(TRGMBE, 2.0E-7, diff);
 
-  double TRGLCV = tuning->getTRGLCV(timestep);
+  double TRGLCV = tuning.getTRGLCV(timestep);
   BOOST_CHECK_CLOSE(TRGLCV, 0.0002, diff);
 
-  double XXXTTE = tuning->getXXXTTE(timestep);
+  double XXXTTE = tuning.getXXXTTE(timestep);
   BOOST_CHECK_CLOSE(XXXTTE, 11.0, diff);
 
-  double XXXCNV = tuning->getXXXCNV(timestep);
+  double XXXCNV = tuning.getXXXCNV(timestep);
   BOOST_CHECK_CLOSE(XXXCNV, 0.02, diff);
 
-  double XXXMBE = tuning->getXXXMBE(timestep);
+  double XXXMBE = tuning.getXXXMBE(timestep);
   BOOST_CHECK_CLOSE(XXXMBE, 2.0E-6, diff);
 
-  double XXXLCV = tuning->getXXXLCV(timestep);
+  double XXXLCV = tuning.getXXXLCV(timestep);
   BOOST_CHECK_CLOSE(XXXLCV, 0.002, diff);
 
-  double XXXWFL = tuning->getXXXWFL(timestep);
+  double XXXWFL = tuning.getXXXWFL(timestep);
   BOOST_CHECK_CLOSE(XXXWFL, 0.002, diff);
 
-  double TRGFIP = tuning->getTRGFIP(timestep);
+  double TRGFIP = tuning.getTRGFIP(timestep);
   BOOST_CHECK_CLOSE(TRGFIP, 0.035, diff);
 
-  TRGSFT_has_value = tuning->getTRGSFThasValue(timestep);
-  double TRGSFT = tuning->getTRGSFT(timestep);
+  TRGSFT_has_value = tuning.getTRGSFThasValue(timestep);
+  double TRGSFT = tuning.getTRGSFT(timestep);
   BOOST_CHECK_EQUAL(true, TRGSFT_has_value);
   BOOST_CHECK_CLOSE(TRGSFT, 66.0, diff);
 
-  double THIONX = tuning->getTHIONX(timestep);
+  double THIONX = tuning.getTHIONX(timestep);
   BOOST_CHECK_CLOSE(THIONX, 0.02, diff);
 
-  int TRWGHT = tuning->getTRWGHT(timestep);
+  int TRWGHT = tuning.getTRWGHT(timestep);
   BOOST_CHECK_EQUAL(TRWGHT, 2);
 
   /********* Record 3 ***********/
-  int NEWTMX = tuning->getNEWTMX(timestep);
+  int NEWTMX = tuning.getNEWTMX(timestep);
   BOOST_CHECK_EQUAL(NEWTMX, 13);
 
-  int NEWTMN = tuning->getNEWTMN(timestep);
+  int NEWTMN = tuning.getNEWTMN(timestep);
   BOOST_CHECK_EQUAL(NEWTMN, 2);
 
-  int LITMAX = tuning->getLITMAX(timestep);
+  int LITMAX = tuning.getLITMAX(timestep);
   BOOST_CHECK_EQUAL(LITMAX, 26);
 
-  int LITMIN = tuning->getLITMIN(timestep);
+  int LITMIN = tuning.getLITMIN(timestep);
   BOOST_CHECK_EQUAL(LITMIN, 2);
 
-  int MXWSIT = tuning->getMXWSIT(timestep);
+  int MXWSIT = tuning.getMXWSIT(timestep);
   BOOST_CHECK_EQUAL(MXWSIT, 9);
 
-  int MXWPIT = tuning->getMXWPIT(timestep);
+  int MXWPIT = tuning.getMXWPIT(timestep);
   BOOST_CHECK_EQUAL(MXWPIT, 9);
 
-  double DDPLIM= tuning->getDDPLIM(timestep);
+  double DDPLIM= tuning.getDDPLIM(timestep);
   BOOST_CHECK_CLOSE(DDPLIM, 4.0E6 * Metric::Pressure, diff);
 
-  double DDSLIM= tuning->getDDSLIM(timestep);
+  double DDSLIM= tuning.getDDSLIM(timestep);
   BOOST_CHECK_CLOSE(DDSLIM, 4.0E6, diff);
 
-  double TRGDPR = tuning->getTRGDPR(timestep);
+  double TRGDPR = tuning.getTRGDPR(timestep);
   BOOST_CHECK_CLOSE(TRGDPR, 4.0E6 * Metric::Pressure, diff);
 
-  XXXDPR_has_value = tuning->getXXXDPRhasValue(timestep);
-  double XXXDPR = tuning->getXXXDPR(timestep);
+  XXXDPR_has_value = tuning.getXXXDPRhasValue(timestep);
+  double XXXDPR = tuning.getXXXDPR(timestep);
   BOOST_CHECK_EQUAL(true, XXXDPR_has_value);
   BOOST_CHECK_CLOSE(XXXDPR, 1.0 * Metric::Pressure, diff);
 
@@ -308,8 +308,8 @@ BOOST_AUTO_TEST_CASE(TuningTest) {
   /*** TIMESTEP 10 ***/
   /********* Record 1 ***********/
   timestep = 10;
-  TMAXWC_has_value = tuning->getTMAXWChasValue(timestep);
-  TMAXWC_default = tuning->getTMAXWC(timestep);
+  TMAXWC_has_value = tuning.getTMAXWChasValue(timestep);
+  TMAXWC_default = tuning.getTMAXWC(timestep);
   BOOST_CHECK_EQUAL(true, TMAXWC_has_value);
   BOOST_CHECK_CLOSE(TMAXWC_default, 10.0 * Metric::Time, diff);
 
@@ -323,7 +323,7 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
   DeckPtr deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   Schedule schedule(ParseContext() , grid , deck);
-  TuningPtr tuning = schedule.getTuning();
+  auto tuning = schedule.getTuning();
 
 
   const double diff = 1.0e-14;
@@ -332,13 +332,13 @@ BOOST_AUTO_TEST_CASE(TuningInitTest) {
   /********* Record 1 ***********/
   size_t timestep = 0;
   double value = 100.00;
-  tuning->setTuningInitialValue("TSINIT",value, false);
-  double TSINIT_default = tuning->getTSINIT(timestep);
+  tuning.setTuningInitialValue("TSINIT",value, false);
+  double TSINIT_default = tuning.getTSINIT(timestep);
   BOOST_CHECK_CLOSE(TSINIT_default, 100.00, diff);
 
   timestep = 10;
-  bool TMAXWC_has_value = tuning->getTMAXWChasValue(timestep);
-  double TMAXWC_default = tuning->getTMAXWC(timestep);
+  bool TMAXWC_has_value = tuning.getTMAXWChasValue(timestep);
+  double TMAXWC_default = tuning.getTMAXWC(timestep);
   BOOST_CHECK_EQUAL(true, TMAXWC_has_value);
   BOOST_CHECK_CLOSE(TMAXWC_default, 10.0 * Metric::Time, diff);
 
@@ -351,7 +351,7 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
   DeckPtr deck = createDeck(deckStr);
   EclipseGrid grid(10,10,10);
   Schedule schedule(ParseContext() , grid , deck);
-  TuningPtr tuning = schedule.getTuning();
+  auto tuning = schedule.getTuning();
 
 
   const double diff = 1.0e-14;
@@ -360,12 +360,12 @@ BOOST_AUTO_TEST_CASE(TuningResetTest) {
   /********* Record 1 ***********/
   size_t timestep = 0;
   double value = 666.00;
-  tuning->setTuningInitialValue("TSINIT",value, true);
-  double TSINIT_default = tuning->getTSINIT(timestep);
+  tuning.setTuningInitialValue("TSINIT",value, true);
+  double TSINIT_default = tuning.getTSINIT(timestep);
   BOOST_CHECK_CLOSE(TSINIT_default, 666.00, diff);
 
   timestep = 10;
-  TSINIT_default = tuning->getTSINIT(timestep);
+  TSINIT_default = tuning.getTSINIT(timestep);
   BOOST_CHECK_CLOSE(TSINIT_default, 666.00, diff);
 
   

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -486,30 +486,30 @@ BOOST_AUTO_TEST_CASE( WellTestGroups ) {
     BOOST_CHECK( sched->hasGroup( "OP" ));
 
     {
-        auto* group = sched->getGroup("INJ");
-        BOOST_CHECK_EQUAL( Phase::WATER , group->getInjectionPhase( 3 ));
-        BOOST_CHECK_EQUAL( GroupInjection::VREP , group->getInjectionControlMode( 3 ));
-        BOOST_CHECK_CLOSE( 10/Metric::Time , group->getSurfaceMaxRate( 3 ) , 0.001);
-        BOOST_CHECK_CLOSE( 20/Metric::Time , group->getReservoirMaxRate( 3 ) , 0.001);
-        BOOST_CHECK_EQUAL( 0.75 , group->getTargetReinjectFraction( 3 ));
-        BOOST_CHECK_EQUAL( 0.95 , group->getTargetVoidReplacementFraction( 3 ));
+        auto& group = sched->getGroup("INJ");
+        BOOST_CHECK_EQUAL( Phase::WATER , group.getInjectionPhase( 3 ));
+        BOOST_CHECK_EQUAL( GroupInjection::VREP , group.getInjectionControlMode( 3 ));
+        BOOST_CHECK_CLOSE( 10/Metric::Time , group.getSurfaceMaxRate( 3 ) , 0.001);
+        BOOST_CHECK_CLOSE( 20/Metric::Time , group.getReservoirMaxRate( 3 ) , 0.001);
+        BOOST_CHECK_EQUAL( 0.75 , group.getTargetReinjectFraction( 3 ));
+        BOOST_CHECK_EQUAL( 0.95 , group.getTargetVoidReplacementFraction( 3 ));
 
-        BOOST_CHECK_EQUAL( Phase::OIL , group->getInjectionPhase( 6 ));
-        BOOST_CHECK_EQUAL( GroupInjection::RATE , group->getInjectionControlMode( 6 ));
-        BOOST_CHECK_CLOSE( 1000/Metric::Time , group->getSurfaceMaxRate( 6 ) , 0.0001);
+        BOOST_CHECK_EQUAL( Phase::OIL , group.getInjectionPhase( 6 ));
+        BOOST_CHECK_EQUAL( GroupInjection::RATE , group.getInjectionControlMode( 6 ));
+        BOOST_CHECK_CLOSE( 1000/Metric::Time , group.getSurfaceMaxRate( 6 ) , 0.0001);
 
-        BOOST_CHECK(group->isInjectionGroup(3));
+        BOOST_CHECK(group.isInjectionGroup(3));
     }
 
     {
-        auto* group = sched->getGroup("OP");
-        BOOST_CHECK_EQUAL( GroupProduction::ORAT , group->getProductionControlMode(3));
-        BOOST_CHECK_CLOSE( 10/Metric::Time , group->getOilTargetRate(3) , 0.001);
-        BOOST_CHECK_CLOSE( 20/Metric::Time , group->getWaterTargetRate(3) , 0.001);
-        BOOST_CHECK_CLOSE( 30/Metric::Time , group->getGasTargetRate(3) , 0.001);
-        BOOST_CHECK_CLOSE( 40/Metric::Time , group->getLiquidTargetRate(3) , 0.001);
+        auto& group = sched->getGroup("OP");
+        BOOST_CHECK_EQUAL( GroupProduction::ORAT , group.getProductionControlMode(3));
+        BOOST_CHECK_CLOSE( 10/Metric::Time , group.getOilTargetRate(3) , 0.001);
+        BOOST_CHECK_CLOSE( 20/Metric::Time , group.getWaterTargetRate(3) , 0.001);
+        BOOST_CHECK_CLOSE( 30/Metric::Time , group.getGasTargetRate(3) , 0.001);
+        BOOST_CHECK_CLOSE( 40/Metric::Time , group.getLiquidTargetRate(3) , 0.001);
 
-        BOOST_CHECK(group->isProductionGroup(3));
+        BOOST_CHECK(group.isProductionGroup(3));
     }
 
 }
@@ -523,24 +523,24 @@ BOOST_AUTO_TEST_CASE( WellTestGroupAndWellRelation ) {
     EclipseGrid grid(10,10,3);
     SchedulePtr sched( new Schedule(parseContext , grid , deck));
 
-    auto* group1 = sched->getGroup("GROUP1");
-    auto* group2 = sched->getGroup("GROUP2");
+    auto& group1 = sched->getGroup("GROUP1");
+    auto& group2 = sched->getGroup("GROUP2");
 
-    BOOST_CHECK( group1->hasBeenDefined(0) );
-    BOOST_CHECK_EQUAL(false , group2->hasBeenDefined(0));
-    BOOST_CHECK( group2->hasBeenDefined(1));
+    BOOST_CHECK( group1.hasBeenDefined(0) );
+    BOOST_CHECK_EQUAL(false , group2.hasBeenDefined(0));
+    BOOST_CHECK( group2.hasBeenDefined(1));
 
-    BOOST_CHECK_EQUAL( true , group1->hasWell("W_1" , 0));
-    BOOST_CHECK_EQUAL( true , group1->hasWell("W_2" , 0));
-    BOOST_CHECK_EQUAL( false, group2->hasWell("W_1" , 0));
-    BOOST_CHECK_EQUAL( false, group2->hasWell("W_2" , 0));
+    BOOST_CHECK_EQUAL( true , group1.hasWell("W_1" , 0));
+    BOOST_CHECK_EQUAL( true , group1.hasWell("W_2" , 0));
+    BOOST_CHECK_EQUAL( false, group2.hasWell("W_1" , 0));
+    BOOST_CHECK_EQUAL( false, group2.hasWell("W_2" , 0));
 
 
 
-    BOOST_CHECK_EQUAL( true  , group1->hasWell("W_1" , 1));
-    BOOST_CHECK_EQUAL( false , group1->hasWell("W_2" , 1));
-    BOOST_CHECK_EQUAL( false , group2->hasWell("W_1" , 1));
-    BOOST_CHECK_EQUAL( true  , group2->hasWell("W_2" , 1));
+    BOOST_CHECK_EQUAL( true  , group1.hasWell("W_1" , 1));
+    BOOST_CHECK_EQUAL( false , group1.hasWell("W_2" , 1));
+    BOOST_CHECK_EQUAL( false , group2.hasWell("W_1" , 1));
+    BOOST_CHECK_EQUAL( true  , group2.hasWell("W_2" , 1));
 }
 
 

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -314,7 +314,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_with_explicit_L0_parenting) {
     EclipseGrid grid(10,10,3);
     SchedulePtr sched(new Schedule(parseContext , grid , deck));
 
-    GroupTreeNodePtr rootNode = sched->getGroupTree(0)->getNode("FIELD");
+    GroupTreeNodePtr rootNode = sched->getGroupTree(0).getNode("FIELD");
 
 
     BOOST_REQUIRE_EQUAL("FIELD", rootNode->name());
@@ -363,7 +363,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_iter_function) 
     SchedulePtr schedule(new Schedule(parseContext , grid , deck));
 
     // Time 0, only from WELSPECS
-    GroupTreeNodeConstPtr root = schedule->getGroupTree(0)->getNode("FIELD");
+    GroupTreeNodeConstPtr root = schedule->getGroupTree(0).getNode("FIELD");
 
     int iter_counted = 0;
 
@@ -374,7 +374,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_iter_function) 
     // Time 1, a new group added in tree
     iter_counted = 0;
 
-    root = schedule->getGroupTree(1)->getNode("FIELD");
+    root = schedule->getGroupTree(1).getNode("FIELD");
     for (auto iter=root->begin(); iter != root->end(); ++iter) {
        iter_counted++;
     }
@@ -390,7 +390,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     SchedulePtr schedule(new Schedule(parseContext , grid , deck));
 
     // Time 0, only from WELSPECS
-    GroupTreeNodePtr root0 = schedule->getGroupTree(0)->getNode("FIELD");
+    GroupTreeNodePtr root0 = schedule->getGroupTree(0).getNode("FIELD");
     BOOST_REQUIRE_EQUAL("FIELD", root0->name());
     BOOST_CHECK(root0->hasChildGroup("GROUP_BJARNE"));
     GroupTreeNodePtr GROUP_BJARNE = root0->getChildGroup("GROUP_BJARNE");
@@ -401,7 +401,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_WELSPECS_AND_GRUPTREE_correct_tree) {
     BOOST_CHECK_EQUAL("GROUP_ODD", GROUP_ODD->name());
 
     // Time 1, now also from GRUPTREE
-    GroupTreeNodePtr root1 = schedule->getGroupTree(1)->getNode("FIELD");
+    GroupTreeNodePtr root1 = schedule->getGroupTree(1).getNode("FIELD");
     BOOST_REQUIRE_EQUAL("FIELD", root1->name());
     BOOST_CHECK(root1->hasChildGroup("GROUP_BJARNE"));
     GroupTreeNodePtr GROUP_BJARNE1 = root1->getChildGroup("GROUP_BJARNE");
@@ -436,7 +436,7 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_GRUPTREE_WITH_REPARENT_correct_tree) {
 
 
     // Time , from  first GRUPTREE
-    GroupTreeNodePtr root0 = schedule->getGroupTree(0)->getNode("FIELD");
+    GroupTreeNodePtr root0 = schedule->getGroupTree(0).getNode("FIELD");
     BOOST_REQUIRE_EQUAL("FIELD", root0->name());
     BOOST_CHECK(root0->hasChildGroup("GROUP_BJARNE"));
     GroupTreeNodePtr GROUP_BJARNE0 = root0->getChildGroup("GROUP_BJARNE");
@@ -467,8 +467,8 @@ BOOST_AUTO_TEST_CASE(GroupTreeTest_PrintGrouptree) {
     EclipseGrid grid(10,10,3);
     SchedulePtr sched(new Schedule(parseContext , grid , deck));
 
-    GroupTreePtr rootNode = sched->getGroupTree(0);
-    rootNode->printTree(std::cout);
+    const auto& rootNode = sched->getGroupTree(0);
+    rootNode.printTree(std::cout);
 
 }
 


### PR DESCRIPTION
Removes most shared_ptr members from the Schedule class. Some other changes are mandated by this:

* `DynamicState::get` returns a *reference*, not a value copy. This has implications for `std::vector<bool>` which can't have its `at` returned by reference since it would be a temporary. All `DynamicState<bool>` are instead represented by `int`, and appropriate bool conversions are added.
* `OilVaporizationProperties` has its default constructor public, but the default constructed version will be `UNDEF` and comparing to this will always be `false`.
* GroupTree has a copy constructor that maps to `GroupTree::deepCopy`.