### PR TITLE
Add JFUNC

### DIFF
--- a/opm/parser/eclipse/Units/ConversionFactors.hpp
+++ b/opm/parser/eclipse/Units/ConversionFactors.hpp
@@ -133,6 +133,7 @@ namespace Opm {
             /// \name Force
             /// @{
             constexpr const double Newton = kilogram*meter / square(second); // == 1
+            constexpr const double dyne   = 1e-5*Newton;
             constexpr const double lbf    = pound * gravity; // Pound-force
             /// @}
 
@@ -211,6 +212,7 @@ namespace Opm {
         constexpr const double Salinity             = kilogram/cubic(meter);
         constexpr const double Viscosity            = centi*Poise;
         constexpr const double Timestep             = day;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
     }
 
 
@@ -236,6 +238,7 @@ namespace Opm {
         constexpr const double Salinity             = pound/stb;
         constexpr const double Viscosity            = centi*Poise;
         constexpr const double Timestep             = day;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
     }
 
 
@@ -261,6 +264,7 @@ namespace Opm {
         constexpr const double Salinity             = gram/cubic(centi*meter);
         constexpr const double Viscosity            = centi*Poise;
         constexpr const double Timestep             = hour;
+        constexpr const double SurfaceTension       = dyne/(centi*meter);
     }
 
 }

--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -488,6 +488,7 @@ namespace {
         system->addDimension("Salinity", Metric::Salinity);
         system->addDimension("Viscosity" , Metric::Viscosity);
         system->addDimension("Timestep"  , Metric::Timestep);
+        system->addDimension("SurfaceTension"  , Metric::SurfaceTension);
         system->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         return system;
     }
@@ -516,6 +517,7 @@ namespace {
         system->addDimension("Salinity", Field::Salinity);
         system->addDimension("Viscosity", Field::Viscosity);
         system->addDimension("Timestep", Field::Timestep);
+        system->addDimension("SurfaceTension"  , Field::SurfaceTension);
         system->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         return system;
     }
@@ -544,6 +546,7 @@ namespace {
         system->addDimension("Salinity", Lab::Salinity);
         system->addDimension("Viscosity", Lab::Viscosity);
         system->addDimension("Timestep", Lab::Timestep);
+        system->addDimension("SurfaceTension"  , Lab::SurfaceTension);
         system->addDimension("ContextDependent", std::numeric_limits<double>::quiet_NaN());
         return system;
     }

--- a/opm/parser/share/keywords/000_Eclipse100/J/JFUNC
+++ b/opm/parser/share/keywords/000_Eclipse100/J/JFUNC
@@ -1,0 +1,8 @@
+{"name" : "JFUNC" , "sections" : ["GRID"], "size" : 1 , "items" : [
+        {"name" : "FLAG" , "value_type" : "STRING", "default": "BOTH"},
+        {"name" : "OW_SURFACE_TENSION" , "value_type" : "DOUBLE", "dimension":"SurfaceTension", "default": -1.0},
+        {"name" : "GO_SURFACE_TENSION" , "value_type" : "DOUBLE", "dimension":"SurfaceTension", "default": -1.0},
+        {"name" : "ALPHA_FACTOR" , "value_type" : "DOUBLE", "default": 0.5},
+        {"name" : "BETA_FACTOR" , "value_type" : "DOUBLE", "default": 0.5},
+        {"name" : "DIRECTION" , "value_type" : "STRING", "default": "XY" }
+]}


### PR DESCRIPTION
this adds the basic support for the JFUNC keyword and this required to parse the deck of "model 2.2" without hickups. the support is "basic" because the keyword is not internalized in any way. (given that the keyword is pretty simple and not present in most decks, I don't think adding it to `EclipseState` is worth the hassle.)