### PR TITLE
Register completion number from COMPDAT

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.hpp
@@ -40,6 +40,7 @@ namespace Opm {
     class Completion {
     public:
         Completion(int i, int j , int k ,
+                   int complnum,
                    double depth,
                    WellCompletion::StateEnum state ,
                    const Value<double>& connectionTransmissibilityFactor,
@@ -49,6 +50,7 @@ namespace Opm {
 
         Completion(const Completion&, WellCompletion::StateEnum newStatus);
         Completion(const Completion&, double wellPi);
+        Completion(const Completion&, int complnum );
 
         bool sameCoordinate(const Completion& other) const;
         bool sameCoordinate(const int i, const int j, const int k) const;
@@ -56,6 +58,7 @@ namespace Opm {
         int getI() const;
         int getJ() const;
         int getK() const;
+        int complnum() const;
         WellCompletion::StateEnum getState() const;
         double getConnectionTransmissibilityFactor() const;
         double getWellPi() const;
@@ -63,6 +66,7 @@ namespace Opm {
         double getDiameter() const;
         double getSkinFactor() const;
         void   fixDefaultIJ(int wellHeadI , int wellHeadJ);
+        void   shift_complnum( int );
         int getSegmentNumber() const;
         double getCenterDepth() const;
         void attachSegment(const int segmentNumber , const double centerDepth);
@@ -80,6 +84,7 @@ namespace Opm {
 
     private:
         int m_i, m_j, m_k;
+        int m_complnum;
         Value<double> m_diameter;
         Value<double> m_connectionTransmissibilityFactor;
         double m_wellPi;

--- a/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.cpp
@@ -47,14 +47,21 @@ namespace Opm {
 
 
     void CompletionSet::add( Completion completion ) {
-        for( auto& c : this->m_completions ) {
-            if( c.sameCoordinate( completion ) ) {
-                c = std::move( completion );
-                return;
-            }
+        auto same = [&]( const Completion& c ) {
+            return c.sameCoordinate( completion );
+        };
+
+        auto prev = std::find_if( this->m_completions.begin(),
+                                  this->m_completions.end(),
+                                  same );
+
+        if( prev != this->m_completions.end() ) {
+            // update the completion, but preserve it's number
+            *prev = Completion( completion, prev->complnum() );
+            return;
         }
 
-        m_completions.push_back( std::move( completion ) );
+        m_completions.emplace_back( completion );
     }
 
     bool CompletionSet::allCompletionsShut( ) const {

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -308,12 +308,14 @@ namespace Opm {
 
     void Well::addCompletions(size_t time_step, std::vector< Completion > newCompletions ) {
         auto new_set = this->getCompletions( time_step );
+        const int complnum_shift = new_set.size();
 
         const auto headI = this->m_headI[ time_step ];
         const auto headJ = this->m_headJ[ time_step ];
 
         for( auto& completion : newCompletions ) {
             completion.fixDefaultIJ( headI , headJ );
+            completion.shift_complnum( complnum_shift );
             new_set.add( std::move( completion ) );
         }
 

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionSetTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionSetTests.cpp
@@ -58,8 +58,8 @@ BOOST_AUTO_TEST_CASE(CreateCompletionSetOK) {
 
 BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
     Opm::CompletionSet completionSet;
-    Opm::Completion completion1( 10,10,10,0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion2( 11,10,10,0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion1( 10,10,10, 1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion2( 11,10,10, 1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -72,8 +72,8 @@ BOOST_AUTO_TEST_CASE(AddCompletionSizeCorrect) {
 
 BOOST_AUTO_TEST_CASE(CompletionSetGetOutOfRangeThrows) {
     Opm::CompletionSet completionSet;
-    Opm::Completion completion1( 10,10,10,0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion2( 11,10,10,0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion1( 10,10,10,1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion2( 11,10,10,1, 0.0,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
     completionSet.add( completion1 );
     BOOST_CHECK_EQUAL( 1U , completionSet.size() );
 
@@ -88,8 +88,8 @@ BOOST_AUTO_TEST_CASE(CompletionSetGetOutOfRangeThrows) {
 
 BOOST_AUTO_TEST_CASE(AddCompletionSameCellUpdates) {
     Opm::CompletionSet completionSet;
-    Opm::Completion completion1( 10,10,10,0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion2( 10,10,10,0.0,Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion2( 10,10,10, 1, 0.0,Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 
 
     completionSet.add( completion1 );
@@ -101,12 +101,12 @@ BOOST_AUTO_TEST_CASE(AddCompletionSameCellUpdates) {
 
 
 
-BOOST_AUTO_TEST_CASE(AddCompletionShallowCopy) {
+BOOST_AUTO_TEST_CASE(AddCompletionCopy) {
     Opm::CompletionSet completionSet;
 
-    Opm::Completion completion1( 10,10,10,0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion2( 10,10,11,0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion3( 10,10,12,0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion1( 10,10,10, 1, 0.0, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion2( 10,10,11, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion3( 10,10,12, 1, 0.0, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 
     completionSet.add( completion1 );
     completionSet.add( completion2 );

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/CompletionTests.cpp
@@ -38,12 +38,12 @@
 
 
 BOOST_AUTO_TEST_CASE(CreateCompletionOK) {
-    Opm::Completion completion(10,10,10,0.0,Opm::WellCompletion::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion(10,10,10, 1, 0.0,Opm::WellCompletion::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 }
 
 
 BOOST_AUTO_TEST_CASE(testGetFunctions) {
-    Opm::Completion completion(10,11,12,0.0, Opm::WellCompletion::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion(10,11,12, 1, 0.0, Opm::WellCompletion::OPEN,Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
     BOOST_CHECK_EQUAL( 10 , completion.getI() );
     BOOST_CHECK_EQUAL( 11 , completion.getJ() );
     BOOST_CHECK_EQUAL( 12 , completion.getK() );
@@ -56,11 +56,11 @@ BOOST_AUTO_TEST_CASE(testGetFunctions) {
 
 
 BOOST_AUTO_TEST_CASE(CompletionTestssameCoordinate) {
-    Opm::Completion completion1(10,10,10,0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion2(10,10,10,0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion3(11,10,10,0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion4(10,11,10,0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion completion5(10,10,11,0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion1(10,10,10, 1, 0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion2(10,10,10, 1, 0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion3(11,10,10, 1, 0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion4(10,11,10, 1, 0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion completion5(10,10,11, 1, 0.0, Opm::WellCompletion::OPEN, Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 
     BOOST_CHECK( completion1.sameCoordinate( completion2 ));
     BOOST_CHECK_EQUAL( false , completion1.sameCoordinate( completion3 ));

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -308,11 +308,11 @@ BOOST_AUTO_TEST_CASE(UpdateCompletions) {
     const auto& completions = well.getCompletions( 0 );
     BOOST_CHECK_EQUAL( 0U , completions.size());
 
-    Opm::Completion comp1( 10 , 10 , 10 , 10,Opm::WellCompletion::AUTO , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion comp2( 10 , 10 , 11 , 11,Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion comp3( 10 , 10 , 12 , 12,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion comp4( 10 , 10 , 12 , 12,Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
-    Opm::Completion comp5( 10 , 10 , 13 , 13,Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion comp1( 10 , 10 , 10 , 1, 10, Opm::WellCompletion::AUTO , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion comp2( 10 , 10 , 11 , 1, 11, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion comp3( 10 , 10 , 12 , 1, 12, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion comp4( 10 , 10 , 12 , 1, 12, Opm::WellCompletion::SHUT , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion comp5( 10 , 10 , 13 , 1, 13, Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 
     //std::vector<Opm::CompletionConstPtr> newCompletions2{ comp4 , comp5}; Newer c++
 
@@ -338,6 +338,7 @@ BOOST_AUTO_TEST_CASE(UpdateCompletions) {
 // Helper function for CompletionOrder test.
 inline Opm::Completion completion( int i, int j, int k ) {
     return Opm::Completion{ i, j, k,
+                            1,
                             k*1.0,
                             Opm::WellCompletion::AUTO,
                             Opm::Value<double>("ConnectionTransmissibilityFactor",99.88),
@@ -584,7 +585,7 @@ BOOST_AUTO_TEST_CASE(WellStatus) {
     Opm::Well well("WELL1" ,  0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
 
     std::vector<Opm::Completion> newCompletions;
-    Opm::Completion comp1(10 , 10 , 10 , 0.25 , Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
+    Opm::Completion comp1(10 , 10 , 10 , 1, 0.25 , Opm::WellCompletion::OPEN , Opm::Value<double>("ConnectionTransmissibilityFactor",99.88), Opm::Value<double>("D",22.33), Opm::Value<double>("SKIN",33.22));
 
     newCompletions.push_back( comp1 );
 


### PR DESCRIPTION
Connections are given a completion number starting at 1 implicitly when
they're first defined by the COMPDAT keyword. Until now this number has
been ignored.

The number itself isn't *used* for anything with this patch, just stored
and accessible.