### PR TITLE
Remagine DynamicState

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Group.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Group.cpp
@@ -96,29 +96,24 @@ namespace Opm {
 
 
     void Group::setInjectionPhase(size_t time_step, Phase phase){
-        if (m_injection.phase.size() == time_step + 1) {
-            Phase currentPhase = m_injection.phase.get(time_step);
-            /*
-              The ECLIPSE documentation of the GCONINJE keyword seems
-              to indicate that a group can inject more than one phase
-              simultaneously. This should be implemented in the input
-              file as:
+        /*
+           The ECLIPSE documentation of the GCONINJE keyword seems
+           to indicate that a group can inject more than one phase
+           simultaneously. This should be implemented in the input
+           file as:
 
-              GCONINJE
-                 'GROUP'   'PHASE1'    'RATE'   ... /
-                 'GROUP'   'PHASE2'    'RATE'   ... /
-                 ...
-              /
+           GCONINJE
+           'GROUP'   'PHASE1'    'RATE'   ... /
+           'GROUP'   'PHASE2'    'RATE'   ... /
+           ...
+           /
 
-              I.e. the same group occurs more than once at the same
-              time step, with different phases. This seems quite
-              weird, and we do currently not support it. Changing the
-              injected phase from one time step to the next is
-              supported.
-            */
-            if (phase != currentPhase)
-                throw std::invalid_argument("Sorry - we currently do not support injecting multiple phases at the same time.");
-        }
+           I.e. the same group occurs more than once at the same
+           time step, with different phases. This seems quite
+           weird, and we do currently not support it - we only set the latest
+           specified phase. Changing the injected phase from one time step to
+           the next is supported.
+           */
         m_injection.phase.update( time_step , phase );
     }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.cpp
@@ -93,6 +93,10 @@ namespace Opm {
         return ovp;
     }
 
+    bool OilVaporizationProperties::defined() const {
+        return this->m_type != OilVaporizationEnum::UNDEF;
+    }
+
     bool OilVaporizationProperties::operator==( const OilVaporizationProperties& rhs ) const {
         if( this->m_type == OilVaporizationEnum::UNDEF
          || rhs.m_type   == OilVaporizationEnum::UNDEF

--- a/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -44,6 +44,7 @@ namespace Opm
         double getMaxDRSDT() const;
         double getMaxDRVDT() const;
         bool getOption() const;
+        bool defined() const;
 
         /*
          * if either argument was default constructed == will always be false

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1593,7 +1593,7 @@ namespace Opm {
     }
 
     bool Schedule::hasOilVaporizationProperties() const {
-        for( size_t i = 0; i < this->m_timeMap->size(); ++i )
+        for( size_t i = 0; i < this->m_timeMap.size(); ++i )
             if( m_oilvaporizationproperties.at( i ).defined() ) return true;
 
         return false;

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -1592,7 +1592,10 @@ namespace Opm {
         return m_oilvaporizationproperties.get(timestep);
     }
 
-    bool Schedule::hasOilVaporizationProperties(){
-        return m_oilvaporizationproperties.size() > 0;
+    bool Schedule::hasOilVaporizationProperties() const {
+        for( size_t i = 0; i < this->m_timeMap->size(); ++i )
+            if( m_oilvaporizationproperties.at( i ).defined() ) return true;
+
+        return false;
     }
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -86,8 +86,8 @@ namespace Opm
         const MessageLimits& getMessageLimits() const;
 
         const Events& getEvents() const;
-        bool hasOilVaporizationProperties();
         const Deck& getModifierDeck(size_t timeStep) const;
+        bool hasOilVaporizationProperties() const;
         const MessageContainer& getMessageContainer() const;
         MessageContainer& getMessageContainer();
 

--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
@@ -18,6 +18,7 @@
 */
 #include <opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp>
 
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -54,4 +55,20 @@ namespace Opm {
     bool WellInjectionProperties::operator!=(const WellInjectionProperties& other) const {
         return !(*this == other);
     }
+
+    std::ostream& operator<<( std::ostream& stream,
+                              const WellInjectionProperties& wp ) {
+        return stream
+            << "WellInjectionProperties { "
+            << "surfacerate: "      << wp.surfaceInjectionRate << ", "
+            << "reservoir rate "    << wp.reservoirInjectionRate << ", "
+            << "BHP limit: "        << wp.BHPLimit << ", "
+            << "THP limit: "        << wp.THPLimit << ", "
+            << "VFP table: "        << wp.VFPTableNumber << ", "
+            << "prediction mode: "  << wp.predictionMode << ", "
+            << "injection ctrl: "   << wp.injectionControls << ", "
+            << "injector type: "    << wp.injectorType << ", "
+            << "control mode: "     << wp.controlMode << " }";
+    }
+
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -20,6 +20,8 @@
 #ifndef WELLINJECTIONPROPERTIES_HPP_HEADER_INCLUDED
 #define WELLINJECTIONPROPERTIES_HPP_HEADER_INCLUDED
 
+#include <iosfwd>
+
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 
 namespace Opm {
@@ -56,6 +58,8 @@ namespace Opm {
                 injectionControls += controlModeArg;
         }
     };
+
+    std::ostream& operator<<( std::ostream&, const WellInjectionProperties& );
 }
 
 #endif

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -16,6 +16,8 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include <iostream>
 #include <string>
 #include <vector>
 
@@ -135,19 +137,17 @@ namespace Opm {
 
 
     bool WellProductionProperties::operator==(const WellProductionProperties& other) const {
-        if ((OilRate == other.OilRate) &&
-            (WaterRate == other.WaterRate) &&
-            (GasRate == other.GasRate) &&
-            (LiquidRate == other.LiquidRate) &&
-            (ResVRate == other.ResVRate) &&
-            (BHPLimit == other.BHPLimit) &&
-            (THPLimit == other.THPLimit) &&
-            (VFPTableNumber == other.VFPTableNumber) &&
-            (controlMode == other.controlMode) &&
-            (m_productionControls == other.m_productionControls))
-            return true;
-        else
-            return false;
+        return OilRate              == other.OilRate
+            && WaterRate            == other.WaterRate
+            && GasRate              == other.GasRate
+            && LiquidRate           == other.LiquidRate
+            && ResVRate             == other.ResVRate
+            && BHPLimit             == other.BHPLimit
+            && THPLimit             == other.THPLimit
+            && VFPTableNumber       == other.VFPTableNumber
+            && controlMode          == other.controlMode
+            && m_productionControls == other.m_productionControls
+            && this->predictionMode == other.predictionMode;
     }
 
 
@@ -155,5 +155,20 @@ namespace Opm {
         return !(*this == other);
     }
 
+
+    std::ostream& operator<<( std::ostream& stream, const WellProductionProperties& wp ) {
+        return stream
+            << "WellProductionProperties { "
+            << "oil rate: "     << wp.OilRate           << ", "
+            << "water rate: "   << wp.WaterRate         << ", "
+            << "gas rate: "     << wp.GasRate           << ", "
+            << "liquid rate: "  << wp.LiquidRate        << ", "
+            << "ResV rate: "    << wp.ResVRate          << ", "
+            << "BHP limit: "    << wp.BHPLimit          << ", "
+            << "THP limit: "    << wp.THPLimit          << ", "
+            << "VFP table: "    << wp.VFPTableNumber    << ", "
+            << "ALQ: "          << wp.ALQValue          << ", "
+            << "prediction: "   << wp.predictionMode    << " }";
+    }
 
 } // namespace Opm

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -20,6 +20,7 @@
 #ifndef WELLPRODUCTIONPROPERTIES_HPP_HEADER_INCLUDED
 #define WELLPRODUCTIONPROPERTIES_HPP_HEADER_INCLUDED
 
+#include <iosfwd>
 #include <memory>
 
 #include <opm/parser/eclipse/EclipseState/Runspec.hpp>
@@ -70,6 +71,9 @@ namespace Opm {
 
         WellProductionProperties(const DeckRecord& record);
     };
+
+    std::ostream& operator<<( std::ostream&, const WellProductionProperties& );
+
 } // namespace Opm
 
 #endif  // WELLPRODUCTIONPROPERTIES_HPP_HEADER_INCLUDED

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/DynamicStateTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/DynamicStateTests.cpp
@@ -44,7 +44,7 @@ BOOST_AUTO_TEST_CASE(DynamicStateGetOutOfRangeThrows) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
     Opm::TimeMap timeMap{ boost::posix_time::ptime(startDate) };
     Opm::DynamicState<double> state(timeMap , 9.99);
-    BOOST_CHECK_THROW( state.get(1) , std::range_error);
+    BOOST_CHECK_THROW( state.get(1) , std::out_of_range );
 }
 
 
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE(DynamicStateSetOutOfRangeThrows) {
 
     Opm::DynamicState<int> state(timeMap , 137);
 
-    BOOST_CHECK_THROW( state.update(3 , 100) , std::range_error);
+    BOOST_CHECK_THROW( state.update(3 , 100) , std::out_of_range );
 }
 
 
@@ -98,21 +98,6 @@ BOOST_AUTO_TEST_CASE(DynamicStateSetOK) {
     BOOST_CHECK_EQUAL( 60 , state.back());
 }
 
-
-
-BOOST_AUTO_TEST_CASE(DynamicStateAddIndexAlreadySetThrows) {
-    boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
-    Opm::TimeMap timeMap{ boost::posix_time::ptime(startDate) };
-    for (size_t i = 0; i < 10; i++)
-        timeMap.addTStep( boost::posix_time::hours( (i+1) * 24 ));
-
-    Opm::DynamicState<int> state(timeMap , 137);
-
-    state.update( 5 , 60);
-    BOOST_CHECK_THROW( state.update(3 , 78) , std::invalid_argument);
-}
-
-
 BOOST_AUTO_TEST_CASE(DynamicStateAddAt) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
     Opm::TimeMap timeMap{ boost::posix_time::ptime(startDate) };
@@ -130,29 +115,6 @@ BOOST_AUTO_TEST_CASE(DynamicStateAddAt) {
         BOOST_CHECK( &v1 != &v2 );
     }
 }
-
-
-BOOST_AUTO_TEST_CASE(DynamicStateCheckSize) {
-    boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
-    Opm::TimeMap timeMap{ boost::posix_time::ptime(startDate) };
-    for (size_t i = 0; i < 10; i++)
-        timeMap.addTStep( boost::posix_time::hours( (i+1) * 24 ));
-    Opm::DynamicState<int> state(timeMap , 137);
-
-    BOOST_CHECK_EQUAL( 0U , state.size() );
-
-    state.update( 0 , 10 );
-    BOOST_CHECK_EQUAL( 1U , state.size() );
-
-    state.update( 2 , 10 );
-    BOOST_CHECK_EQUAL( 3U , state.size() );
-    state.update( 2 , 10 );
-    BOOST_CHECK_EQUAL( 3U , state.size() );
-
-    state.update( 6 , 10 );
-    BOOST_CHECK_EQUAL( 7U , state.size() );
-}
-
 
 BOOST_AUTO_TEST_CASE(DynamicStateOperatorSubscript) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GroupTests.cpp
@@ -114,10 +114,9 @@ BOOST_AUTO_TEST_CASE(GroupChangePhaseSameTimeThrows) {
     auto timeMap = createXDaysTimeMap(10);
     Opm::Group group("G1" , timeMap , 0);
     BOOST_CHECK_EQUAL( Opm::Phase::WATER , group.getInjectionPhase( 0 )); // Default phase - assumed WATER
-    group.setInjectionPhase(5 , Opm::Phase::WATER );
-    BOOST_CHECK_THROW( group.setInjectionPhase( 5 , Opm::Phase::GAS ) , std::invalid_argument );
-    BOOST_CHECK_NO_THROW( group.setInjectionPhase( 5 , Opm::Phase::WATER ));
-    BOOST_CHECK_NO_THROW( group.setInjectionPhase( 6 , Opm::Phase::GAS ));
+    group.setInjectionPhase( 5, Opm::Phase::WATER );
+    group.setInjectionPhase( 5, Opm::Phase::WATER );
+    group.setInjectionPhase( 6, Opm::Phase::GAS );
     BOOST_CHECK_EQUAL( Opm::Phase::GAS , group.getInjectionPhase( 6 ));
     BOOST_CHECK_EQUAL( Opm::Phase::GAS , group.getInjectionPhase( 8 ));
 }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(CreateWell_GetProductionPropertiesShouldReturnSameObject) {
 
     BOOST_CHECK_EQUAL(&(well.getProductionProperties(5)), &(well.getProductionProperties(5)));
     BOOST_CHECK_EQUAL(&(well.getProductionProperties(8)), &(well.getProductionProperties(8)));
-    BOOST_CHECK_EQUAL(&(well.getProductionProperties(5)), &(well.getProductionProperties(8)));
+    BOOST_CHECK_EQUAL(well.getProductionProperties(5), well.getProductionProperties(8));
 }
 
 BOOST_AUTO_TEST_CASE(CreateWell_GetInjectionPropertiesShouldReturnSameObject) {
@@ -77,7 +77,7 @@ BOOST_AUTO_TEST_CASE(CreateWell_GetInjectionPropertiesShouldReturnSameObject) {
 
     BOOST_CHECK_EQUAL(&(well.getInjectionProperties(5)), &(well.getInjectionProperties(5)));
     BOOST_CHECK_EQUAL(&(well.getInjectionProperties(8)), &(well.getInjectionProperties(8)));
-    BOOST_CHECK_EQUAL(&(well.getInjectionProperties(5)), &(well.getInjectionProperties(8)));
+    BOOST_CHECK_EQUAL(well.getInjectionProperties(5), well.getInjectionProperties(8));
 }
 
 BOOST_AUTO_TEST_CASE(CreateWellCreateTimeStepOK) {
@@ -148,10 +148,9 @@ BOOST_AUTO_TEST_CASE(setPredictionModeProduction_ModeSetCorrect) {
     Opm::WellProductionProperties props;
     props.predictionMode = false;
     well.setProductionProperties( 5 , props);
-    BOOST_CHECK_EQUAL(false , well.getProductionPropertiesCopy(5).predictionMode);
-    BOOST_CHECK_EQUAL(false , well.getProductionPropertiesCopy(8).predictionMode);
+    BOOST_CHECK( !well.getProductionPropertiesCopy(5).predictionMode );
+    BOOST_CHECK( !well.getProductionPropertiesCopy(8).predictionMode );
 }
-
 
 
 BOOST_AUTO_TEST_CASE(setpredictionModeInjection_ModeSetCorrect) {


### PR DESCRIPTION
This PR fixes a couple of bugs unearthed by the main effort - simplify the `DynamicState` implementation (or rather multiple aspects of it).

The *big* change here is the last commit:
> Changes DynamicState's implementation to, instead of maintaining a
> current and initial element, rely on std::vector's capabilities. This
> introduces a small change in semantics.
> 
> The new DynamicState will up-front allocate a vector of TimeMap.size,
> and all entries will be the initial value. Lookup is then simplified to
> vector.at. DynamicState.update will assgin to the given index and *all
> consecutive elements* which will enforce the same invariant as before.
>
> The behavorial change is that DynamicState will no longer throw on
> update(x); update(y); where y < x. Instead, the resulting effect will be
> that update(x) was never called.
>
> This means that the Group.setInjectionPhase function behaves slightly
> differently, because DynamicState.size is non-sensical. If multiple
> distinct injection phases are specified for a group inside the same time
> step then the last specified phase will be used. The comment has been
> updated accordingly.

These new semantics may not be acceptable (I think they're an improvement, YMMV).

Performance wise this seems like a slight improvement on Heidrun, Norne seems unaffected.