### PR TITLE
Always applying the BHP limit from WCONINJE.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -617,17 +617,15 @@ namespace Opm {
                     properties.dropInjectionControl(WellInjector::THP);
 
                 /*
-                  What a mess; there is a sensible default BHP limit
-                  defined, so the BHPLimit can be safely set
-                  unconditionally - but should we make BHP control
-                  available based on that default value - currently we
-                  do not do that.
+                  There is a sensible default BHP limit defined, so the BHPLimit can be
+                  safely set unconditionally, and we make BHP limit as a constraint based
+                  on that default value. It is not easy to infer from the manual, while the
+                  current behavoir agrees with the behovir of Eclipse when BHPLimit is not
+                  specified while employed during group control.
                 */
                 properties.BHPLimit = record.getItem("BHP").getSIDouble(0);
-                if (!record.getItem("BHP").defaultApplied(0)) {
-                    properties.addInjectionControl(WellInjector::BHP);
-                } else
-                    properties.dropInjectionControl(WellInjector::BHP);
+                // BHP control should always be there.
+                properties.addInjectionControl(WellInjector::BHP);
 
                 if (well->isAvailableForGroupControl(currentStep))
                     properties.addInjectionControl(WellInjector::GRUP);

--- a/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -244,13 +244,13 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
             const WellInjectionProperties& prop9 = well1->getInjectionProperties(9);
             BOOST_CHECK_CLOSE(20000/Metric::Time ,  prop9.surfaceInjectionRate  , 0.001);
             BOOST_CHECK_CLOSE(200000/Metric::Time , prop9.reservoirInjectionRate, 0.001);
-            BOOST_CHECK_CLOSE(6891 * Metric::Pressure , prop9.BHPLimit, 0.001);
+            BOOST_CHECK_CLOSE(6895 * Metric::Pressure , prop9.BHPLimit, 0.001);
             BOOST_CHECK_CLOSE(0 , prop9.THPLimit , 0.001);
             BOOST_CHECK_EQUAL( WellInjector::RESV  , prop9.controlMode);
             BOOST_CHECK(  prop9.hasInjectionControl(WellInjector::RATE ));
             BOOST_CHECK(  prop9.hasInjectionControl(WellInjector::RESV ));
             BOOST_CHECK( !prop9.hasInjectionControl(WellInjector::THP));
-            BOOST_CHECK( !prop9.hasInjectionControl(WellInjector::BHP));
+            BOOST_CHECK(  prop9.hasInjectionControl(WellInjector::BHP));
         }
 
 

--- a/opm/parser/share/keywords/000_Eclipse100/W/WCONINJE
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WCONINJE
@@ -5,7 +5,7 @@
     {"name" : "CMODE"        , "value_type" : "STRING" },
     {"name" : "RATE" , "value_type" : "DOUBLE" , "dimension" : "ContextDependent"},
     {"name" : "RESV" , "value_type" : "DOUBLE" , "dimension" : "ReservoirVolume/Time"},
-    {"name" : "BHP"  , "value_type" : "DOUBLE" , "dimension" : "Pressure" , "default" : 6891},
+    {"name" : "BHP"  , "value_type" : "DOUBLE" , "dimension" : "Pressure" , "default" : 6895},
     {"name" : "THP"  , "value_type" : "DOUBLE" , "dimension" : "Pressure"},
     {"name" : "VFP_TABLE" , "value_type" : "INT" , "default" : 0},
     {"name" : "VAPOIL_C" , "value_type" : "DOUBLE" , "default" : 0},

--- a/opm/parser/share/keywords/000_Eclipse100/W/WSEGITER
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WSEGITER
@@ -1,0 +1,6 @@
+     {"name" : "WSEGITER", "sections" : ["SCHEDULE"], "size" : 1, "items" : [
+         {"name" : "MAX_WELL_ITERATIONS"   , "value_type" : "INT"    , "default" : 20},
+         {"name" : "MAX_TIMES_REDUCED"     , "value_type" : "INT"    , "default" : 5},
+         {"name" : "REDUCTION_FACTOR"      , "value_type" : "DOUBLE" , "default" : 0.3},
+         {"name" : "INCREASING_FACTOR"     , "value_type" : "DOUBLE" , "default" : 2.0}
+     ]}

--- a/opm/parser/share/keywords/001_Eclipse300/G/GCONPROD
+++ b/opm/parser/share/keywords/001_Eclipse300/G/GCONPROD
@@ -14,6 +14,10 @@
         {"name" : "LIQUID_EXCEED_PROCEDURE" , "value_type" : "STRING"},
         {"name" : "RESERVOIR_FLUID_TARGET" , "value_type" : "DOUBLE", "dimension" : "ReservoirVolume/Time", "default" : -999e100},
         {"name" : "RESERVOIR_VOLUME_BALANCE" , "value_type" : "DOUBLE", "dimension" : "1"},
+        {"name" : "WET_GAS_TARGET" , "value_type" : "DOUBLE", "dimension" : "1"},
+        {"name" : "CALORIFIC_TARGET" , "value_type" : "DOUBLE", "dimension" : "1"},
+        {"name" : "SURFACE_GAS_BALANCE" , "value_type" : "DOUBLE", "dimension" : "1"},
+        {"name" : "SURFACE_WATER_BALANCE" , "value_type" : "DOUBLE", "dimension" : "1"},
         {"name" : "LINEAR_COMBINED_TARGET" , "value_type" : "DOUBLE", "dimension" : "1"},
         {"name" : "LIN_TARGET_EXCEED_PROCEDURE" , "value_type" : "STRING"}
 ]}


### PR DESCRIPTION
This is a PR looking for suggestion. 
In our model, we need to handle some statement like the following when using group control. 

```
WCONINJE
'INJE1' 'WATER' 'OPEN' 'GRUP' /
/
```

With the current implementation, basically, it gives no control for the well `INJE1` now. And the results from Eclipse strongly suggest that they use the defaulted BHP limit value ( `6803 atma, or 1.0E5 psia, or 6895 barsa`). That means the defaulted BHP limit always work there.

Please help to suggest if the current proposal works or we should do it in some different way. We got the desired result with this PR. 

BTW: I am not sure what unit system we should use when specify default value in the keyword definition. I saw previous value is 6891, I assume it was barsa there. Please correct me if I was wrong. 
