### PR TITLE
Short circuit when line terminator is found first

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -68,7 +68,7 @@ inline Itr find_terminator( Itr begin, Itr end, Term terminator ) {
 
     auto pos = terminator( begin, end );
 
-    if( pos == end ) return end;
+    if( pos == begin || pos == end) return pos;
 
     auto qbegin = std::find_if( begin, end, RawConsts::is_quote() );
 


### PR DESCRIPTION
The termination logic would sometimes need to scan the full line to see
if some terminating condition was found inside quotes. Plenty of
comments in a file start on the first character of a line, meaning this
scan is unnecessary.