### PR TITLE
Correct unit for Field gas-oil+oil-gas ratio

### DIFF
--- a/opm/parser/eclipse/Units/UnitSystem.cpp
+++ b/opm/parser/eclipse/Units/UnitSystem.cpp
@@ -144,8 +144,8 @@ namespace {
         1 / ( Field::ReservoirVolume / Field::Time ),
         1 / Field::Transmissibility,
         1 / Field::Mass,
-        1, /* gas-oil ratio */
-        1, /* oil-gas ratio */
+        1 / ( Field::GasSurfaceVolume / Field::LiquidSurfaceVolume ), /* gas-oil ratio */
+        1 / ( Field::LiquidSurfaceVolume / Field::GasSurfaceVolume ), /* oil-gas ratio */
         1, /* water cut */
         1 / (Field::ReservoirVolume / Field::GasSurfaceVolume), /* gas formation volume factor */
         1, /* oil formation volume factor */
@@ -173,8 +173,8 @@ namespace {
          Field::ReservoirVolume / Field::Time,
          Field::Transmissibility,
          Field::Mass,
-         1, /* gas-oil ratio */
-         1, /* oil-gas ratio */
+         Field::GasSurfaceVolume / Field::LiquidSurfaceVolume, /* gas-oil ratio */
+         Field::LiquidSurfaceVolume / Field::GasSurfaceVolume, /* oil-gas ratio */
          1, /* water cut */
          Field::ReservoirVolume / Field::GasSurfaceVolume, /* gas formation volume factor */
          1, /* oil formation volume factor */

--- a/opm/parser/eclipse/Units/tests/UnitTests.cpp
+++ b/opm/parser/eclipse/Units/tests/UnitTests.cpp
@@ -230,3 +230,18 @@ BOOST_AUTO_TEST_CASE( VectorConvert ) {
     for (size_t i = 0; i < d1.size(); i++)
         BOOST_CHECK_EQUAL( units.from_si( UnitSystem::measure::pressure , d1[i] ) , d0[i]);
 }
+
+BOOST_AUTO_TEST_CASE( GasOilRatioNotIdentityForField ) {
+    const double gas = 14233.4;
+    const double oil = 4223;
+
+    const double ratio = gas / oil;
+    const auto units = UnitSystem::newFIELD();
+
+    const auto field_gas = (gas * 35.314666721) / 1000;
+    const auto field_oil = oil * 6.28981100;
+
+    const auto gor = UnitSystem::measure::gas_oil_ratio;
+
+    BOOST_CHECK_CLOSE( units.from_si( gor, ratio ), field_gas / field_oil, 1e-5 );
+}


### PR DESCRIPTION
The FIELD units don't use identity in their converison from SI, as the
unit is Mscf/stb rather than m3/m3.

Should fix https://github.com/OPM/opm-output/issues/146