### PR TITLE
Changes to MessageLimits:

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.cpp
@@ -20,152 +20,189 @@
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 
 namespace Opm {
 
 
+
+
+
     MessageLimits::MessageLimits( const TimeMap& timemap ) :
-        m_message_print_limit(timemap, ParserKeywords::MESSAGES::MESSAGE_PRINT_LIMIT::defaultValue),
-        m_comment_print_limit(timemap, ParserKeywords::MESSAGES::COMMENT_PRINT_LIMIT::defaultValue),
-        m_warning_print_limit(timemap, ParserKeywords::MESSAGES::WARNING_PRINT_LIMIT::defaultValue),
-        m_problem_print_limit(timemap, ParserKeywords::MESSAGES::PROBLEM_PRINT_LIMIT::defaultValue),
-        m_error_print_limit(timemap, ParserKeywords::MESSAGES::ERROR_PRINT_LIMIT::defaultValue),
-        m_bug_print_limit(timemap, ParserKeywords::MESSAGES::BUG_PRINT_LIMIT::defaultValue),
-        m_message_stop_limit(timemap, ParserKeywords::MESSAGES::MESSAGE_STOP_LIMIT::defaultValue),
-        m_comment_stop_limit(timemap, ParserKeywords::MESSAGES::COMMENT_STOP_LIMIT::defaultValue),
-        m_warning_stop_limit(timemap, ParserKeywords::MESSAGES::WARNING_STOP_LIMIT::defaultValue),
-        m_problem_stop_limit(timemap, ParserKeywords::MESSAGES::PROBLEM_STOP_LIMIT::defaultValue),
-        m_error_stop_limit(timemap, ParserKeywords::MESSAGES::ERROR_STOP_LIMIT::defaultValue),
-        m_bug_stop_limit(timemap, ParserKeywords::MESSAGES::BUG_STOP_LIMIT::defaultValue)
-        {
-        }
-
-
+        limits( timemap , MLimits())
+    { }
 
 
     int MessageLimits::getMessagePrintLimit(size_t timestep) const
     {
-        return m_message_print_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.message_print_limit;
     }
 
     int MessageLimits::getCommentPrintLimit(size_t timestep) const
     {
-        return m_comment_print_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.comment_print_limit;
     }
 
     int MessageLimits::getWarningPrintLimit(size_t timestep) const
     {
-        return m_warning_print_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.warning_print_limit;
     }
 
     int MessageLimits::getProblemPrintLimit(size_t timestep) const
     {
-        return m_problem_print_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.problem_print_limit;
     }
 
     int MessageLimits::getErrorPrintLimit(size_t timestep) const
     {
-        return m_error_print_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.error_print_limit;
     }
 
     int MessageLimits::getBugPrintLimit(size_t timestep) const
     {
-        return m_bug_print_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.bug_print_limit;
     }
 
-
-
-    void MessageLimits::setMessagePrintLimit(size_t timestep, int value)
-    {
-        m_message_print_limit.update(timestep, value);
-    }
-
-    void MessageLimits::setCommentPrintLimit(size_t timestep, int value)
-    {
-        m_comment_print_limit.update(timestep, value);
-    }
-
-    void MessageLimits::setWarningPrintLimit(size_t timestep, int value)
-    {
-        m_warning_print_limit.update(timestep, value);
-    }
-
-    void MessageLimits::setProblemPrintLimit(size_t timestep, int value)
-    {
-        m_problem_print_limit.update(timestep, value);
-    }
-
-    void MessageLimits::setErrorPrintLimit(size_t timestep, int value)
-    {
-        m_error_print_limit.update(timestep, value);
-    }
-
-    void MessageLimits::setBugPrintLimit(size_t timestep, int value)
-    {
-        m_bug_print_limit.update(timestep, value);
-    }
-
+    /*-----------------------------------------------------------------*/
 
     int MessageLimits::getMessageStopLimit(size_t timestep) const
     {
-        return m_message_stop_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.message_stop_limit;
     }
 
     int MessageLimits::getCommentStopLimit(size_t timestep) const
     {
-        return m_comment_stop_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.comment_stop_limit;
     }
 
     int MessageLimits::getWarningStopLimit(size_t timestep) const
     {
-        return m_warning_stop_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.warning_stop_limit;
     }
 
     int MessageLimits::getProblemStopLimit(size_t timestep) const
     {
-        return m_problem_stop_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.problem_stop_limit;
     }
 
     int MessageLimits::getErrorStopLimit(size_t timestep) const
     {
-        return m_error_stop_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.error_stop_limit;
     }
 
     int MessageLimits::getBugStopLimit(size_t timestep) const
     {
-        return m_bug_stop_limit.get(timestep);
+        const auto& mlimit = limits.get( timestep );
+        return mlimit.bug_stop_limit;
     }
 
+    /*-----------------------------------------------------------------*/
+
+    void MessageLimits::update(size_t timestep, const MLimits& value) {
+        if (timestep == 0)
+            limits.updateInitial( value );
+        else
+            limits.update( timestep , value );
+    }
+
+    void MessageLimits::setMessagePrintLimit(size_t timestep, int value)
+    {
+        auto mlimit = limits.get( timestep );
+        mlimit.message_print_limit = value;
+        this->update( timestep , mlimit );
+    }
+
+    void MessageLimits::setCommentPrintLimit(size_t timestep, int value)
+    {
+        auto mlimit = limits.get( timestep );
+        mlimit.comment_print_limit = value;
+        this->update( timestep , mlimit );
+    }
+
+    void MessageLimits::setWarningPrintLimit(size_t timestep, int value)
+    {
+        auto mlimit = limits.get( timestep );
+        mlimit.warning_print_limit = value;
+        this->update( timestep , mlimit );
+    }
+
+    void MessageLimits::setProblemPrintLimit(size_t timestep, int value)
+    {
+        auto mlimit = limits.get( timestep );
+        mlimit.problem_print_limit = value;
+        this->update( timestep , mlimit );
+    }
+
+    void MessageLimits::setErrorPrintLimit(size_t timestep, int value)
+    {
+        auto mlimit = limits.get( timestep );
+        mlimit.error_print_limit = value;
+        this->update( timestep , mlimit );
+    }
+
+    void MessageLimits::setBugPrintLimit(size_t timestep, int value)
+    {
+        auto mlimit = limits.get( timestep );
+        mlimit.bug_print_limit = value;
+        this->update( timestep , mlimit );
+    }
+
+    /*-----------------------------------------------------------------*/
 
     void MessageLimits::setMessageStopLimit(size_t timestep, int value)
     {
-        m_message_stop_limit.update(timestep, value);
+        auto mlimit = limits.get( timestep );
+        mlimit.message_stop_limit = value;
+        this->update( timestep , mlimit );
     }
 
     void MessageLimits::setCommentStopLimit(size_t timestep, int value)
     {
-        m_comment_stop_limit.update(timestep, value);
+        auto mlimit = limits.get( timestep );
+        mlimit.comment_stop_limit = value;
+        this->update( timestep , mlimit );
     }
 
     void MessageLimits::setWarningStopLimit(size_t timestep, int value)
     {
-        m_warning_stop_limit.update(timestep, value);
+        auto mlimit = limits.get( timestep );
+        mlimit.warning_stop_limit = value;
+        this->update( timestep , mlimit );
     }
 
     void MessageLimits::setProblemStopLimit(size_t timestep, int value)
     {
-        m_problem_stop_limit.update(timestep, value);
+        auto mlimit = limits.get( timestep );
+        mlimit.problem_stop_limit = value;
+        this->update( timestep , mlimit );
     }
 
     void MessageLimits::setErrorStopLimit(size_t timestep, int value)
     {
-        m_error_stop_limit.update(timestep, value);
+        auto mlimit = limits.get( timestep );
+        mlimit.error_stop_limit = value;
+        this->update( timestep , mlimit );
     }
 
     void MessageLimits::setBugStopLimit(size_t timestep, int value)
     {
-        m_bug_stop_limit.update(timestep, value);
+        auto mlimit = limits.get( timestep );
+        mlimit.bug_stop_limit = value;
+        this->update( timestep , mlimit );
     }
+
+
 
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
@@ -21,10 +21,48 @@
 #define OPM_MESSAGES_HPP
 
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
 
 namespace Opm {
 
-    class TimeMap;    
+    class TimeMap;
+
+    struct MLimits {
+        int message_print_limit = ParserKeywords::MESSAGES::MESSAGE_PRINT_LIMIT::defaultValue;
+        int comment_print_limit = ParserKeywords::MESSAGES::COMMENT_PRINT_LIMIT::defaultValue;
+        int warning_print_limit = ParserKeywords::MESSAGES::WARNING_PRINT_LIMIT::defaultValue;
+        int problem_print_limit = ParserKeywords::MESSAGES::PROBLEM_PRINT_LIMIT::defaultValue;
+        int error_print_limit   = ParserKeywords::MESSAGES::ERROR_PRINT_LIMIT::defaultValue;
+        int bug_print_limit     = ParserKeywords::MESSAGES::BUG_PRINT_LIMIT::defaultValue;
+        int message_stop_limit  = ParserKeywords::MESSAGES::MESSAGE_STOP_LIMIT::defaultValue;
+        int comment_stop_limit  = ParserKeywords::MESSAGES::COMMENT_STOP_LIMIT::defaultValue;
+        int warning_stop_limit  = ParserKeywords::MESSAGES::WARNING_STOP_LIMIT::defaultValue;
+        int problem_stop_limit  = ParserKeywords::MESSAGES::PROBLEM_STOP_LIMIT::defaultValue;
+        int error_stop_limit    = ParserKeywords::MESSAGES::ERROR_STOP_LIMIT::defaultValue;
+        int bug_stop_limit      = ParserKeywords::MESSAGES::BUG_STOP_LIMIT::defaultValue;
+
+
+        bool operator==(const MLimits& other) const {
+            return  ((this->message_print_limit == other.message_print_limit) &&
+                     (this->comment_print_limit == other.comment_print_limit) &&
+                     (this->warning_print_limit == other.warning_print_limit) &&
+                     (this->problem_print_limit == other.problem_print_limit) &&
+                     (this->error_print_limit   == other.error_print_limit  ) &&
+                     (this->bug_print_limit     == other.bug_print_limit    ) &&
+                     (this->message_stop_limit  == other.message_stop_limit ) &&
+                     (this->comment_stop_limit  == other.comment_stop_limit ) &&
+                     (this->warning_stop_limit  == other.warning_stop_limit ) &&
+                     (this->problem_stop_limit  == other.problem_stop_limit ) &&
+                     (this->error_stop_limit    == other.error_stop_limit   ) &&
+                     (this->bug_stop_limit      == other.bug_stop_limit     ));
+        }
+
+        bool operator!=(const MLimits& other) const {
+            return !(*this == other);
+        }
+
+    };
+
 
     class MessageLimits {
     public:
@@ -63,20 +101,11 @@ namespace Opm {
         void setProblemStopLimit(size_t timestep, int value);
         void setErrorStopLimit(size_t timestep, int value);
         void setBugStopLimit(size_t timestep, int value);
-    private:
-        DynamicState<int> m_message_print_limit;
-        DynamicState<int> m_comment_print_limit;
-        DynamicState<int> m_warning_print_limit;
-        DynamicState<int> m_problem_print_limit;
-        DynamicState<int> m_error_print_limit;
-        DynamicState<int> m_bug_print_limit;
 
-        DynamicState<int> m_message_stop_limit;
-        DynamicState<int> m_comment_stop_limit;
-        DynamicState<int> m_warning_stop_limit;
-        DynamicState<int> m_problem_stop_limit;
-        DynamicState<int> m_error_stop_limit;
-        DynamicState<int> m_bug_stop_limit;
+    private:
+        void update(size_t timestep, const MLimits& value);
+
+        DynamicState<MLimits> limits;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/CMakeLists.txt
@@ -5,7 +5,7 @@ foreach(tapp TimeMapTest ScheduleTests WellTests
              DynamicStateTests GroupTreeNodeTests
              GroupTreeTests TuningTests EventTests
              WellSolventTests DynamicVectorTests
-             GeomodifierTests)
+             GeomodifierTests MessageLimitTests)
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})
 endforeach()

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/MessageLimitTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/MessageLimitTests.cpp
@@ -1,0 +1,95 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <stdexcept>
+#include <iostream>
+#include <boost/filesystem.hpp>
+
+#define BOOST_TEST_MODULE MessageLimitTests
+
+#include <boost/test/unit_test.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+
+#include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+#include <opm/parser/eclipse/Parser/ParseContext.hpp>
+
+using namespace Opm;
+
+
+BOOST_AUTO_TEST_CASE(MESSAGES) {
+    Opm::Parser parser;
+    std::string input =
+            "START             -- 0 \n"
+            "19 JUN 2007 / \n"
+            "RUNSPEC\n"
+            "MESSAGES\n"
+            "  5* 10 /\n"
+             "GRID\n"
+            "MESSAGES\n"
+            "  5* 77 /\n"
+            "SCHEDULE\n"
+            "DATES             -- 1\n"
+            " 10  OKT 2008 / \n"
+            "/\n"
+            "WELSPECS\n"
+            "    'P1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "    'P2'       'OP'   5   5 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "    'I'       'OP'   1   1 1*     'WATER' 1*      1*  1*   1*  1*   1*  1*  / \n"
+            "/\n"
+            "COMPDAT\n"
+            " 'P1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            " 'P1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+            " 'P2'  5  5   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            " 'P2'  5  5   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
+            " 'I'  1  1   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
+            "/\n"
+            "WCONHIST\n"
+            " 'P1' 'OPEN' 'ORAT' 5*/ \n"
+            " 'P2' 'OPEN' 'ORAT' 5*/ \n"
+            "/\n"
+            "MESSAGES\n"
+            "  1 2 /\n"
+            "DATES             -- 2\n"
+            " 15  OKT 2008 / \n"
+            "/\n"
+            "MESSAGES\n"
+            "  10 /\n"
+        ;
+
+    ParseContext parseContext;
+    auto deck = parser.parseString(input, parseContext);
+    EclipseGrid grid(10,10,10);
+    Schedule schedule(parseContext , grid, deck );
+    const MessageLimits limits = schedule.getMessageLimits();
+
+    BOOST_CHECK_EQUAL( limits.getBugPrintLimit( 0 ) , 77 );   // The pre Schedule initialization
+
+    BOOST_CHECK_EQUAL( limits.getMessagePrintLimit( 1 ) , 1 );
+    BOOST_CHECK_EQUAL( limits.getCommentPrintLimit( 1 ) , 2 );
+    BOOST_CHECK_EQUAL( limits.getBugPrintLimit( 1 ) , 77 );
+
+    BOOST_CHECK_EQUAL( limits.getMessagePrintLimit( 2 ) , 10 );
+    BOOST_CHECK_EQUAL( limits.getCommentPrintLimit( 2 ) , 2  );
+    BOOST_CHECK_EQUAL( limits.getBugPrintLimit( 2 ) , 77 );
+}
+


### PR DESCRIPTION
 1. Will retain already set values when only some items are set.
 2. Will parse the sections before the SCHEDULE section to create a
    correctly initialized MessageLimits object.