### PR TITLE
Make constructor explicit, fix operator<<.

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -66,7 +66,7 @@ namespace Opm {
             water_inverse_formation_volume_factor,
         };
 
-        UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);
+        explicit UnitSystem(UnitType unit = UnitType::UNIT_TYPE_METRIC);
 
         const std::string& getName() const;
         UnitType getType() const;

--- a/opm/parser/eclipse/Units/tests/UnitTests.cpp
+++ b/opm/parser/eclipse/Units/tests/UnitTests.cpp
@@ -174,7 +174,7 @@ BOOST_AUTO_TEST_CASE(DimensionEqual) {
 
 namespace Opm {
 inline std::ostream& operator<<( std::ostream& stream, const UnitSystem& us ) {
-    return stream << us.getName() << " :: " << us.getType();
+    return stream << us.getName() << " :: " << static_cast<int>(us.getType());
 }
 }
 


### PR DESCRIPTION
Currently on a warning-hunt to clean up the sources before the release. Encountered this:
```
/Users/atgeirr/opm-build-release/opm-parser/opm/parser/eclipse/Units/tests/UnitTests.cpp:176:79: warning: 
      all paths through this function will call itself [-Winfinite-recursion]
inline std::ostream& operator<<( std::ostream& stream, const UnitSystem& us ) {
                                                                              ^
```
This is not a false positive, although this operator has not been triggered since the tests succeed. The root cause is the lack of `explicit` making the UnitSystem constructor implicitly converting. After adding that, an explicit cast to int is also needed for the operator<<. (I assumed that is the behaviour sought.)