### PR TITLE
Ignore SKIPREST

### DIFF
--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -40,8 +40,6 @@ namespace Opm {
         const Equil& getEquil() const;
 
     private:
-        void initRestartKW(const Deck& deck);
-
         bool m_restartRequested = false;
         int m_restartStep = 0;
         std::string m_restartRootName;


### PR DESCRIPTION
The SKIPREST keyword is really only needed in eclipse - since we parse
through the entire deck and create a complete internal representation
with random access, we don't need to actually skip parts of the input.

The old behaviour was to mimic some possible failure modes for eclipse,
however this has caused issues for no real benefit.

refs:
* https://github.com/OPM/opm-parser/issues/773
* https://github.com/OPM/opm-parser/issues/960