### PR TITLE
Make Well+Schedule copyable

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -56,9 +56,9 @@ namespace Opm {
         m_runspec(           deck ),
         m_gridDims(          deck ),
         m_inputGrid(         deck, nullptr ),
-        m_schedule(          std::make_shared<Schedule>( m_parseContext, m_inputGrid, deck, m_runspec.phases() ) ),
+        m_schedule(          m_parseContext, m_inputGrid, deck, m_runspec.phases() ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
-        m_eclipseConfig(     deck, m_eclipseProperties, m_gridDims, *m_schedule , parseContext),
+        m_eclipseConfig(     deck, m_eclipseProperties, m_gridDims, m_schedule, parseContext ),
         m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
                              m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) ),
         m_inputNnc(          deck, m_gridDims ),
@@ -81,7 +81,7 @@ namespace Opm {
         initFaults(deck);
 
         m_messageContainer.appendMessages(m_tables.getMessageContainer());
-        m_messageContainer.appendMessages(m_schedule->getMessageContainer());
+        m_messageContainer.appendMessages(m_schedule.getMessageContainer());
         m_messageContainer.appendMessages(m_inputGrid.getMessageContainer());
         m_messageContainer.appendMessages(m_eclipseProperties.getMessageContainer());
     }
@@ -133,7 +133,7 @@ namespace Opm {
     }
 
     const Schedule& EclipseState::getSchedule() const {
-        return *m_schedule;
+        return this->m_schedule;
     }
 
     /// [[deprecated]] --- use cfg().io()

--- a/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -30,6 +30,7 @@
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -50,7 +51,6 @@ namespace Opm {
     class IOConfig;
     class ParseContext;
     class RestartConfig;
-    class Schedule;
     class Section;
     class SimulationConfig;
     class TableManager;
@@ -125,7 +125,7 @@ namespace Opm {
         Runspec m_runspec;
         const GridDims m_gridDims;
         EclipseGrid m_inputGrid;
-        std::shared_ptr< const Schedule > m_schedule;
+        Schedule m_schedule;
         Eclipse3DProperties m_eclipseProperties;
         EclipseConfig m_eclipseConfig;
         TransMult m_transMult;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -73,7 +73,7 @@ namespace Opm {
         m_rootGroupTree( this->m_timeMap, GroupTree{} ),
         m_oilvaporizationproperties( this->m_timeMap, OilVaporizationProperties{} ),
         m_events( this->m_timeMap ),
-        m_modifierDeck( this->m_timeMap, nullptr ),
+        m_modifierDeck( this->m_timeMap, Deck{} ),
         m_tuning( this->m_timeMap ),
         m_messageLimits( this->m_timeMap ),
         m_phases(phases)
@@ -237,18 +237,8 @@ namespace Opm {
             else if (geoModifiers.find( keyword.name() ) != geoModifiers.end()) {
                 bool supported = geoModifiers.at( keyword.name() );
                 if (supported) {
-                    /*
-                      If the deck stored at currentStep is a null pointer (i.e. evaluates
-                      to false) we must first create a new deck and install that under
-                      index currentstep; then we fetch the deck (newly created - or old)
-                      from the container and add the keyword.
-                    */
-                    if (!m_modifierDeck.iget(currentStep))
-                        m_modifierDeck.iset( currentStep , std::make_shared<Deck>( ));
-
-                    m_modifierDeck.iget( currentStep )->addKeyword( keyword );
+                    this->m_modifierDeck[ currentStep ].addKeyword( keyword );
                     m_events.addEvent( ScheduleEvents::GEO_MODIFIER , currentStep);
-
                 } else {
                     std::string msg = "OPM does not support grid property modifier " + keyword.name() + " in the Schedule section. Error at report: " + std::to_string( currentStep );
                     parseContext.handleError( ParseContext::UNSUPPORTED_SCHEDULE_GEO_MODIFIER , m_messages, msg );
@@ -1577,7 +1567,7 @@ namespace Opm {
       return this->m_tuning;
     }
 
-    std::shared_ptr<const Deck> Schedule::getModifierDeck(size_t timeStep) const {
+    const Deck& Schedule::getModifierDeck(size_t timeStep) const {
         return m_modifierDeck.iget( timeStep );
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -96,8 +96,7 @@ namespace Opm {
         }
 
         if (Section::hasSCHEDULE(deck)) {
-            std::shared_ptr<SCHEDULESection> scheduleSection = std::make_shared<SCHEDULESection>(deck);
-            iterateScheduleSection(parseContext , *scheduleSection , grid );
+            iterateScheduleSection( parseContext, SCHEDULESection( deck ), grid );
         }
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -87,7 +87,7 @@ namespace Opm
 
         const Events& getEvents() const;
         bool hasOilVaporizationProperties();
-        std::shared_ptr<const Deck> getModifierDeck(size_t timeStep) const;
+        const Deck& getModifierDeck(size_t timeStep) const;
         const MessageContainer& getMessageContainer() const;
         MessageContainer& getMessageContainer();
 
@@ -99,7 +99,7 @@ namespace Opm
         DynamicState< GroupTree > m_rootGroupTree;
         DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;
         Events m_events;
-        DynamicVector<std::shared_ptr<Deck> > m_modifierDeck;
+        DynamicVector< Deck > m_modifierDeck;
         Tuning m_tuning;
         MessageLimits m_messageLimits;
         Phases m_phases;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -93,7 +93,7 @@ namespace Opm
 
 
     private:
-        std::shared_ptr< TimeMap > m_timeMap;
+        TimeMap m_timeMap;
         OrderedMap<std::shared_ptr< Well >> m_wells;
         std::map<std::string, Group > m_groups;
         DynamicState< GroupTree > m_rootGroupTree;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -32,6 +32,7 @@
 #include <opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
 #include <opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp>
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
@@ -48,7 +49,6 @@ namespace Opm
     class SCHEDULESection;
     class TimeMap;
     class UnitSystem;
-    class Well;
 
     class Schedule {
     public:
@@ -94,7 +94,7 @@ namespace Opm
 
     private:
         TimeMap m_timeMap;
-        OrderedMap<std::shared_ptr< Well >> m_wells;
+        OrderedMap< Well > m_wells;
         std::map<std::string, Group > m_groups;
         DynamicState< GroupTree > m_rootGroupTree;
         DynamicState< OilVaporizationProperties > m_oilvaporizationproperties;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GeomodifierTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GeomodifierTests.cpp
@@ -84,21 +84,21 @@ BOOST_AUTO_TEST_CASE( CheckUnsoppertedInSCHEDULE ) {
         BOOST_CHECK_EQUAL( false , events.hasEvent( ScheduleEvents::GEO_MODIFIER , 3 ));
 
 
-        BOOST_CHECK( !schedule.getModifierDeck(1) );
-        BOOST_CHECK( !schedule.getModifierDeck(3) );
+        BOOST_CHECK_EQUAL( 0U, schedule.getModifierDeck(1).size() );
+        BOOST_CHECK_EQUAL( 0U, schedule.getModifierDeck(3).size() );
 
-        std::shared_ptr<const Deck> multflt_deck = schedule.getModifierDeck(2);
-        BOOST_CHECK_EQUAL( 2U , multflt_deck->size());
-        BOOST_CHECK( multflt_deck->hasKeyword<ParserKeywords::MULTFLT>() );
+        const Deck& multflt_deck = schedule.getModifierDeck(2);
+        BOOST_CHECK_EQUAL( 2U , multflt_deck.size());
+        BOOST_CHECK( multflt_deck.hasKeyword<ParserKeywords::MULTFLT>() );
 
-        const auto& multflt1 = multflt_deck->getKeyword(0);
+        const auto& multflt1 = multflt_deck.getKeyword(0);
         BOOST_CHECK_EQUAL( 1U , multflt1.size( ) );
 
         const auto& record0 = multflt1.getRecord( 0 );
         BOOST_CHECK_EQUAL( 100.0  , record0.getItem<ParserKeywords::MULTFLT::factor>().get< double >(0));
         BOOST_CHECK_EQUAL( "F1" , record0.getItem<ParserKeywords::MULTFLT::fault>().get< std::string >(0));
 
-        const auto& multflt2 = multflt_deck->getKeyword(1);
+        const auto& multflt2 = multflt_deck.getKeyword(1);
         BOOST_CHECK_EQUAL( 1U , multflt2.size( ) );
 
         const auto& record1 = multflt2.getRecord( 0 );

--- a/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
+++ b/opm/parser/eclipse/EclipseState/Util/OrderedMap.hpp
@@ -122,6 +122,14 @@ public:
     typename std::vector<T>::const_iterator end() const {
         return m_vector.end();
     }
+
+    typename std::vector<T>::iterator begin() {
+        return m_vector.begin();
+    }
+
+    typename std::vector<T>::iterator end() {
+        return m_vector.end();
+    }
 };
 }
 

--- a/opm/parser/eclipse/IntegrationTests/TransMultIntegrationTests.cpp
+++ b/opm/parser/eclipse/IntegrationTests/TransMultIntegrationTests.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(MULTFLT_IN_SCHEDULE) {
     BOOST_CHECK( events.hasEvent( ScheduleEvents::GEO_MODIFIER , 3 ) );
     {
         const auto& mini_deck = schedule.getModifierDeck(3);
-        state.applyModifierDeck( *mini_deck );
+        state.applyModifierDeck( mini_deck );
     }
     BOOST_CHECK_EQUAL( 2.00 , trans.getMultiplier( 2,2,0,FaceDir::XPlus ));
     BOOST_CHECK_EQUAL( 0.10 , trans.getMultiplier( 3,2,0,FaceDir::XPlus ));


### PR DESCRIPTION
Now that WellSet and GroupTree have been modified to no longer use internal references, we can make the Well object copyable and store it directly in the Schedule object.