### PR TITLE
Don't crash keyword compilation on broken locales

### DIFF
--- a/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
+++ b/opm/parser/eclipse/Parser/createDefaultKeywordList.cpp
@@ -16,11 +16,19 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#if !defined(WIN32)
+    #define _POSIX_C_SOURCE 200112L
+    #include <stdlib.h>
+#endif
+
 #include <iostream>
+#include <locale>
+
+#include <boost/filesystem.hpp>
 
 #include <opm/parser/eclipse/Generator/KeywordGenerator.hpp>
 #include <opm/parser/eclipse/Generator/KeywordLoader.hpp>
-
 
 
 int main(int argc , char ** argv) {
@@ -33,6 +41,33 @@ int main(int argc , char ** argv) {
         const char * output_files = argv[6];
         bool verboseLoader = false;
         bool verboseGenerator = true;
+
+        try {
+            /* sometimes the local env's locales are broken on POSIX. Boost <=
+             * 1.56 uses the std::locale("") constructor which respects user
+             * preferred locales, and might crash. If this is the case, and
+             * we're on a non-windows system (assuming POSIX), in case of an
+             * exception, set the environment to "C" and keep going.
+             *
+             * Can be removed once boost < 1.57 is no longer supported
+             */
+            std::locale( "" );
+        } catch( const std::runtime_error& ) {
+            #if !defined(WIN32)
+            setenv( "LC_ALL", "C", 1 );
+            #endif
+            auto loc = boost::filesystem::path::imbue( std::locale::classic() );
+            boost::filesystem::path::imbue( loc );
+            std::cout << "User preferred locale setting is invalid "
+                      << "which breaks Boost <= 1.56 "
+                      << "- forcing to 'C' as workaround for Boost <= 1.56. "
+                      << "This workaround only applies to compile opm-parser, "
+                      << "but your locale settings seem BROKEN, "
+                      << "and opm-parser is likely NOT GOING TO WORK. "
+                      << "If you're on linux you can try setting the LANG "
+                      << "or LC_ALL environment variables to C or POSIX."
+                      << std::endl;
+        }
 
         Opm::KeywordLoader loader(verboseLoader);
         Opm::KeywordGenerator generator(verboseGenerator);


### PR DESCRIPTION
Work around a weakness of older boosts by forcing C locale if
std::locale throws.

The real solution is to not have broken locales, but this should make it
slightly easier to get the JSON keywords compiled.

Addresses https://github.com/OPM/opm-parser/issues/973

Please note that this does not fix unit tests, it does not fix opmi and it does not fix flow, because it's really up to the driver application to handle this.

A sufficiently new boost, properly configured locales or `LC_ALL="C" make` should also solve this problem.