### PR TITLE
DeckItem.push_back overload for size = 1

### DIFF
--- a/opm/parser/eclipse/Deck/DeckItem.cpp
+++ b/opm/parser/eclipse/Deck/DeckItem.cpp
@@ -120,6 +120,26 @@ const std::vector< T >& DeckItem::getData() const {
 }
 
 template< typename T >
+void DeckItem::push( T x ) {
+    auto& val = this->value_ref< T >();
+
+    val.push_back( std::move( x ) );
+    this->defaulted.push_back( false );
+}
+
+void DeckItem::push_back( int x ) {
+    this->push( x );
+}
+
+void DeckItem::push_back( double x ) {
+    this->push( x );
+}
+
+void DeckItem::push_back( std::string x ) {
+    this->push( std::move( x ) );
+}
+
+template< typename T >
 void DeckItem::push( T x, size_t n ) {
     auto& val = this->value_ref< T >();
 

--- a/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -62,9 +62,12 @@ namespace Opm {
         template< typename T > const std::vector< T >& getData() const;
         const std::vector< double >& getSIDoubleData() const;
 
-        void push_back( int, size_t = 1 );
-        void push_back( double, size_t = 1 );
-        void push_back( std::string, size_t = 1 );
+        void push_back( int );
+        void push_back( double );
+        void push_back( std::string );
+        void push_back( int, size_t );
+        void push_back( double, size_t );
+        void push_back( std::string, size_t );
         void push_backDefault( int );
         void push_backDefault( double );
         void push_backDefault( std::string );
@@ -90,6 +93,7 @@ namespace Opm {
 
         template< typename T > std::vector< T >& value_ref();
         template< typename T > const std::vector< T >& value_ref() const;
+        template< typename T > void push( T );
         template< typename T > void push( T, size_t );
         template< typename T > void push_default( T );
     };


### PR DESCRIPTION
DeckItem.push_back using insert for 1 element turns out to be very
expensive and caused a performance degredation.