### PR TITLE
[Discussion] only using WHISTCTL for non-prediction mode.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -447,15 +447,17 @@ namespace Opm {
                 }
 
                 if (status != WellCommon::SHUT) {
-                    const std::string& cmodeString =
+                        std::string cmodeString =
                         record.getItem("CMODE").getTrimmedString(0);
 
                     WellProducer::ControlModeEnum control =
                         WellProducer::ControlModeFromString(cmodeString);
 
+
                     if ( m_controlModeWHISTCTL != WellProducer::CMODE_UNDEFINED &&
-                         m_controlModeWHISTCTL != WellProducer::NONE) {
+                         m_controlModeWHISTCTL != WellProducer::NONE && !isPredictionMode){
                         control = m_controlModeWHISTCTL; // overwrite given control
+                        cmodeString = WellProducer::ControlMode2String(control); // update the string
                     }
 
                     if (properties.hasProductionControl(control)) {


### PR DESCRIPTION
I think WHISTCTL should only apply to the history matching wells, not apply to keywords like WCONPROD. 

Any comments? It throws an exception for one model due to the change of mode from WHISTCTL. 