### PR TITLE
COMPLUMP support

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Completion.cpp
@@ -292,6 +292,7 @@ namespace Opm {
         return this->m_i == rhs.m_i
             && this->m_j == rhs.m_j
             && this->m_k == rhs.m_k
+            && this->m_complnum == rhs.m_complnum
             && this->m_diameter == rhs.m_diameter
             && this->m_connectionTransmissibilityFactor
                == rhs.m_connectionTransmissibilityFactor

--- a/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.cpp
@@ -28,6 +28,10 @@
 
 namespace Opm {
 
+    CompletionSet::CompletionSet( std::initializer_list< Completion > cs ) {
+        for( auto&& c : cs ) this->add( c );
+    }
+
     size_t CompletionSet::size() const {
         return m_completions.size();
     }

--- a/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
@@ -21,14 +21,15 @@
 #ifndef COMPLETIONSET_HPP_
 #define COMPLETIONSET_HPP_
 
-#include <memory>
-
 #include <opm/parser/eclipse/EclipseState/Schedule/Completion.hpp>
 
 namespace Opm {
 
     class CompletionSet {
     public:
+        CompletionSet() = default;
+        CompletionSet( std::initializer_list< Completion > );
+
         using const_iterator = std::vector< Completion >::const_iterator;
 
         void add( Completion );

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -121,6 +121,7 @@ namespace Opm
         void handleWCONPROD( const DeckKeyword& keyword, size_t currentStep);
         void handleWGRUPCON( const DeckKeyword& keyword, size_t currentStep);
         void handleCOMPDAT( const DeckKeyword& keyword,  size_t currentStep, const EclipseGrid& grid);
+        void handleCOMPLUMP( const DeckKeyword& keyword,  size_t currentStep );
         void handleWELSEGS( const DeckKeyword& keyword, size_t currentStep);
         void handleCOMPSEGS( const DeckKeyword& keyword, size_t currentStep);
         void handleWCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -127,7 +127,7 @@ namespace Opm
         void handleWPOLYMER( const DeckKeyword& keyword, size_t currentStep);
         void handleWSOLVENT( const DeckKeyword& keyword, size_t currentStep);
         void handleWCONINJH( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep);
-        void handleWELOPEN( const DeckKeyword& keyword, size_t currentStep, bool hascomplump);
+        void handleWELOPEN( const DeckKeyword& keyword, size_t currentStep );
         void handleWELTARG( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep);
         void handleGCONINJE( const SCHEDULESection&,  const DeckKeyword& keyword, size_t currentStep);
         void handleGCONPROD( const DeckKeyword& keyword, size_t currentStep);

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -306,7 +306,7 @@ namespace Opm {
         return m_completions.back();
     }
 
-    void Well::addCompletions(size_t time_step, std::vector< Completion > newCompletions ) {
+    void Well::addCompletions(size_t time_step, const std::vector< Completion >& newCompletions ) {
         auto new_set = this->getCompletions( time_step );
         int complnum_shift = new_set.size();
 
@@ -314,11 +314,11 @@ namespace Opm {
         const auto headJ = this->m_headJ[ time_step ];
 
         auto prev_size = new_set.size();
-        for( auto& completion : newCompletions ) {
+        for( auto completion : newCompletions ) {
             completion.fixDefaultIJ( headI , headJ );
             completion.shift_complnum( complnum_shift );
 
-            new_set.add( std::move( completion ) );
+            new_set.add( completion );
             const auto new_size = new_set.size();
 
             /* Completions can be "re-added", i.e. same coordinates but with a

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -89,7 +89,7 @@ namespace Opm {
         bool isInjector(size_t timeStep) const;
         void addWELSPECS(const DeckRecord& deckRecord);
 
-        void addCompletions(size_t time_step, std::vector< Completion > );
+        void addCompletions(size_t time_step, const std::vector< Completion >& );
         void addCompletionSet(size_t time_step, CompletionSet );
         const CompletionSet& getCompletions(size_t timeStep) const;
         const CompletionSet& getCompletions() const;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -543,44 +543,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWELOPEN_TryToOpenWellWithShutCompleti
   BOOST_CHECK_EQUAL(WellCommon::StatusEnum::SHUT, well->getStatus(currentStep));
 }
 
-BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithCOMPLUMPwithDefaultValuesInWELOPEN) {
-    Opm::Parser parser;
-    std::string input =
-            "START             -- 0 \n"
-                    "1 NOV 1979 / \n"
-                    "SCHEDULE\n"
-                    "DATES             -- 1\n"
-                    " 1 DES 1979/ \n"
-                    "/\n"
-                    "WELSPECS\n"
-                    "    'OP_1'       'OP'   9   9 1*     'OIL' 1*      1*  1*   1*  1*   1*  1*  / \n"
-                    "/\n"
-                    "COMPDAT\n"
-                    " 'OP_1'  9  9   1   1 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-                    " 'OP_1'  9  9   2   2 'OPEN' 1*   46.825   0.311  4332.346 1*  1*  'X'  22.123 / \n"
-                    " 'OP_1'  9  9   3  9 'OPEN' 1*   32.948   0.311  3047.839 1*  1*  'X'  22.100 / \n"
-                    "/\n"
-                    "DATES             -- 3\n"
-                    " 10  OKT 2008 / \n"
-                    "/\n"
-                    "WELOPEN\n"
-                    " 'OP_1' OPEN/ \n"
-                    "/\n"
-                    "COMPLUMP\n"
-                    " 'OP_1' 0 0 0 0 0 / \n "
-                    "/\n"
-                    "DATES             -- 4\n"
-                    " 10  NOV 2008 / \n"
-                    "/\n";
-
-    EclipseGrid grid(10,10,10);
-    auto deck = parser.parseString(input, ParseContext());
-    Schedule schedule(ParseContext() , grid , deck, Phases(true, true, true) );
-    auto* well = schedule.getWell("OP_1");
-    size_t currentStep = 3;
-    BOOST_CHECK_EQUAL(WellCommon::StatusEnum::OPEN, well->getStatus(currentStep));
-}
-
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFT) {
     Opm::Parser parser;
     std::string input =
@@ -677,9 +639,6 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithWRFTPLT) {
                     "/\n"
                     "WELOPEN\n"
                     " 'OP_1' OPEN / \n"
-                    "/\n"
-                    "COMPLUMP\n"
-                    " 'OP_1' 0 0 0 0 0 / \n "
                     "/\n"
                     "DATES             -- 5\n"
                     " 10  NOV 2008 / \n"
@@ -1207,7 +1166,7 @@ BOOST_AUTO_TEST_CASE(move_HEAD_I_location) {
     BOOST_CHECK_EQUAL( 2, well.getHeadI( 1 ) );
 }
 
-BOOST_AUTO_TEST_CASE(change_ref_depth ) {
+BOOST_AUTO_TEST_CASE(change_ref_depth) {
     std::string input = R"(
             START             -- 0
             19 JUN 2007 /
@@ -1307,8 +1266,8 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_wells ) {
     )";
 
     ParseContext ctx;
-    auto deck = Parser().parseString(input, ctx);
-    EclipseGrid grid(10,10,10);
+    auto deck = Parser().parseString( input, ctx );
+    EclipseGrid grid( 10, 10, 10 );
     Schedule schedule( ctx, grid, deck, Phases( true, true, true ) );
 
     const auto& w1cs = schedule.getWell( "W1" )->getCompletions();
@@ -1354,4 +1313,170 @@ BOOST_AUTO_TEST_CASE( COMPDAT_multiple_records_same_completion ) {
     BOOST_CHECK_EQUAL( 1, cs.get( 0 ).complnum() );
     BOOST_CHECK_EQUAL( 2, cs.get( 1 ).complnum() );
     BOOST_CHECK_EQUAL( 3, cs.get( 2 ).complnum() );
+}
+
+BOOST_AUTO_TEST_CASE( complump_less_than_1 ) {
+    std::string input = R"(
+            START             -- 0
+            19 JUN 2007 /
+            SCHEDULE
+
+            WELSPECS
+                'W1' 'G1'  3 3 2873.94 'WATER' 0.00 'STD' 'SHUT' 'NO' 0 'SEG' /
+            /
+
+            COMPDAT
+                'W1' 0 0 1 2 'SHUT' 1*    /
+            /
+
+            COMPLUMP
+                'W1' 0 0 0 0 0 /
+            /
+    )";
+
+    ParseContext ctx;
+    auto deck = Parser().parseString( input, ctx );
+    EclipseGrid grid( 10, 10, 10);
+    Phases p( true, true, true );
+    BOOST_CHECK_THROW( Schedule( ctx, grid, deck, p ), std::invalid_argument );
+}
+
+BOOST_AUTO_TEST_CASE( complump ) {
+    std::string input = R"(
+            START             -- 0
+            19 JUN 2007 /
+            SCHEDULE
+
+            WELSPECS
+                'W1' 'G1'  3 3 2873.94 'WATER' 0.00 'STD' 'SHUT' 'NO' 0 'SEG' /
+                'W2' 'G2'  5 5 1       'OIL'   0.00 'STD' 'SHUT' 'NO' 0 'SEG' /
+            /
+
+            COMPDAT
+                'W1' 0 0 1 2 'SHUT' 1*    /
+                'W1' 0 0 2 3 'SHUT' 1*    /
+                'W1' 0 0 4 6 'SHUT' 1*    /
+                'W2' 0 0 3 4 'SHUT' 1*    /
+                'W2' 0 0 1 4 'SHUT' 1*    /
+            /
+
+            COMPLUMP
+                -- name I J K1 K2 C
+                -- where C is the completion number of this lump
+                'W1' 0 0 1 3 1 /
+            /
+
+            DATES             -- 1
+             10  OKT 2008 /
+            /
+
+            WELOPEN
+                'W1' 'OPEN' 0 0 0 1 1 /
+            /
+    )";
+
+    constexpr auto open = WellCompletion::StateEnum::OPEN;
+    constexpr auto shut = WellCompletion::StateEnum::SHUT;
+
+    ParseContext ctx;
+    auto deck = Parser().parseString(input, ctx);
+    EclipseGrid grid(10,10,10);
+    Schedule schedule( ctx, grid, deck, Phases( true, true, true ) );
+
+    const auto& well = *schedule.getWell( "W1" );
+    const auto& sc0  = well.getCompletions( 0 );
+
+    /* complnum should be modified by COMPLNUM */
+    BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 0 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 1 ).complnum() );
+    BOOST_CHECK_EQUAL( 1, sc0.getFromIJK( 2, 2, 2 ).complnum() );
+    BOOST_CHECK_EQUAL( 4, sc0.getFromIJK( 2, 2, 3 ).complnum() );
+
+    BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 0 ).getState() );
+    BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 1 ).getState() );
+    BOOST_CHECK_EQUAL( shut, sc0.getFromIJK( 2, 2, 2 ).getState() );
+
+    const auto& sc1  = well.getCompletions( 1 );
+    BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 0 ).getState() );
+    BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 1 ).getState() );
+    BOOST_CHECK_EQUAL( open, sc1.getFromIJK( 2, 2, 2 ).getState() );
+    BOOST_CHECK_EQUAL( shut, sc1.getFromIJK( 2, 2, 3 ).getState() );
+}
+
+BOOST_AUTO_TEST_CASE( COMPLUMP_specific_coordinates ) {
+    std::string input = R"(
+        START             -- 0
+        19 JUN 2007 /
+        SCHEDULE
+
+        WELSPECS
+            'W1' 'G1'  3 3 2873.94 'WATER' 0.00 'STD' 'SHUT' 'NO' 0 'SEG' /
+        /
+
+        COMPDAT                         -- completion number
+            'W1' 1 1 1 1 'SHUT' 1*    / -- 1
+            'W1' 1 1 2 2 'SHUT' 1*    / -- 2
+            'W1' 0 0 1 2 'SHUT' 1*    / -- 3, 4
+            'W1' 0 0 2 3 'SHUT' 1*    / -- 5
+            'W1' 2 2 1 1 'SHUT' 1*    / -- 6
+            'W1' 2 2 4 6 'SHUT' 1*    / -- 7, 8, 9
+        /
+
+        DATES             -- 1
+            10  OKT 2008 /
+        /
+
+        WELOPEN -- open completion 1, rest are still shut
+            'W1' OPEN 1 1 0 1 1 /
+        /
+
+        DATES             -- 2
+            15  OKT 2008 /
+        /
+
+        COMPLUMP
+            -- name I J K1 K2 C
+            -- where C is the completion number of this lump
+            'W1' 0 0 2 3 2 / -- all with k = [2 <= k <= 3] -> {2, 4, 5}
+            'W1' 2 2 1 5 7 / -- fix'd i,j, k = [1 <= k <= 5] -> {6, 7, 8}
+        /
+
+        WELOPEN
+            'W1' OPEN 0 0 0 2 2 / -- open the new 2 {2, 4, 5}
+            'W1' OPEN 0 0 0 5 7 / -- open 5..7 {5, 6, 7, 8}
+        /
+    )";
+
+    constexpr auto open = WellCompletion::StateEnum::OPEN;
+    constexpr auto shut = WellCompletion::StateEnum::SHUT;
+
+    ParseContext ctx;
+    auto deck = Parser().parseString( input, ctx );
+    EclipseGrid grid( 10, 10, 10 );
+    Schedule schedule( ctx, grid, deck, Phases( true, true, true ) );
+
+    const auto& well = *schedule.getWell( "W1" );
+    const auto& cs1 = well.getCompletions( 1 );
+    const auto& cs2 = well.getCompletions( 2 );
+
+    BOOST_CHECK_EQUAL( 9U, cs1.size() );
+    BOOST_CHECK_EQUAL( open, cs1.getFromIJK( 0, 0, 0 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 0, 0, 1 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 0 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 1 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 2, 2, 2 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 0 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 3 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 4 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs1.getFromIJK( 1, 1, 5 ).getState() );
+
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 0, 0, 0 ).getState() );
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 0, 0, 1 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs2.getFromIJK( 2, 2, 0 ).getState() );
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 2, 2, 1 ).getState() );
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 2, 2, 2 ).getState() );
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 1, 1, 0 ).getState() );
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 1, 1, 3 ).getState() );
+    BOOST_CHECK_EQUAL( open, cs2.getFromIJK( 1, 1, 4 ).getState() );
+    BOOST_CHECK_EQUAL( shut, cs2.getFromIJK( 1, 1, 5 ).getState() );
 }


### PR DESCRIPTION
Support for COMPLUMP. a keyword to re-assign completion numbers that can
be used with keywords such as WELOPEN.

Some helper functions were moved out of handleWELOPEN and reused in
handleCOMPLUMP.

Built on top of https://github.com/OPM/opm-parser/pull/995 and https://github.com/OPM/opm-parser/pull/996