### PR TITLE
Added Well::getCompletions( ).

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -291,6 +291,10 @@ namespace Opm {
         return m_completions->get( timeStep );
     }
 
+    CompletionSetConstPtr Well::getCompletions() const {
+        return m_completions->back();
+    }
+
     void Well::addCompletions(size_t time_step , const std::vector<CompletionPtr>& newCompletions) {
         CompletionSetConstPtr currentCompletionSet = m_completions->get(time_step);
         CompletionSetPtr newCompletionSet = CompletionSetPtr( currentCompletionSet->shallowCopy() );

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -81,6 +81,7 @@ namespace Opm {
         void addCompletions(size_t time_step , const std::vector<std::shared_ptr< Completion >>& newCompletions);
         void addCompletionSet(size_t time_step, const std::shared_ptr< const CompletionSet > newCompletionSet);
         std::shared_ptr< const CompletionSet > getCompletions(size_t timeStep) const;
+        std::shared_ptr< const CompletionSet > getCompletions( ) const;
 
         /* The rate of a given phase under the following assumptions:
          * * Returns zero if production is requested for an injector (and vice


### PR DESCRIPTION
The new Well::getCompletions( ) method without argument will return all
the existing completions at the end of the simulation.