### PR TITLE
Support JFUNC in TableManager

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -331,7 +331,7 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
     return std::move( mnemonics );
 }
 
-void expand_RPTRST_mnemonics(std::map< std::string, int >& mnemonics) {
+inline void expand_RPTRST_mnemonics(std::map< std::string, int >& mnemonics) {
     const auto allprops = mnemonics.find( "ALLPROPS");
     if (allprops != mnemonics.end()) {
         const auto value = allprops->second;

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -28,7 +28,7 @@ namespace Opm {
     class SgfnTable : public SimpleTable {
 
     public:
-        SgfnTable( const DeckItem& item );
+        SgfnTable( const DeckItem& item, const bool jfunc );
 
         const TableColumn& getSgColumn() const;
         const TableColumn& getKrgColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgfnTable.hpp
@@ -33,6 +33,8 @@ namespace Opm {
         const TableColumn& getSgColumn() const;
         const TableColumn& getKrgColumn() const;
         const TableColumn& getPcogColumn() const;
+
+        const TableColumn& getJFuncColumn() const;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -27,7 +27,7 @@ namespace Opm {
     class SgofTable : public SimpleTable {
 
     public:
-        SgofTable( const DeckItem& item );
+        SgofTable( const DeckItem& item, const bool jfunc );
 
         const TableColumn& getSgColumn() const;
         const TableColumn& getKrgColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SgofTable.hpp
@@ -38,6 +38,8 @@ namespace Opm {
         // is inconsistent, but it is the one used in the Eclipse
         // manual...)
         const TableColumn& getPcogColumn() const;
+
+        const TableColumn& getJFuncColumn() const;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -26,15 +26,17 @@
 namespace Opm {
 
     SimpleTable::SimpleTable( TableSchema schema, const DeckItem& deckItem) :
-        m_schema( std::move( schema ) ) {
-
+        m_schema( std::move( schema ) ),
+        m_jfunc (false)
+    {
         init( deckItem );
     }
 
 
     SimpleTable::SimpleTable( TableSchema schema ) :
-        m_schema( std::move( schema ) ) {
-
+        m_schema( std::move( schema ) ),
+        m_jfunc (false)
+    {
         addColumns();
     }
 
@@ -70,7 +72,7 @@ namespace Opm {
         return col[row];
     }
 
-    void SimpleTable::init( const DeckItem& deckItem, const bool jfunc ) {
+    void SimpleTable::init( const DeckItem& deckItem ) {
         this->addColumns();
 
         if ( (deckItem.size() % numColumns()) != 0)
@@ -84,7 +86,7 @@ namespace Opm {
                 size_t deckItemIdx = rowIdx*numColumns() + colIdx;
                 if (deckItem.defaultApplied(deckItemIdx))
                     column.addDefault( );
-                else if (jfunc) {
+                else if (m_jfunc) {
                     column.addValue( deckItem.getData<double>()[deckItemIdx] );
                 }
                 else
@@ -134,4 +136,12 @@ size_t SimpleTable::numRows() const {
         return valueColumn.eval( index );
     }
 
+    void SimpleTable::assertJFuncPressure(const bool jf) const {
+        if (jf == m_jfunc)
+            return;
+        if (m_jfunc)
+            throw std::invalid_argument("Cannot get pressure column with JFUNC in deck");
+        else
+            throw std::invalid_argument("Cannot get JFUNC column when JFUNC not in deck");
+    }
 }

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -97,13 +97,13 @@ namespace Opm {
         }
     }
 
-size_t SimpleTable::numColumns() const {
-    return m_schema.size();
-}
+    size_t SimpleTable::numColumns() const {
+        return m_schema.size();
+    }
 
-size_t SimpleTable::numRows() const {
-    return getColumn( 0 ).size();
-}
+    size_t SimpleTable::numRows() const {
+        return getColumn( 0 ).size();
+    }
 
     const TableColumn& SimpleTable::getColumn( const std::string& name) const {
         return m_columns.get( name );

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.cpp
@@ -70,7 +70,7 @@ namespace Opm {
         return col[row];
     }
 
-    void SimpleTable::init( const DeckItem& deckItem ) {
+    void SimpleTable::init( const DeckItem& deckItem, const bool jfunc ) {
         this->addColumns();
 
         if ( (deckItem.size() % numColumns()) != 0)
@@ -84,6 +84,9 @@ namespace Opm {
                 size_t deckItemIdx = rowIdx*numColumns() + colIdx;
                 if (deckItem.defaultApplied(deckItemIdx))
                     column.addDefault( );
+                else if (jfunc) {
+                    column.addValue( deckItem.getData<double>()[deckItemIdx] );
+                }
                 else
                     column.addValue( deckItem.getSIDouble(deckItemIdx) );
             }

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         SimpleTable(TableSchema, const DeckItem& deckItem);
         explicit SimpleTable( TableSchema );
         void addColumns();
-        void init(const DeckItem& deckItem);
+        void init(const DeckItem& deckItem, const bool jfunc = false);
         size_t numColumns() const;
         size_t numRows() const;
         void addRow( const std::vector<double>& row);

--- a/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -39,7 +39,7 @@ namespace Opm {
         SimpleTable(TableSchema, const DeckItem& deckItem);
         explicit SimpleTable( TableSchema );
         void addColumns();
-        void init(const DeckItem& deckItem, const bool jfunc = false);
+        void init(const DeckItem& deckItem );
         size_t numColumns() const;
         size_t numRows() const;
         void addRow( const std::vector<double>& row);
@@ -60,11 +60,15 @@ namespace Opm {
          */
         double evaluate(const std::string& columnName, double xPos) const;
 
+        /// throws std::invalid_argument if jf != m_jfunc
+        void assertJFuncPressure(const bool jf) const;
+
     protected:
         std::map<std::string, size_t> m_columnNames;
         std::vector<std::vector<bool> > m_valueDefaulted;
         TableSchema m_schema;
         OrderedMap<TableColumn> m_columns;
+        bool m_jfunc = false;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -28,7 +28,7 @@ namespace Opm {
     class SlgofTable : public SimpleTable {
 
     public:
-        SlgofTable( const DeckItem& item );
+        SlgofTable( const DeckItem& item, const bool jfunc );
         const TableColumn& getSlColumn() const;
         const TableColumn& getKrgColumn() const;
         const TableColumn& getKrogColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SlgofTable.hpp
@@ -38,6 +38,8 @@ namespace Opm {
         // is inconsistent, but it is the one used in the Eclipse
         // manual...)
         const TableColumn& getPcogColumn() const;
+
+        const TableColumn& getJFuncColumn() const;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -30,9 +30,12 @@ namespace Opm {
         const TableColumn& getSwColumn() const;
         const TableColumn& getKrwColumn() const;
 
-        // this column is p_o - p_w (non-wetting phase pressure minus
-        // wetting phase pressure for a given water saturation)
+        /// this column is p_o - p_w (non-wetting phase pressure minus
+        /// wetting phase pressure for a given water saturation)
         const TableColumn& getPcowColumn() const;
+
+        /// use this function if JFUNC is set in the deck
+        const TableColumn& getJFuncColumn() const;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp
@@ -25,7 +25,7 @@ namespace Opm {
     class SwfnTable : public SimpleTable {
 
     public:
-        SwfnTable( const DeckItem& item );
+        SwfnTable( const DeckItem& item, const bool jfunc );
 
         const TableColumn& getSwColumn() const;
         const TableColumn& getKrwColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -35,6 +35,9 @@ namespace Opm {
         // this column is p_o - p_w (non-wetting phase pressure minus
         // wetting phase pressure for a given water saturation)
         const TableColumn& getPcowColumn() const;
+
+        /// use this function if JFUNC is set in the deck
+        const TableColumn& getJFuncColumn() const;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp
@@ -27,7 +27,7 @@ namespace Opm {
 
     class SwofTable : public SimpleTable {
     public:
-        SwofTable( const DeckItem& item );
+        SwofTable( const DeckItem& item, const bool jfunc );
         const TableColumn& getSwColumn() const;
         const TableColumn& getKrwColumn() const;
         const TableColumn& getKrowColumn() const;

--- a/opm/parser/eclipse/EclipseState/Tables/TableColumn.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableColumn.cpp
@@ -44,7 +44,9 @@ namespace Opm {
             throw std::invalid_argument("Incorrect ordering of values in column: " + m_schema.name());
     }
 
-
+    const std::string& TableColumn::name() const {
+        return m_name;
+    }
 
     void TableColumn::assertNext(size_t index , double value) const {
         size_t nextIndex = index + 1;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -232,9 +232,9 @@ namespace Opm {
             }
             addTables( "SORWMIS", numMiscibleTables);
             addTables( "SGCWMIS", numMiscibleTables);
-            addTables( "MISC", numMiscibleTables);
-            addTables( "PMISC", numMiscibleTables);
-            addTables( "TLPMIXPA", numMiscibleTables);
+            addTables( "MISC",    numMiscibleTables);
+            addTables( "PMISC",   numMiscibleTables);
+            addTables( "TLPMIXPA",numMiscibleTables);
         }
 
         {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -77,7 +77,8 @@ namespace Opm {
         :
         hasImptvd (deck.hasKeyword("IMPTVD")),
         hasEnptvd (deck.hasKeyword("ENPTVD")),
-        hasEqlnum (deck.hasKeyword("EQLNUM"))
+        hasEqlnum (deck.hasKeyword("EQLNUM")),
+        hasJFunc  (deck.hasKeyword("JFUNC"))
     {
         initPhases( deck );
         initDims( deck );
@@ -261,17 +262,20 @@ namespace Opm {
             addTables( "ROCKTAB", numRocktabTables);
         }
 
-        initSimpleTableContainer<SwofTable>(deck, "SWOF" , m_tabdims->getNumSatTables());
         initSimpleTableContainer<SgwfnTable>(deck, "SGWFN", m_tabdims->getNumSatTables());
-        initSimpleTableContainer<SgofTable>(deck, "SGOF" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<SlgofTable>(deck, "SLGOF" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<Sof2Table>(deck, "SOF2" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<Sof3Table>(deck, "SOF3" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<SwfnTable>(deck, "SWFN" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<SgfnTable>(deck, "SGFN" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<SsfnTable>(deck, "SSFN" , m_tabdims->getNumSatTables());
-        initSimpleTableContainer<MsfnTable>(deck, "MSFN" , m_tabdims->getNumSatTables());
+        initSimpleTableContainer<Sof2Table>(deck,  "SOF2",  m_tabdims->getNumSatTables());
+        initSimpleTableContainer<Sof3Table>(deck,  "SOF3",  m_tabdims->getNumSatTables());
 
+        { // JFUNC aware tables
+            initSimpleTableContainerWithJFunc<SwofTable>(deck, "SWOF", m_tabdims->getNumSatTables());
+            initSimpleTableContainerWithJFunc<SgofTable>(deck, "SGOF", m_tabdims->getNumSatTables());
+            initSimpleTableContainerWithJFunc<SwfnTable>(deck, "SWFN", m_tabdims->getNumSatTables());
+            initSimpleTableContainerWithJFunc<SgfnTable>(deck, "SGFN", m_tabdims->getNumSatTables());
+            initSimpleTableContainerWithJFunc<SlgofTable>(deck, "SLGOF", m_tabdims->getNumSatTables());
+        }
+
+        initSimpleTableContainer<SsfnTable>(deck, "SSFN", m_tabdims->getNumSatTables());
+        initSimpleTableContainer<MsfnTable>(deck, "MSFN", m_tabdims->getNumSatTables());
 
         initSimpleTableContainer<RsvdTable>(deck, "RSVD" , m_eqldims->getNumEquilRegions());
         initSimpleTableContainer<RvvdTable>(deck, "RVVD" , m_eqldims->getNumEquilRegions());
@@ -706,6 +710,9 @@ namespace Opm {
         return hasEqlnum;
     }
 
+    bool TableManager::useJFunc() const {
+        return hasJFunc;
+    }
 
     const MessageContainer& TableManager::getMessageContainer() const {
         return m_messages;

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -118,6 +118,9 @@ namespace Opm {
         /// deck has keyword "EQLNUM" --- Equilibriation region numbers
         bool useEqlnum() const;
 
+        /// deck has keyword "JFUNC" --- Use Leverett's J Function for capillary pressure
+        bool useJFunc() const;
+
         const MessageContainer& getMessageContainer() const;
         MessageContainer& getMessageContainer();
 
@@ -144,6 +147,39 @@ namespace Opm {
         void initPlymaxTables(const Deck& deck);
         void initPlyrockTables(const Deck& deck);
         void initPlyshlogTables(const Deck& deck);
+
+
+
+
+        /**
+         * JFUNC
+         */
+        template <class TableType>
+        void initSimpleTableContainerWithJFunc(const Deck& deck,
+                                      const std::string& keywordName,
+                                      const std::string& tableName,
+                                      size_t numTables) {
+            if (!deck.hasKeyword(keywordName))
+                return; // the table is not featured by the deck...
+
+            auto& container = forceGetTables(tableName , numTables);
+
+            if (deck.count(keywordName) > 1) {
+                complainAboutAmbiguousKeyword(deck, keywordName);
+                return;
+            }
+
+            const auto& tableKeyword = deck.getKeyword(keywordName);
+            for (size_t tableIdx = 0; tableIdx < tableKeyword.size(); ++tableIdx) {
+                const auto& dataItem = tableKeyword.getRecord( tableIdx ).getItem( 0 );
+                if (dataItem.size() > 0) {
+                    std::shared_ptr<TableType> table = std::make_shared<TableType>( dataItem, useJFunc() );
+                    container.addTable( tableIdx , table );
+                }
+            }
+        }
+
+
 
         template <class TableType>
         void initSimpleTableContainer(const Deck& deck,
@@ -176,6 +212,15 @@ namespace Opm {
                                       size_t numTables) {
             initSimpleTableContainer<TableType>(deck , keywordName , keywordName , numTables);
         }
+
+
+        template <class TableType>
+        void initSimpleTableContainerWithJFunc(const Deck& deck,
+                                      const std::string& keywordName,
+                                      size_t numTables) {
+            initSimpleTableContainerWithJFunc<TableType>(deck , keywordName , keywordName , numTables);
+        }
+
 
 
         template <class TableType>
@@ -245,6 +290,7 @@ namespace Opm {
         const bool hasImptvd;// if deck has keyword IMPTVD
         const bool hasEnptvd;// if deck has keyword ENPTVD
         const bool hasEqlnum;// if deck has keyword EQLNUM
+        const bool hasJFunc; // if deck has keyword JFUNC
 
         MessageContainer m_messages;
     };

--- a/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -99,14 +99,14 @@ PvtoTable::PvtoTable( const DeckKeyword& keyword, size_t tableIdx) :
         PvtxTable::init(keyword , tableIdx);
     }
 
-SwofTable::SwofTable( const DeckItem& item ) {
+SwofTable::SwofTable( const DeckItem& item , const bool jfunc) {
 
     m_schema.addColumn( ColumnSchema( "SW"   , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE) );
     m_schema.addColumn( ColumnSchema( "KRW"  , Table::RANDOM              , Table::DEFAULT_LINEAR) );
     m_schema.addColumn( ColumnSchema( "KROW" , Table::RANDOM              , Table::DEFAULT_LINEAR) );
     m_schema.addColumn( ColumnSchema( "PCOW" , Table::RANDOM              , Table::DEFAULT_LINEAR) );
 
-    SimpleTable::init( item );
+    SimpleTable::init( item,  jfunc );
 }
 
 const TableColumn& SwofTable::getSwColumn() const {
@@ -151,13 +151,13 @@ const TableColumn& SgwfnTable::getPcgwColumn() const {
     return SimpleTable::getColumn(3); 
 }
 
-SgofTable::SgofTable( const DeckItem& item ) {
+SgofTable::SgofTable( const DeckItem& item , const bool jfunc) {
     m_schema.addColumn( ColumnSchema("SG"   , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE));
     m_schema.addColumn( ColumnSchema("KRG"  , Table::RANDOM              , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("KROG" , Table::RANDOM              , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("PCOG" , Table::RANDOM              , Table::DEFAULT_LINEAR ));
 
-    SimpleTable::init( item );
+    SimpleTable::init( item, jfunc );
 }
 
 const TableColumn& SgofTable::getSgColumn() const {
@@ -177,13 +177,13 @@ const TableColumn& SgofTable::getPcogColumn() const {
 
 }
 
-SlgofTable::SlgofTable( const DeckItem& item ) {
+SlgofTable::SlgofTable( const DeckItem& item, const bool jfunc ) {
     m_schema.addColumn( ColumnSchema("SL"   , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ));
     m_schema.addColumn( ColumnSchema("KRG"  , Table::DECREASING , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("KROG" , Table::INCREASING , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("PCOG" , Table::DECREASING , Table::DEFAULT_LINEAR ));
 
-    SimpleTable::init( item );
+    SimpleTable::init( item ,  jfunc);
 
     if (getSlColumn().back() != 1.0) {
         throw std::invalid_argument("The last saturation of the SLGOF keyword must be 1!");
@@ -285,12 +285,12 @@ const TableColumn& PvdoTable::getViscosityColumn() const {
     return SimpleTable::getColumn(2);
 }
 
-SwfnTable::SwfnTable( const DeckItem& item ) {
+SwfnTable::SwfnTable( const DeckItem& item, const bool jfunc ) {
     m_schema.addColumn( ColumnSchema("SW"   , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ));
     m_schema.addColumn( ColumnSchema("KRW"  , Table::INCREASING , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("PCOW" , Table::DECREASING , Table::DEFAULT_LINEAR ));
 
-    SimpleTable::init(item);
+    SimpleTable::init(item, jfunc);
 }
 
 const TableColumn& SwfnTable::getSwColumn() const {
@@ -305,12 +305,12 @@ const TableColumn& SwfnTable::getPcowColumn() const {
     return SimpleTable::getColumn(2);
 }
 
-SgfnTable::SgfnTable( const DeckItem& item ) {
+SgfnTable::SgfnTable( const DeckItem& item, const bool jfunc ) {
     m_schema.addColumn( ColumnSchema("SG"  , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ) );
     m_schema.addColumn( ColumnSchema("KRG" , Table::INCREASING , Table::DEFAULT_LINEAR));
     m_schema.addColumn( ColumnSchema("PCOG" , Table::INCREASING , Table::DEFAULT_LINEAR));
 
-    SimpleTable::init(item);
+    SimpleTable::init(item, jfunc);
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -106,7 +106,8 @@ SwofTable::SwofTable( const DeckItem& item , const bool jfunc) {
     m_schema.addColumn( ColumnSchema( "KROW" , Table::RANDOM              , Table::DEFAULT_LINEAR) );
     m_schema.addColumn( ColumnSchema( "PCOW" , Table::RANDOM              , Table::DEFAULT_LINEAR) );
 
-    SimpleTable::init( item,  jfunc );
+    m_jfunc = jfunc;
+    SimpleTable::init( item );
 }
 
 const TableColumn& SwofTable::getSwColumn() const {
@@ -122,6 +123,12 @@ const TableColumn& SwofTable::getKrowColumn() const {
 }
 
 const TableColumn& SwofTable::getPcowColumn() const {
+    SimpleTable::assertJFuncPressure(false);
+    return SimpleTable::getColumn(3);
+}
+
+const TableColumn& SwofTable::getJFuncColumn() const {
+    SimpleTable::assertJFuncPressure(true);
     return SimpleTable::getColumn(3);
 }
 
@@ -157,7 +164,8 @@ SgofTable::SgofTable( const DeckItem& item , const bool jfunc) {
     m_schema.addColumn( ColumnSchema("KROG" , Table::RANDOM              , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("PCOG" , Table::RANDOM              , Table::DEFAULT_LINEAR ));
 
-    SimpleTable::init( item, jfunc );
+    m_jfunc = jfunc;
+    SimpleTable::init( item );
 }
 
 const TableColumn& SgofTable::getSgColumn() const {
@@ -173,8 +181,13 @@ const TableColumn& SgofTable::getKrogColumn() const {
 }
 
 const TableColumn& SgofTable::getPcogColumn() const {
+    SimpleTable::assertJFuncPressure(false);
     return SimpleTable::getColumn(3);
+}
 
+const TableColumn& SgofTable::getJFuncColumn() const {
+    SimpleTable::assertJFuncPressure(true);
+    return SimpleTable::getColumn(3);
 }
 
 SlgofTable::SlgofTable( const DeckItem& item, const bool jfunc ) {
@@ -183,7 +196,8 @@ SlgofTable::SlgofTable( const DeckItem& item, const bool jfunc ) {
     m_schema.addColumn( ColumnSchema("KROG" , Table::INCREASING , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("PCOG" , Table::DECREASING , Table::DEFAULT_LINEAR ));
 
-    SimpleTable::init( item ,  jfunc);
+    m_jfunc = jfunc;
+    SimpleTable::init( item );
 
     if (getSlColumn().back() != 1.0) {
         throw std::invalid_argument("The last saturation of the SLGOF keyword must be 1!");
@@ -203,6 +217,12 @@ const TableColumn& SlgofTable::getKrogColumn() const {
 }
 
 const TableColumn& SlgofTable::getPcogColumn() const {
+    SimpleTable::assertJFuncPressure(false);
+    return SimpleTable::getColumn(3);
+}
+
+const TableColumn& SlgofTable::getJFuncColumn() const {
+    SimpleTable::assertJFuncPressure(true);
     return SimpleTable::getColumn(3);
 }
 
@@ -290,7 +310,8 @@ SwfnTable::SwfnTable( const DeckItem& item, const bool jfunc ) {
     m_schema.addColumn( ColumnSchema("KRW"  , Table::INCREASING , Table::DEFAULT_LINEAR ));
     m_schema.addColumn( ColumnSchema("PCOW" , Table::DECREASING , Table::DEFAULT_LINEAR ));
 
-    SimpleTable::init(item, jfunc);
+    m_jfunc = jfunc;
+    SimpleTable::init( item );
 }
 
 const TableColumn& SwfnTable::getSwColumn() const {
@@ -302,15 +323,23 @@ const TableColumn& SwfnTable::getKrwColumn() const {
 }
 
 const TableColumn& SwfnTable::getPcowColumn() const {
+    SimpleTable::assertJFuncPressure(false);
     return SimpleTable::getColumn(2);
 }
+
+const TableColumn& SwfnTable::getJFuncColumn() const {
+    SimpleTable::assertJFuncPressure(true);
+    return SimpleTable::getColumn(2);
+}
+
 
 SgfnTable::SgfnTable( const DeckItem& item, const bool jfunc ) {
     m_schema.addColumn( ColumnSchema("SG"  , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ) );
     m_schema.addColumn( ColumnSchema("KRG" , Table::INCREASING , Table::DEFAULT_LINEAR));
     m_schema.addColumn( ColumnSchema("PCOG" , Table::INCREASING , Table::DEFAULT_LINEAR));
 
-    SimpleTable::init(item, jfunc);
+    m_jfunc = jfunc;
+    SimpleTable::init( item );
 }
 
 
@@ -323,6 +352,12 @@ const TableColumn& SgfnTable::getKrgColumn() const {
 }
 
 const TableColumn& SgfnTable::getPcogColumn() const {
+    SimpleTable::assertJFuncPressure(false);
+    return SimpleTable::getColumn(2);
+}
+
+const TableColumn& SgfnTable::getJFuncColumn() const {
+    SimpleTable::assertJFuncPressure(true);
     return SimpleTable::getColumn(2);
 }
 

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableContainerTests.cpp
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE( CreateContainer ) {
     BOOST_CHECK_EQUAL( 0 , container.size() );
     BOOST_CHECK_EQUAL( false , container.hasTable( 1 ));
 
-    std::shared_ptr<Opm::SimpleTable> table = std::make_shared<Opm::SwofTable>( deck.getKeyword("SWOF").getRecord(0).getItem(0) );
+    std::shared_ptr<Opm::SimpleTable> table = std::make_shared<Opm::SwofTable>( deck.getKeyword("SWOF").getRecord(0).getItem(0), false );
     BOOST_CHECK_THROW( container.addTable( 10 , table ), std::invalid_argument );
     container.addTable( 6 , table );
     BOOST_CHECK_EQUAL( 1 , container.size() );

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -90,6 +90,35 @@ Opm::Deck createSingleRecordDeckWithVd() {
     return parser.parseString(deckData, Opm::ParseContext());
 }
 
+Opm::Deck createSingleRecordDeckWithJFunc() {
+    const char *deckData =
+        "RUNSPEC\n"
+        "ENDSCALE\n"
+        "2* 1 2 /\n"
+        "PROPS\n"
+        "JFUNC\n"
+        "  WATER 22.0 /\n"
+        "TABDIMS\n"
+        " 2 /\n"
+        "\n"
+        "SWFN\n"
+        "0.22 .0   7.0 \n"
+        "0.3  .0   4.0 \n"
+        "0.5  .24  2.5 \n"
+        "0.8  .65  1.0 \n"
+        "0.9  .83  .5  \n"
+        "1.0  1.00 .0 /\n"
+        "/\n"
+        "IMPTVD\n"
+        "3000.0 6*0.1 0.31 1*0.1\n"
+        "9000.0 6*0.1 0.32 1*0.1/\n"
+        "ENPTVD\n"
+        "3000.0 0.20 0.20 1.0 0.0 0.04 1.0 0.18 0.22\n"
+        "9000.0 0.22 0.22 1.0 0.0 0.04 1.0 0.18 0.22 /";
+
+    Opm::Parser parser;
+    return parser.parseString(deckData, Opm::ParseContext());
+}
 }
 
 BOOST_AUTO_TEST_CASE( CreateTables ) {
@@ -105,12 +134,59 @@ BOOST_AUTO_TEST_CASE( CreateTablesWithVd ) {
     auto deck = createSingleRecordDeckWithVd();
     Opm::TableManager tables(deck);
     auto tabdims = tables.getTabdims();
-    BOOST_CHECK_EQUAL( tabdims->getNumSatTables() , 2 );
-    BOOST_CHECK( tables.useImptvd() );
-    BOOST_CHECK( tables.useEnptvd() );
+    BOOST_CHECK_EQUAL(tabdims->getNumSatTables(), 2);
+    BOOST_CHECK(tables.useImptvd());
+    BOOST_CHECK(tables.useEnptvd());
+
+    const auto swfnTab = tables.getSwfnTables();
+
+    const float swfnData[] =
+        {0.22, 0.00, 700000, 0.3, 0.00, 400000, 0.5, 0.24, 250000,
+         0.80, 0.65, 100000, 0.9, 0.83,  50000, 1.0, 1.00,      0};
+
+
+    for (size_t t_idx = 0; t_idx < swfnTab.size(); t_idx++) {
+        const auto tab = swfnTab.getTable(t_idx);
+        for (size_t c_idx = 0; c_idx < tab.numColumns(); c_idx++) {
+            const auto col = tab.getColumn(c_idx);
+            for (size_t i = 0; i < col.size(); i++) {
+                int idx = c_idx + i*3;
+                BOOST_CHECK_CLOSE( col[i], swfnData[idx], 0.00001 );
+            }
+        }
+    }
+
+    BOOST_CHECK( ! tables.useJFunc() );
 }
 
+BOOST_AUTO_TEST_CASE( CreateTablesWithJFunc ) {
+    auto deck = createSingleRecordDeckWithJFunc();
+    Opm::TableManager tables(deck);
+    auto tabdims = tables.getTabdims();
+    BOOST_CHECK_EQUAL(tabdims->getNumSatTables(), 2);
+    BOOST_CHECK(tables.useImptvd());
+    BOOST_CHECK(tables.useEnptvd());
 
+    const auto swfnTab = tables.getSwfnTables();
+
+    const float swfnDataVerbatim[] =
+        {0.22, 0.00, 7.00, 0.30, 0.00, 4.00, 0.50, 0.24, 2.50,
+         0.80, 0.65, 1.00, 0.90, 0.83, 0.50, 1.00, 1.00, 0.00};
+
+
+    for (size_t tab = 0; tab < swfnTab.size(); tab++) {
+        const auto t = swfnTab.getTable(tab);
+        for (size_t c_idx = 0; c_idx < t.numColumns(); c_idx++) {
+            const auto col = t.getColumn(c_idx);
+            for (size_t i = 0; i < col.size(); i++) {
+                int idx = c_idx + i*3;
+                BOOST_CHECK_CLOSE( col[i], swfnDataVerbatim[idx], 0.00001 );
+            }
+        }
+    }
+
+    BOOST_CHECK( tables.useJFunc() );
+}
 /*****************************************************************/
 
 
@@ -130,8 +206,8 @@ BOOST_AUTO_TEST_CASE(SwofTable_Tests) {
     Opm::Parser parser;
     auto deck = parser.parseString(deckData, Opm::ParseContext());
 
-    Opm::SwofTable swof1Table(deck.getKeyword("SWOF").getRecord(0).getItem(0));
-    Opm::SwofTable swof2Table(deck.getKeyword("SWOF").getRecord(1).getItem(0));
+    Opm::SwofTable swof1Table(deck.getKeyword("SWOF").getRecord(0).getItem(0), deck.hasKeyword("JFUNC"));
+    Opm::SwofTable swof2Table(deck.getKeyword("SWOF").getRecord(1).getItem(0), deck.hasKeyword("JFUNC"));
 
     BOOST_CHECK_EQUAL(swof1Table.numRows(), 2);
     BOOST_CHECK_EQUAL(swof2Table.numRows(), 3);
@@ -216,8 +292,8 @@ BOOST_AUTO_TEST_CASE(SgofTable_Tests) {
     Opm::Parser parser;
     auto deck = parser.parseString(deckData, Opm::ParseContext());
 
-    Opm::SgofTable sgof1Table(deck.getKeyword("SGOF").getRecord(0).getItem(0));
-    Opm::SgofTable sgof2Table(deck.getKeyword("SGOF").getRecord(1).getItem(0));
+    Opm::SgofTable sgof1Table(deck.getKeyword("SGOF").getRecord(0).getItem(0), deck.hasKeyword("JFUNC"));
+    Opm::SgofTable sgof2Table(deck.getKeyword("SGOF").getRecord(1).getItem(0), deck.hasKeyword("JFUNC"));
 
     BOOST_CHECK_EQUAL(sgof1Table.numRows(), 2);
     BOOST_CHECK_EQUAL(sgof2Table.numRows(), 3);

--- a/opm/parser/eclipse/IntegrationTests/ParseSGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSGOF.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE( parse_SGOF_OK ) {
     const auto& item0 = record0.getItem(0);
     BOOST_CHECK_EQUAL(10U * 4, item0.size());
 
-    Opm::SgofTable sgofTable(deck.getKeyword("SGOF").getRecord(0).getItem(0));
+    Opm::SgofTable sgofTable(deck.getKeyword("SGOF").getRecord(0).getItem(0), false);
     BOOST_CHECK_EQUAL(10U, sgofTable.getSgColumn().size());
     BOOST_CHECK_EQUAL(0.1, sgofTable.getSgColumn()[0]);
     BOOST_CHECK_EQUAL(0.0, sgofTable.getKrgColumn()[0]);

--- a/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSLGOF.cpp
@@ -61,7 +61,7 @@ BOOST_AUTO_TEST_CASE( parse_SLGOF_OK ) {
     BOOST_CHECK_EQUAL(1U , record0.size());
     BOOST_CHECK_EQUAL(10U * 4, item0.size());
 
-    Opm::SlgofTable slgofTable( deck.getKeyword("SLGOF").getRecord(0).getItem(0) );
+    Opm::SlgofTable slgofTable( deck.getKeyword("SLGOF").getRecord(0).getItem(0), false );
     BOOST_CHECK_EQUAL(10U, slgofTable.getSlColumn().size());
     BOOST_CHECK_EQUAL(0.1, slgofTable.getSlColumn()[0]);
     BOOST_CHECK_EQUAL(1.0, slgofTable.getSlColumn()[9]);

--- a/opm/parser/eclipse/IntegrationTests/ParseSWOF.cpp
+++ b/opm/parser/eclipse/IntegrationTests/ParseSWOF.cpp
@@ -63,7 +63,7 @@ BOOST_AUTO_TEST_CASE( parse_SWOF_OK ) {
     BOOST_CHECK_EQUAL(1U , record0.size());
     BOOST_CHECK_EQUAL(10U * 4, item0.size());
 
-    Opm::SwofTable swofTable(deck.getKeyword("SWOF").getRecord(0).getItem(0));
+    Opm::SwofTable swofTable(deck.getKeyword("SWOF").getRecord(0).getItem(0), false);
     BOOST_CHECK_EQUAL(10U, swofTable.getSwColumn().size());
     BOOST_CHECK_CLOSE(0.1, swofTable.getSwColumn()[0], 1e-8);
     BOOST_CHECK_CLOSE(1.0, swofTable.getSwColumn().back(), 1e-8);


### PR DESCRIPTION
With this PR,

* the `JFUNC` keyword is internalized in `TableManager` by the function `.useJFunc()`
* the tables that should respect `JFUNC` will not be SI converted when tables are constructed:
 * `SWFN`, `SGFN`, `SWOF`, `SGOF`, `SLGOF`

Notice that the last of the three commits only contain general maintenance.