### PR TITLE
Update jenkins downstream list

### DIFF
--- a/jenkins/build.sh
+++ b/jenkins/build.sh
@@ -17,8 +17,8 @@ fi
 declare -a downstreams
 downstreams=(opm-material
              opm-output
-             opm-core
              opm-grid
+             opm-core
              ewoms
              opm-simulators
              opm-upscaling)

--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -759,7 +759,6 @@ namespace Opm {
     void Eclipse3DProperties::handleOPERATEKeyword( const DeckKeyword& deckKeyword, BoxManager& boxManager) {
         for( const auto& record : deckKeyword ) {
             const std::string& targetArray = record.getItem("TARGET_ARRAY").get< std::string >(0);
-            const std::string& srcArray = record.getItem("ARRAY").get< std::string >(0);
 
             if (m_intGridProperties.supportsKeyword( targetArray ))
                 m_intGridProperties.handleOPERATERecord( record  , boxManager);


### PR DESCRIPTION
opm-grid moved in the dependency graph. also has a commit that removes an unused variable i now noticed. i can remove if you want.