### PR TITLE
Remove shared ptr members well

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp
@@ -153,7 +153,7 @@ namespace Opm {
 
         /// Will return the index of the first occurence of @value, or
         /// -1 if @value is not found.
-        ssize_t find(const T& value) {
+        ssize_t find(const T& value) const {
             auto iter = std::find( m_data.begin() , m_data.end() , value);
             if (iter != m_data.end()) {
                 // Found normally

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1382,7 +1382,7 @@ namespace Opm {
             automaticShutIn = false;
         }
 
-        auto well = std::make_shared<Well>(wellName, headI, headJ, refDepth, preferredPhase, m_timeMap , timeStep,
+        auto well = std::make_shared<Well>(wellName, headI, headJ, refDepth, preferredPhase, *m_timeMap , timeStep,
                                            wellCompletionOrder, allowCrossFlow, automaticShutIn);
         m_wells.insert( wellName  , well);
         m_events.addEvent( ScheduleEvents::NEW_WELL , timeStep );

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -24,6 +24,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MSW/SegmentSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/Value.hpp>
 
@@ -54,7 +55,6 @@ namespace Opm {
           m_groupName( timeMap, "" ),
           m_rft( timeMap, false ),
           m_plt( timeMap, false ),
-          m_timeMap( timeMap ),
           m_headI(headI),
           m_headJ(headJ),
           m_refDepth(refDepth),
@@ -62,7 +62,8 @@ namespace Opm {
           m_comporder(completionOrdering),
           m_allowCrossFlow(allowCrossFlow),
           m_automaticShutIn(automaticShutIn),
-          m_segmentset( timeMap, SegmentSet{} )
+          m_segmentset( timeMap, SegmentSet{} ),
+          timesteps( timeMap.numTimesteps() )
     {}
 
     const std::string& Well::name() const {
@@ -273,7 +274,7 @@ namespace Opm {
                 break;
             } else {
                 timeStep++;
-                if (timeStep >= m_timeMap.size())
+                if( timeStep > this->timesteps )
                     throw std::invalid_argument("No completions defined for well: " + name() + " can not infer reference depth");
             }
         }
@@ -359,8 +360,7 @@ namespace Opm {
 
 
     int Well::findWellFirstOpen(int startTimeStep) const{
-        int numberOfTimeSteps = m_timeMap.numTimesteps();
-        for(int i = startTimeStep; i < numberOfTimeSteps;i++){
+        for( size_t i = startTimeStep; i < this->timesteps ;i++){
             if(getStatus(i)==WellCommon::StatusEnum::OPEN){
                 return i;
             }

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -26,10 +26,14 @@
 #include <vector>
 
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellEconProductionLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/MSW/SegmentSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/Value.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 
@@ -47,7 +51,7 @@ namespace Opm {
     public:
         Well(const std::string& name, int headI,
              int headJ, Value<double> refDepth , Phase preferredPhase,
-             std::shared_ptr< const TimeMap > timeMap, size_t creationTimeStep,
+             const TimeMap& timeMap, size_t creationTimeStep,
              WellCompletion::CompletionOrderEnum completionOrdering = WellCompletion::TRACK,
              bool allowCrossFlow = true, bool automaticShutIn = true);
         const std::string& name() const;
@@ -143,27 +147,27 @@ namespace Opm {
         size_t m_creationTimeStep;
         std::string m_name;
 
-        std::shared_ptr<DynamicState<WellCommon::StatusEnum> > m_status;
+        DynamicState< WellCommon::StatusEnum > m_status;
 
-        std::shared_ptr<DynamicState<int> > m_isAvailableForGroupControl;
-        std::shared_ptr<DynamicState<double> > m_guideRate;
-        std::shared_ptr<DynamicState<GuideRate::GuideRatePhaseEnum> > m_guideRatePhase;
-        std::shared_ptr<DynamicState<double> > m_guideRateScalingFactor;
+        DynamicState< int > m_isAvailableForGroupControl;
+        DynamicState< double > m_guideRate;
+        DynamicState< GuideRate::GuideRatePhaseEnum > m_guideRatePhase;
+        DynamicState< double > m_guideRateScalingFactor;
 
-        std::shared_ptr<DynamicState<int> > m_isProducer;
-        std::shared_ptr<DynamicState<std::shared_ptr< const CompletionSet >> > m_completions;
-        std::shared_ptr<DynamicState<WellProductionProperties> > m_productionProperties;
-        std::shared_ptr<DynamicState<WellInjectionProperties> > m_injectionProperties;
-        std::shared_ptr<DynamicState<WellPolymerProperties> > m_polymerProperties;
-        std::shared_ptr<DynamicState<WellEconProductionLimits> > m_econproductionlimits;
-        std::shared_ptr<DynamicState<double> > m_solventFraction;
-        std::shared_ptr<DynamicState<std::string> > m_groupName;
-        std::shared_ptr<DynamicState<int> > m_rft;
-        std::shared_ptr<DynamicState<int> > m_plt;
+        DynamicState< int > m_isProducer;
+        DynamicState< CompletionSet > m_completions;
+        DynamicState< WellProductionProperties > m_productionProperties;
+        DynamicState< WellInjectionProperties > m_injectionProperties;
+        DynamicState< WellPolymerProperties > m_polymerProperties;
+        DynamicState< WellEconProductionLimits > m_econproductionlimits;
+        DynamicState< double > m_solventFraction;
+        DynamicState< std::string > m_groupName;
+        DynamicState< int > m_rft;
+        DynamicState< int > m_plt;
 
         // WELSPECS data - assumes this is not dynamic
 
-        std::shared_ptr< const TimeMap > m_timeMap;
+        TimeMap m_timeMap;
         int m_headI;
         int m_headJ;
         mutable Value<double> m_refDepth;
@@ -175,7 +179,7 @@ namespace Opm {
         MessageContainer m_messages;
         // WELSEGS DATA - for mutli-segment wells
         // flag indicating if the well is a multi-segment well
-        std::shared_ptr<DynamicState< SegmentSet >> m_segmentset;
+        DynamicState< SegmentSet > m_segmentset;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -28,7 +28,6 @@
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/DynamicState.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellEconProductionLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/WellPolymerProperties.hpp>
@@ -167,7 +166,6 @@ namespace Opm {
 
         // WELSPECS data - assumes this is not dynamic
 
-        TimeMap m_timeMap;
         int m_headI;
         int m_headJ;
         mutable Value<double> m_refDepth;
@@ -180,6 +178,7 @@ namespace Opm {
         // WELSEGS DATA - for mutli-segment wells
         // flag indicating if the well is a multi-segment well
         DynamicState< SegmentSet > m_segmentset;
+        size_t timesteps;
     };
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -157,8 +157,8 @@ BOOST_AUTO_TEST_CASE(GroupDoesNotHaveWell) {
 
 BOOST_AUTO_TEST_CASE(GroupAddWell) {
 
-    auto timeMap = std::make_shared< Opm::TimeMap >( createXDaysTimeMap( 10 ) );
-    Opm::Group group("G1" , *timeMap , 0);
+    auto timeMap = createXDaysTimeMap( 10 );
+    Opm::Group group("G1" , timeMap , 0);
     auto well1 = std::make_shared< Well >("WELL1", 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
     auto well2 = std::make_shared< Well >("WELL2", 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 
@@ -194,8 +194,8 @@ BOOST_AUTO_TEST_CASE(GroupAddWell) {
 
 BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
 
-    auto timeMap = std::make_shared< Opm::TimeMap >( createXDaysTimeMap( 10 ) );
-    Opm::Group group("G1" , *timeMap , 0);
+    auto timeMap = createXDaysTimeMap( 10 );
+    Opm::Group group("G1" , timeMap , 0);
     auto well1 = std::make_shared< Well >("WELL1", 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
     auto well2 = std::make_shared< Well >("WELL2", 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 
@@ -230,8 +230,8 @@ BOOST_AUTO_TEST_CASE(GroupAddAndDelWell) {
 }
 
 BOOST_AUTO_TEST_CASE(getWells) {
-    auto timeMap = std::make_shared< Opm::TimeMap >( createXDaysTimeMap( 10 ) );
-    Opm::Group group("G1" , *timeMap , 0);
+    auto timeMap = createXDaysTimeMap( 10 );
+    Opm::Group group("G1" , timeMap , 0);
     auto well1 = std::make_shared< Well >("WELL1", 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
     auto well2 = std::make_shared< Well >("WELL2", 0, 0, Opm::Value<double>("REF_DEPTH"), Opm::Phase::OIL, timeMap, 0);
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellSetTests.cpp
@@ -31,11 +31,11 @@
 
 using namespace Opm;
 
-static std::shared_ptr< Opm::TimeMap > createXDaysTimeMap(size_t numDays) {
+static TimeMap createXDaysTimeMap(size_t numDays) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
-    auto timeMap = std::make_shared< Opm::TimeMap >(boost::posix_time::ptime(startDate));
+    TimeMap timeMap{ boost::posix_time::ptime(startDate) };
     for (size_t i = 0; i < numDays; i++)
-        timeMap->addTStep( boost::posix_time::hours( (i+1) * 24 ));
+        timeMap.addTStep( boost::posix_time::hours( (i+1) * 24 ));
     return timeMap;
 }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -41,11 +41,11 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
-static std::shared_ptr< Opm::TimeMap > createXDaysTimeMap(size_t numDays) {
+static Opm::TimeMap createXDaysTimeMap(size_t numDays) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
-    auto timeMap = std::make_shared< Opm::TimeMap >(boost::posix_time::ptime(startDate));
+    Opm::TimeMap timeMap{ boost::posix_time::ptime(startDate ) };
     for (size_t i = 0; i < numDays; i++)
-        timeMap->addTStep( boost::posix_time::hours( (i+1) * 24 ));
+        timeMap.addTStep( boost::posix_time::hours( (i+1) * 24 ));
     return timeMap;
 }
 


### PR DESCRIPTION
Simply flatten the Well class by removing all internal shared_ptrs. PR also includes the following minor changes:

* A bugfix in DynamicState, making the `find` method const
* TimeMap is not a member in `Well` as only its size was used, which is what we're now storing.