### PR TITLE
Do not use ParserKeyword-derived definitions.

### DIFF
--- a/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -56,12 +56,8 @@ namespace Opm {
         const std::vector<std::string>& getStringData() const;
         size_t getDataSize() const;
 
-        template <class Keyword>
-        bool isKeyword() const {
-            if (Keyword::keywordName == m_keywordName)
-                return true;
-            else
-                return false;
+        bool isKeyword( const std::string& nm ) const {
+            return nm == this->m_keywordName;
         }
 
         const_iterator begin() const;

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -246,14 +246,13 @@ namespace Opm {
     }
 
     void EclipseState::applyModifierDeck(const Deck& deck) {
-        using namespace ParserKeywords;
         for (const auto& keyword : deck) {
 
-            if (keyword.isKeyword<MULTFLT>()) {
+            if (keyword.isKeyword( "MULTFLT" )) {
                 for (const auto& record : keyword) {
-                    const std::string& faultName = record.getItem<MULTFLT::fault>().get< std::string >(0);
+                    const std::string& faultName = record.getItem( "fault" ).get< std::string >(0);
                     auto& fault = m_faults.getFault( faultName );
-                    double tmpMultFlt = record.getItem<MULTFLT::factor>().get< double >(0);
+                    double tmpMultFlt = record.getItem( "factor" ).get< double >(0);
                     double oldMultFlt = fault.getTransMult( );
                     double newMultFlt = oldMultFlt * tmpMultFlt;
 

--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -169,8 +169,8 @@ namespace Opm {
         if (actnum != nullptr)
             resetACTNUM(actnum);
         else {
-            if (deck.hasKeyword<ParserKeywords::ACTNUM>()) {
-                const auto& actnumData = deck.getKeyword<ParserKeywords::ACTNUM>().getIntData();
+            if (deck.hasKeyword( "ACTNUM" )) {
+                const auto& actnumData = deck.getKeyword( "ACTNUM" ).getIntData();
                 if (actnumData.size() == getCartesianSize())
                     resetACTNUM( actnumData.data());
                 else {
@@ -191,33 +191,33 @@ namespace Opm {
             throw std::invalid_argument("EclipseGrid needs cornerpoint or cartesian keywords.");
         }
 
-        if (deck.hasKeyword<ParserKeywords::PINCH>()) {
-            const auto& record = deck.getKeyword<ParserKeywords::PINCH>( ).getRecord(0);
-            const auto& item = record.getItem<ParserKeywords::PINCH::THRESHOLD_THICKNESS>( );
+        if (deck.hasKeyword( "PINCH" )) {
+            const auto& record = deck.getKeyword( "PINCH" ).getRecord(0);
+            const auto& item = record.getItem( "THRESHOLD_THICKNESS" );
             m_pinch.setValue( item.getSIDouble(0) );
 
-            auto pinchoutString = record.getItem<ParserKeywords::PINCH::PINCHOUT_OPTION>().get< std::string >(0);
+            auto pinchoutString = record.getItem( "PINCHOUT_OPTION" ).get< std::string >(0);
             m_pinchoutMode = PinchMode::PinchModeFromString(pinchoutString);
 
-            auto multzString = record.getItem<ParserKeywords::PINCH::MULTZ_OPTION>().get< std::string >(0);
+            auto multzString = record.getItem( "MULTZ_OPTION" ).get< std::string >(0);
             m_multzMode = PinchMode::PinchModeFromString(multzString);
         }
 
-        if (deck.hasKeyword<ParserKeywords::MINPV>() && deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
+        if( deck.hasKeyword( "MINPV" ) && deck.hasKeyword( "MINPVFIL" ) ) {
             throw std::invalid_argument("Can not have both MINPV and MINPVFIL in deck.");
         }
 
-        if (deck.hasKeyword<ParserKeywords::MINPV>()) {
-            const auto& record = deck.getKeyword<ParserKeywords::MINPV>( ).getRecord(0);
-            const auto& item = record.getItem<ParserKeywords::MINPV::VALUE>( );
+        if (deck.hasKeyword( "MINPV" )) {
+            const auto& record = deck.getKeyword( "MINPV" ).getRecord(0);
+            const auto& item = record.getItem( "VALUE" );
             m_minpvValue = item.getSIDouble(0);
             m_minpvMode = MinpvMode::ModeEnum::EclSTD;
         }
 
 
-        if (deck.hasKeyword<ParserKeywords::MINPVFIL>()) {
-            const auto& record = deck.getKeyword<ParserKeywords::MINPVFIL>( ).getRecord(0);
-            const auto& item = record.getItem<ParserKeywords::MINPVFIL::VALUE>( );
+        if (deck.hasKeyword( "MINPVFIL" )) {
+            const auto& record = deck.getKeyword( "MINPVFIL" ).getRecord(0);
+            const auto& item = record.getItem( "VALUE" );
             m_minpvValue = item.getSIDouble(0);
             m_minpvMode = MinpvMode::ModeEnum::OpmFIL;
         }
@@ -285,10 +285,10 @@ namespace Opm {
 
 
     void EclipseGrid::initDVDEPTHZGrid(const std::array<int, 3>& dims, const Deck& deck) {
-        const std::vector<double>& DXV = deck.getKeyword<ParserKeywords::DXV>().getSIDoubleData();
-        const std::vector<double>& DYV = deck.getKeyword<ParserKeywords::DYV>().getSIDoubleData();
-        const std::vector<double>& DZV = deck.getKeyword<ParserKeywords::DZV>().getSIDoubleData();
-        const std::vector<double>& DEPTHZ = deck.getKeyword<ParserKeywords::DEPTHZ>().getSIDoubleData();
+        const std::vector<double>& DXV = deck.getKeyword( "DXV" ).getSIDoubleData();
+        const std::vector<double>& DYV = deck.getKeyword( "DYV" ).getSIDoubleData();
+        const std::vector<double>& DZV = deck.getKeyword( "DZV" ).getSIDoubleData();
+        const std::vector<double>& DEPTHZ = deck.getKeyword( "DEPTHZ" ).getSIDoubleData();
 
         assertVectorSize( DEPTHZ , static_cast<size_t>( (dims[0] + 1)*(dims[1] +1 )) , "DEPTHZ");
         assertVectorSize( DXV    , static_cast<size_t>( dims[0] ) , "DXV");
@@ -340,14 +340,14 @@ namespace Opm {
     void EclipseGrid::initCornerPointGrid(const std::array<int,3>& dims, const Deck& deck) {
         assertCornerPointKeywords( dims , deck);
         {
-            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>();
-            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>();
+            const auto& ZCORNKeyWord = deck.getKeyword( "ZCORN" );
+            const auto& COORDKeyWord = deck.getKeyword( "COORD" );
             const std::vector<double>& zcorn = ZCORNKeyWord.getSIDoubleData();
             const std::vector<double>& coord = COORDKeyWord.getSIDoubleData();
             double * mapaxes = nullptr;
 
-            if (deck.hasKeyword<ParserKeywords::MAPAXES>()) {
-                const auto& mapaxesKeyword = deck.getKeyword<ParserKeywords::MAPAXES>();
+            if( deck.hasKeyword( "MAPAXES" ) ) {
+                const auto& mapaxesKeyword = deck.getKeyword( "MAPAXES" );
                 const auto& record = mapaxesKeyword.getRecord(0);
                 mapaxes = new double[6];
                 for (size_t i = 0; i < 6; i++) {
@@ -363,10 +363,7 @@ namespace Opm {
 
 
     bool EclipseGrid::hasCornerPointKeywords(const Deck& deck) {
-        if (deck.hasKeyword<ParserKeywords::ZCORN>() && deck.hasKeyword<ParserKeywords::COORD>())
-            return true;
-        else
-            return false;
+        return deck.hasKeyword( "ZCORN" ) && deck.hasKeyword( "COORD" );
     }
 
 
@@ -376,7 +373,7 @@ namespace Opm {
         const int ny = dims[1];
         const int nz = dims[2];
         {
-            const auto& ZCORNKeyWord = deck.getKeyword<ParserKeywords::ZCORN>();
+            const auto& ZCORNKeyWord = deck.getKeyword( "ZCORN" );
 
             if (ZCORNKeyWord.getDataSize() != static_cast<size_t>(8*nx*ny*nz)) {
                 const std::string msg =
@@ -389,7 +386,7 @@ namespace Opm {
         }
 
         {
-            const auto& COORDKeyWord = deck.getKeyword<ParserKeywords::COORD>();
+            const auto& COORDKeyWord = deck.getKeyword( "COORD" );
             if (COORDKeyWord.getDataSize() != static_cast<size_t>(6*(nx + 1)*(ny + 1))) {
                 const std::string msg =
                     "Wrong size of the COORD keyword: Expected 6*(nx + 1)*(ny + 1) = "
@@ -412,20 +409,20 @@ namespace Opm {
 
 
     bool EclipseGrid::hasDVDEPTHZKeywords(const Deck& deck) {
-        if (deck.hasKeyword<ParserKeywords::DXV>() &&
-            deck.hasKeyword<ParserKeywords::DYV>() &&
-            deck.hasKeyword<ParserKeywords::DZV>() &&
-            deck.hasKeyword<ParserKeywords::DEPTHZ>())
+        if (deck.hasKeyword( "DXV" ) &&
+            deck.hasKeyword( "DYV" ) &&
+            deck.hasKeyword( "DZV" ) &&
+            deck.hasKeyword( "DEPTHZ" ))
             return true;
         else
             return false;
     }
 
     bool EclipseGrid::hasDTOPSKeywords(const Deck& deck) {
-        if ((deck.hasKeyword<ParserKeywords::DX>() || deck.hasKeyword<ParserKeywords::DXV>()) &&
-            (deck.hasKeyword<ParserKeywords::DY>() || deck.hasKeyword<ParserKeywords::DYV>()) &&
-            (deck.hasKeyword<ParserKeywords::DZ>() || deck.hasKeyword<ParserKeywords::DZV>()) &&
-            deck.hasKeyword<ParserKeywords::TOPS>())
+        if ((deck.hasKeyword( "DX" ) || deck.hasKeyword( "DXV" )) &&
+            (deck.hasKeyword( "DY" ) || deck.hasKeyword( "DYV" )) &&
+            (deck.hasKeyword( "DZ" ) || deck.hasKeyword( "DZV" )) &&
+             deck.hasKeyword( "TOPS" ))
             return true;
         else
             return false;
@@ -478,7 +475,7 @@ namespace Opm {
         double z_tolerance = 1e-6;
         size_t volume = dims[0] * dims[1] * dims[2];
         size_t area = dims[0] * dims[1];
-        const auto& TOPSKeyWord = deck.getKeyword<ParserKeywords::TOPS>();
+        const auto& TOPSKeyWord = deck.getKeyword( "TOPS" );
         std::vector<double> TOPS = TOPSKeyWord.getSIDoubleData();
 
         if (TOPS.size() >= area) {

--- a/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/FaultCollection.cpp
@@ -43,7 +43,7 @@ namespace Opm {
 
     FaultCollection::FaultCollection(const GRIDSection& gridSection,
                                      const GridDims& grid) {
-        const auto& faultKeywords = gridSection.getKeywordList<ParserKeywords::FAULTS>();
+        const auto& faultKeywords = gridSection.getKeywordList("FAULTS");
 
         for (auto keyword_iter = faultKeywords.begin(); keyword_iter != faultKeywords.end(); ++keyword_iter) {
             const auto& faultsKeyword = *keyword_iter;

--- a/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/NNC.cpp
@@ -31,7 +31,7 @@
 namespace Opm
 {
     NNC::NNC(const Deck& deck, const GridDims& gridDims) {
-        const auto& nncs = deck.getKeywordList<ParserKeywords::NNC>();
+        const auto& nncs = deck.getKeywordList( "NNC" );
         for (size_t idx_nnc = 0; idx_nnc<nncs.size(); ++idx_nnc) {
             const auto& nnc = *nncs[idx_nnc];
             for (size_t i = 0; i < nnc.size(); ++i) {

--- a/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.cpp
@@ -33,8 +33,8 @@
 namespace Opm {
 
     static inline Equil equils( const Deck& deck ) {
-        if( !deck.hasKeyword<ParserKeywords::EQUIL>( ) ) return {};
-        return Equil( deck.getKeyword<ParserKeywords::EQUIL>(  ) );
+        if( !deck.hasKeyword( "EQUIL" ) ) return {};
+        return Equil( deck.getKeyword( "EQUIL" ) );
     }
 
     InitConfig::InitConfig(const Deck& deck) : equil(equils(deck)) {

--- a/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MSW/Compsegs.cpp
@@ -54,15 +54,15 @@ namespace Opm {
         for (size_t recordIndex = 1; recordIndex < compsegsKeyword.size(); ++recordIndex) {
             const auto& record = compsegsKeyword.getRecord(recordIndex);
             // following the coordinate rule for completions
-            const int I = record.getItem<ParserKeywords::COMPSEGS::I>().get< int >(0) - 1;
-            const int J = record.getItem<ParserKeywords::COMPSEGS::J>().get< int >(0) - 1;
-            const int K = record.getItem<ParserKeywords::COMPSEGS::K>().get< int >(0) - 1;
-            const int branch = record.getItem<ParserKeywords::COMPSEGS::BRANCH>().get< int >(0);
+            const int I = record.getItem( "I" ).get< int >(0) - 1;
+            const int J = record.getItem( "J" ).get< int >(0) - 1;
+            const int K = record.getItem( "K" ).get< int >(0) - 1;
+            const int branch = record.getItem( "BRANCH" ).get< int >(0);
 
             double distance_start;
             double distance_end;
-            if (record.getItem<ParserKeywords::COMPSEGS::DISTANCE_START>().hasValue(0)) {
-                distance_start = record.getItem<ParserKeywords::COMPSEGS::DISTANCE_START>().getSIDouble(0);
+            if (record.getItem( "DISTANCE_START" ).hasValue(0)) {
+                distance_start = record.getItem( "DISTANCE_START" ).getSIDouble(0);
             } else if (recordIndex == 1) {
                 distance_start = 0.;
             } else {
@@ -71,20 +71,20 @@ namespace Opm {
                 // since basically no specific order for the completions
                 throw std::runtime_error("this way to obtain DISTANCE_START not implemented yet!");
             }
-            if (record.getItem<ParserKeywords::COMPSEGS::DISTANCE_END>().hasValue(0)) {
-                distance_end = record.getItem<ParserKeywords::COMPSEGS::DISTANCE_END>().getSIDouble(0);
+            if (record.getItem( "DISTANCE_END" ).hasValue(0)) {
+                distance_end = record.getItem( "DISTANCE_END").getSIDouble(0);
             } else {
                 // TODO: the distance_start plus the thickness of the grid block
                 throw std::runtime_error("this way to obtain DISTANCE_END not implemented yet!");
             }
 
-            if( !record.getItem< ParserKeywords::COMPSEGS::DIRECTION >().hasValue( 0 ) &&
-                !record.getItem< ParserKeywords::COMPSEGS::DISTANCE_END >().hasValue( 0 ) ) {
+            if( !record.getItem( "DIRECTION" ).hasValue( 0 ) &&
+                !record.getItem( "DISTANCE_END" ).hasValue( 0 ) ) {
                 throw std::runtime_error("the direction has to be specified when DISTANCE_END in the record is not specified");
             }
 
-            if( record.getItem< ParserKeywords::COMPSEGS::END_IJK >().hasValue( 0 ) &&
-               !record.getItem< ParserKeywords::COMPSEGS::DIRECTION >().hasValue( 0 ) ) {
+            if( record.getItem( "END_IJK" ).hasValue( 0 ) &&
+               !record.getItem( "DIRECTION" ).hasValue( 0 ) ) {
                 throw std::runtime_error("the direction has to be specified when END_IJK in the record is specified");
             }
 
@@ -93,13 +93,13 @@ namespace Opm {
              * is set or a range is specified. If not this is effectively ignored.
              */
             WellCompletion::DirectionEnum direction = WellCompletion::X;
-            if( record.getItem< ParserKeywords::COMPSEGS::DIRECTION >().hasValue( 0 ) ) {
-                direction = WellCompletion::DirectionEnumFromString(record.getItem<ParserKeywords::COMPSEGS::DIRECTION>().get< std::string >(0));
+            if( record.getItem( "DIRECTION" ).hasValue( 0 ) ) {
+                direction = WellCompletion::DirectionEnumFromString(record.getItem( "DIRECTION" ).get< std::string >(0));
             }
 
             double center_depth;
-            if (!record.getItem<ParserKeywords::COMPSEGS::CENTER_DEPTH>().defaultApplied(0)) {
-                center_depth = record.getItem<ParserKeywords::COMPSEGS::CENTER_DEPTH>().getSIDouble(0);
+            if (!record.getItem( "CENTER_DEPTH" ).defaultApplied(0)) {
+                center_depth = record.getItem( "CENTER_DEPTH" ).getSIDouble(0);
             } else {
                 // 0.0 is also the defaulted value
                 // which is used to indicate to obtain the final value through related segment
@@ -112,14 +112,14 @@ namespace Opm {
             }
 
             int segment_number;
-            if (record.getItem<ParserKeywords::COMPSEGS::SEGMENT_NUMBER>().hasValue(0)) {
-                segment_number = record.getItem<ParserKeywords::COMPSEGS::SEGMENT_NUMBER>().get< int >(0);
+            if (record.getItem( "SEGMENT_NUMBER" ).hasValue(0)) {
+                segment_number = record.getItem( "SEGMENT_NUMBER" ).get< int >(0);
             } else {
                 segment_number = 0;
                 // will decide the segment number based on the distance in a process later.
             }
 
-            if (!record.getItem<ParserKeywords::COMPSEGS::END_IJK>().hasValue(0)) { // only one compsegs
+            if (!record.getItem( "END_IJK" ).hasValue(0)) { // only one compsegs
                 compsegs.emplace_back( I, J, K,
                                        branch,
                                        distance_start, distance_end,

--- a/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
@@ -28,18 +28,18 @@ namespace Opm {
     class TimeMap;
 
     struct MLimits {
-        int message_print_limit = ParserKeywords::MESSAGES::MESSAGE_PRINT_LIMIT::defaultValue;
-        int comment_print_limit = ParserKeywords::MESSAGES::COMMENT_PRINT_LIMIT::defaultValue;
-        int warning_print_limit = ParserKeywords::MESSAGES::WARNING_PRINT_LIMIT::defaultValue;
-        int problem_print_limit = ParserKeywords::MESSAGES::PROBLEM_PRINT_LIMIT::defaultValue;
-        int error_print_limit   = ParserKeywords::MESSAGES::ERROR_PRINT_LIMIT::defaultValue;
-        int bug_print_limit     = ParserKeywords::MESSAGES::BUG_PRINT_LIMIT::defaultValue;
-        int message_stop_limit  = ParserKeywords::MESSAGES::MESSAGE_STOP_LIMIT::defaultValue;
-        int comment_stop_limit  = ParserKeywords::MESSAGES::COMMENT_STOP_LIMIT::defaultValue;
-        int warning_stop_limit  = ParserKeywords::MESSAGES::WARNING_STOP_LIMIT::defaultValue;
-        int problem_stop_limit  = ParserKeywords::MESSAGES::PROBLEM_STOP_LIMIT::defaultValue;
-        int error_stop_limit    = ParserKeywords::MESSAGES::ERROR_STOP_LIMIT::defaultValue;
-        int bug_stop_limit      = ParserKeywords::MESSAGES::BUG_STOP_LIMIT::defaultValue;
+        int message_print_limit = 1000000;
+        int comment_print_limit = 1000000;
+        int warning_print_limit = 10000;
+        int problem_print_limit = 100;
+        int error_print_limit   = 100;
+        int bug_print_limit     = 100;
+        int message_stop_limit  = 1000000;
+        int comment_stop_limit  = 1000000;
+        int warning_stop_limit  = 10000;
+        int problem_stop_limit  = 100;
+        int error_stop_limit    = 10;
+        int bug_stop_limit      = 1;
 
 
         bool operator==(const MLimits& other) const {

--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -290,7 +290,7 @@ namespace Opm {
 
     void Schedule::handleCOMPORD(const ParseContext& parseContext, const DeckKeyword& compordKeyword, size_t /* currentStep */) {
         for (const auto& record : compordKeyword) {
-            const auto& methodItem = record.getItem<ParserKeywords::COMPORD::ORDER_TYPE>();
+            const auto& methodItem = record.getItem( "ORDER_TYPE" );
             if ((methodItem.get< std::string >(0) != "TRACK")  && (methodItem.get< std::string >(0) != "INPUT")) {
                 std::string msg = "The COMPORD keyword only handles 'TRACK' or 'INPUT' order.";
                 m_messages.error(msg);
@@ -1359,12 +1359,12 @@ namespace Opm {
                         : -1.0;
 
         bool allowCrossFlow = true;
-        const std::string& allowCrossFlowStr = record.getItem<ParserKeywords::WELSPECS::CROSSFLOW>().getTrimmedString(0);
+        const std::string& allowCrossFlowStr = record.getItem( "CROSSFLOW" ).getTrimmedString(0);
         if (allowCrossFlowStr == "NO")
             allowCrossFlow = false;
 
         bool automaticShutIn = true;
-        const std::string& automaticShutInStr = record.getItem<ParserKeywords::WELSPECS::AUTO_SHUTIN>().getTrimmedString(0);
+        const std::string& automaticShutInStr = record.getItem( "AUTO_SHUTIN" ).getTrimmedString(0);
         if (automaticShutInStr == "STOP") {
             automaticShutIn = false;
         }

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/GeomodifierTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/GeomodifierTests.cpp
@@ -89,20 +89,20 @@ BOOST_AUTO_TEST_CASE( CheckUnsoppertedInSCHEDULE ) {
 
         const Deck& multflt_deck = schedule.getModifierDeck(2);
         BOOST_CHECK_EQUAL( 2U , multflt_deck.size());
-        BOOST_CHECK( multflt_deck.hasKeyword<ParserKeywords::MULTFLT>() );
+        BOOST_CHECK( multflt_deck.hasKeyword( "MULTFLT" ) );
 
         const auto& multflt1 = multflt_deck.getKeyword(0);
         BOOST_CHECK_EQUAL( 1U , multflt1.size( ) );
 
         const auto& record0 = multflt1.getRecord( 0 );
-        BOOST_CHECK_EQUAL( 100.0  , record0.getItem<ParserKeywords::MULTFLT::factor>().get< double >(0));
-        BOOST_CHECK_EQUAL( "F1" , record0.getItem<ParserKeywords::MULTFLT::fault>().get< std::string >(0));
+        BOOST_CHECK_EQUAL( 100.0  , record0.getItem( "factor" ).get< double >(0));
+        BOOST_CHECK_EQUAL( "F1" ,   record0.getItem( "fault" ).get< std::string >(0));
 
         const auto& multflt2 = multflt_deck.getKeyword(1);
         BOOST_CHECK_EQUAL( 1U , multflt2.size( ) );
 
         const auto& record1 = multflt2.getRecord( 0 );
-        BOOST_CHECK_EQUAL( 77.0  , record1.getItem<ParserKeywords::MULTFLT::factor>().get< double >(0));
-        BOOST_CHECK_EQUAL( "F2" , record1.getItem<ParserKeywords::MULTFLT::fault>().get< std::string >(0));
+        BOOST_CHECK_EQUAL( 77.0  , record1.getItem( "factor" ).get< double >(0));
+        BOOST_CHECK_EQUAL( "F2" ,  record1.getItem( "fault" ).get< std::string >(0));
     }
 }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.cpp
@@ -55,17 +55,17 @@ namespace Opm {
     {
         if (Section::hasRUNSPEC(deck)) {
             const RUNSPECSection runspec(deck);
-            if (runspec.hasKeyword<ParserKeywords::CPR>()) {
-                const auto& cpr = runspec.getKeyword<ParserKeywords::CPR>();
+            if( runspec.hasKeyword( "CPR" ) ) {
+                const auto& cpr = runspec.getKeyword( "CPR" );
                 if (cpr.size() > 0)
                     throw std::invalid_argument("ERROR: In the RUNSPEC section the CPR keyword should EXACTLY one empty record.");
 
                 m_useCPR = true;
             }
-            if (runspec.hasKeyword<ParserKeywords::DISGAS>()) {
+            if( runspec.hasKeyword( "DISGAS" ) ) {
                 m_DISGAS = true;
             }
-            if (runspec.hasKeyword<ParserKeywords::VAPOIL>()) {
+            if( runspec.hasKeyword( "VAPOIL" ) ) {
                 m_VAPOIL = true;
             }
         }

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.cpp
@@ -39,13 +39,13 @@ namespace Opm {
         SOLUTIONSection solutionSection( deck );
 
         bool       thpresOption     = false;
-        const bool thpresKeyword    = solutionSection.hasKeyword<ParserKeywords::THPRES>();
+        const bool thpresKeyword    = solutionSection.hasKeyword( "THPRES" );
         const bool hasEqlnumKeyword = eclipseProperties.hasDeckIntGridProperty( "EQLNUM" );
         int        maxEqlnum        = 0;
 
         //Is THPRES option set?
-        if( runspecSection.hasKeyword<ParserKeywords::EQLOPTS>() ) {
-            const auto& eqlopts = runspecSection.getKeyword<ParserKeywords::EQLOPTS>( );
+        if( runspecSection.hasKeyword( "EQLOPTS" ) ) {
+            const auto& eqlopts = runspecSection.getKeyword( "EQLOPTS" );
             const auto& rec = eqlopts.getRecord(0);
             for( const auto& item : rec ) {
                 if( !item.hasValue( 0 ) ) continue;
@@ -82,12 +82,12 @@ namespace Opm {
 
 
             // Fill threshold pressure table.
-            const auto& thpres = solutionSection.getKeyword<ParserKeywords::THPRES>( );
+            const auto& thpres = solutionSection.getKeyword( "THPRES" );
 
             for( const auto& rec : thpres ) {
-                const auto& region1Item = rec.getItem<ParserKeywords::THPRES::REGION1>();
-                const auto& region2Item = rec.getItem<ParserKeywords::THPRES::REGION2>();
-                const auto& thpressItem = rec.getItem<ParserKeywords::THPRES::VALUE>();
+                const auto& region1Item = rec.getItem( "REGION1" );
+                const auto& region2Item = rec.getItem( "REGION2" );
+                const auto& thpressItem = rec.getItem( "VALUE" );
 
                 if( !region1Item.hasValue( 0 ) || !region2Item.hasValue( 0 ) )
                     throw std::runtime_error("Missing region data for use of the THPRES keyword");

--- a/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
+++ b/opm/parser/eclipse/EclipseState/SimulationConfig/tests/SimulationConfigTest.cpp
@@ -176,13 +176,13 @@ BOOST_AUTO_TEST_CASE(SimulationConfigCPRBoth) {
     BOOST_CHECK(  simulationConfig.useCPR());
     BOOST_CHECK(  summary.hasKeyword("CPR"));
 
-    const auto& cpr = summary.getKeyword<ParserKeywords::CPR>();
+    const auto& cpr = summary.getKeyword( "CPR" );
     const auto& record = cpr.getRecord(0);
     BOOST_CHECK_EQUAL( 1 , cpr.size());
-    BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::WELL>().get< std::string >(0) , "well1");
-    BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::I>().get< int >(0) , 10);
-    BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::J>().get< int >(0) , 20);
-    BOOST_CHECK_EQUAL( record.getItem<ParserKeywords::CPR::K>().get< int >(0) , 30);
+    BOOST_CHECK_EQUAL( record.getItem( "WELL" ).get< std::string >(0) , "well1");
+    BOOST_CHECK_EQUAL( record.getItem( "I" ).get< int >(0) , 10);
+    BOOST_CHECK_EQUAL( record.getItem( "J" ).get< int >(0) , 20);
+    BOOST_CHECK_EQUAL( record.getItem( "K" ).get< int >(0) , 30);
 }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Eqldims.hpp
@@ -32,11 +32,11 @@ namespace Opm {
     public:
 
         Eqldims() :
-            m_ntequl( ParserKeywords::EQLDIMS::NTEQUL::defaultValue ),
-            m_depth_nodes_p( ParserKeywords::EQLDIMS::DEPTH_NODES_P::defaultValue ),
-            m_depth_nodes_tab( ParserKeywords::EQLDIMS::DEPTH_NODES_TAB::defaultValue ),
-            m_nttrvd(  ParserKeywords::EQLDIMS::NTTRVD::defaultValue ),
-            m_nstrvd(  ParserKeywords::EQLDIMS::NSTRVD::defaultValue )
+            m_ntequl( 1 ),
+            m_depth_nodes_p( 100 ),
+            m_depth_nodes_tab( 20 ),
+            m_nttrvd( 1 ),
+            m_nstrvd( 20 )
         { }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Regdims.hpp
@@ -32,11 +32,11 @@ namespace Opm {
     public:
 
         Regdims() :
-            m_NTFIP( ParserKeywords::REGDIMS::NTFIP::defaultValue ),
-            m_NMFIPR( ParserKeywords::REGDIMS::NMFIPR::defaultValue ),
-            m_NRFREG( ParserKeywords::REGDIMS::NRFREG::defaultValue ),
-            m_NTFREG( ParserKeywords::REGDIMS::NTFREG::defaultValue ),
-            m_NPLMIX( ParserKeywords::REGDIMS::NPLMIX::defaultValue )
+            m_NTFIP(  1 ),
+            m_NMFIPR( 1 ),
+            m_NRFREG( 0 ),
+            m_NTFREG( 0 ),
+            m_NPLMIX( 1 )
         { }
 
         Regdims(size_t ntfip , size_t nmfipr , size_t nrfregr , size_t ntfreg , size_t nplmix) :

--- a/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -40,12 +40,12 @@ namespace Opm {
           internalize the most common items.
         */
         Tabdims() :
-            m_ntsfun( ParserKeywords::TABDIMS::NTSFUN::defaultValue ),
-            m_ntpvt( ParserKeywords::TABDIMS::NTPVT::defaultValue ),
-            m_nssfun( ParserKeywords::TABDIMS::NSSFUN::defaultValue ),
-            m_nppvt(  ParserKeywords::TABDIMS::NPPVT::defaultValue ),
-            m_ntfip(  ParserKeywords::TABDIMS::NTFIP::defaultValue ),
-            m_nrpvt(  ParserKeywords::TABDIMS::NRPVT::defaultValue )
+            m_ntsfun( 1 ),
+            m_ntpvt(  1 ),
+            m_nssfun( 20 ),
+            m_nppvt(  20 ),
+            m_ntfip(  1 ),
+            m_nrpvt(  20 )
         { }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -17,17 +17,8 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/V.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/M.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/P.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/T.hpp>
-#include <opm/parser/eclipse/Parser/ParserKeywords/V.hpp>
 
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp> // Phase::PhaseEnum
 #include <opm/parser/eclipse/EclipseState/Tables/EnkrvdTable.hpp>
@@ -92,29 +83,28 @@ namespace Opm {
     }
 
     void TableManager::initDims(const Deck& deck) {
-        using namespace Opm::ParserKeywords;
 
-        if (deck.hasKeyword<EQLDIMS>()) {
-            const auto& keyword = deck.getKeyword<EQLDIMS>();
+        if( deck.hasKeyword( "EQLDIMS" ) ) {
+            const auto& keyword = deck.getKeyword( "EQLDIMS" );
             const auto& record = keyword.getRecord(0);
-            int ntsequl   = record.getItem<EQLDIMS::NTEQUL>().get< int >(0);
-            int nodes_p   = record.getItem<EQLDIMS::DEPTH_NODES_P>().get< int >(0);
-            int nodes_tab = record.getItem<EQLDIMS::DEPTH_NODES_TAB>().get< int >(0);
-            int nttrvd    = record.getItem<EQLDIMS::NTTRVD>().get< int >(0);
-            int ntsrvd    = record.getItem<EQLDIMS::NSTRVD>().get< int >(0);
+            int ntsequl   = record.getItem( "NTEQUL" ).get< int >(0);
+            int nodes_p   = record.getItem( "DEPTH_NODES_P" ).get< int >(0);
+            int nodes_tab = record.getItem( "DEPTH_NODES_TAB" ).get< int >(0);
+            int nttrvd    = record.getItem( "NTTRVD" ).get< int >(0);
+            int ntsrvd    = record.getItem( "NSTRVD" ).get< int >(0);
 
             m_eqldims = std::make_shared<Eqldims>(ntsequl , nodes_p , nodes_tab , nttrvd , ntsrvd );
         } else
             m_eqldims = std::make_shared<Eqldims>();
 
-        if (deck.hasKeyword<REGDIMS>()) {
-            const auto& keyword = deck.getKeyword<REGDIMS>();
+        if( deck.hasKeyword( "REGDIMS" ) ) {
+            const auto& keyword = deck.getKeyword( "REGDIMS" );
             const auto& record = keyword.getRecord(0);
-            int ntfip  = record.getItem<REGDIMS::NTFIP>().get< int >(0);
-            int nmfipr = record.getItem<REGDIMS::NMFIPR>().get< int >(0);
-            int nrfreg = record.getItem<REGDIMS::NRFREG>().get< int >(0);
-            int ntfreg = record.getItem<REGDIMS::NTFREG>().get< int >(0);
-            int nplmix = record.getItem<REGDIMS::NPLMIX>().get< int >(0);
+            int ntfip  = record.getItem( "NTFIP" ).get< int >(0);
+            int nmfipr = record.getItem( "NMFIPR" ).get< int >(0);
+            int nrfreg = record.getItem( "NRFREG" ).get< int >(0);
+            int ntfreg = record.getItem( "NTFREG" ).get< int >(0);
+            int nplmix = record.getItem( "NPLMIX" ).get< int >(0);
             m_regdims = std::make_shared<Regdims>( ntfip , nmfipr , nrfreg , ntfreg , nplmix );
         } else
             m_regdims = std::make_shared<Regdims>();
@@ -189,40 +179,51 @@ namespace Opm {
         addTables( "RVVD", m_eqldims->getNumEquilRegions());
 
         {
-            size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
-            if (deck.hasKeyword<ParserKeywords::MISCIBLE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::MISCIBLE>();
+            size_t numMiscibleTables = 1; // NTMISC default value
+            if( deck.hasKeyword( "MISCIBLE" ) ) {
+                const auto& keyword = deck.getKeyword( "MISCIBLE" );
                 const auto& record = keyword.getRecord(0);
-                numMiscibleTables =  static_cast<size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
+                numMiscibleTables =  record.getItem( "NTMISC" ).get< int >( 0 );
             }
             addTables( "SORWMIS", numMiscibleTables);
             addTables( "SGCWMIS", numMiscibleTables);
             addTables( "MISC",    numMiscibleTables);
             addTables( "PMISC",   numMiscibleTables);
             addTables( "TLPMIXPA",numMiscibleTables);
+
+            initSimpleTableContainer<SorwmisTable>(deck, "SORWMIS", numMiscibleTables);
+            initSimpleTableContainer<SgcwmisTable>(deck, "SGCWMIS", numMiscibleTables);
+            initSimpleTableContainer<MiscTable>(deck, "MISC", numMiscibleTables);
+            initSimpleTableContainer<PmiscTable>(deck, "PMISC", numMiscibleTables);
+            initSimpleTableContainer<TlpmixpaTable>(deck, "TLPMIXPA", numMiscibleTables);
         }
 
         {
-            size_t numEndScaleTables = ParserKeywords::ENDSCALE::NUM_TABLES::defaultValue;
+            size_t numEndScaleTables = 1;// NUM_TABLES default value
 
-            if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ENDSCALE>();
+            if( deck.hasKeyword( "ENDSCALE" ) ) {
+                const auto& keyword = deck.getKeyword( "ENDSCALE" );
                 const auto& record = keyword.getRecord(0);
-                numEndScaleTables = static_cast<size_t>(record.getItem<ParserKeywords::ENDSCALE::NUM_TABLES>().get< int >(0));
+                numEndScaleTables = record.getItem( "NUM_TABLES" ).get< int >( 0 );
             }
 
             addTables( "ENKRVD", numEndScaleTables);
             addTables( "ENPTVD", numEndScaleTables);
             addTables( "IMKRVD", numEndScaleTables);
             addTables( "IMPTVD", numEndScaleTables);
+
+            initSimpleTableContainer<EnkrvdTable>( deck, "ENKRVD", numEndScaleTables );
+            initSimpleTableContainer<EnptvdTable>( deck, "ENPTVD", numEndScaleTables );
+            initSimpleTableContainer<ImkrvdTable>( deck, "IMKRVD", numEndScaleTables );
+            initSimpleTableContainer<ImptvdTable>( deck, "IMPTVD", numEndScaleTables );
         }
         {
-            size_t numRocktabTables = ParserKeywords::ROCKCOMP::NTROCC::defaultValue;
+            size_t numRocktabTables = 1;// NTROCC default value
 
-            if (deck.hasKeyword<ParserKeywords::ROCKCOMP>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ROCKCOMP>();
+            if( deck.hasKeyword( "ROCKCOMP" ) ) {
+                const auto& keyword = deck.getKeyword( "ROCKCOMP" );
                 const auto& record = keyword.getRecord(0);
-                numRocktabTables = static_cast<size_t>(record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0));
+                numRocktabTables = record.getItem( "NTROCC" ).get< int >( 0 );
             }
             addTables( "ROCKTAB", numRocktabTables);
         }
@@ -241,35 +242,6 @@ namespace Opm {
 
         initSimpleTableContainer<RsvdTable>(deck, "RSVD" , m_eqldims->getNumEquilRegions());
         initSimpleTableContainer<RvvdTable>(deck, "RVVD" , m_eqldims->getNumEquilRegions());
-        {
-            size_t numEndScaleTables = ParserKeywords::ENDSCALE::NUM_TABLES::defaultValue;
-
-            if (deck.hasKeyword<ParserKeywords::ENDSCALE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::ENDSCALE>();
-                const auto& record = keyword.getRecord(0);
-                numEndScaleTables = static_cast<size_t>(record.getItem<ParserKeywords::ENDSCALE::NUM_TABLES>().get< int >(0));
-            }
-
-            initSimpleTableContainer<EnkrvdTable>( deck , "ENKRVD", numEndScaleTables);
-            initSimpleTableContainer<EnptvdTable>( deck , "ENPTVD", numEndScaleTables);
-            initSimpleTableContainer<ImkrvdTable>( deck , "IMKRVD", numEndScaleTables);
-            initSimpleTableContainer<ImptvdTable>( deck , "IMPTVD", numEndScaleTables);
-        }
-
-        {
-            size_t numMiscibleTables = ParserKeywords::MISCIBLE::NTMISC::defaultValue;
-            if (deck.hasKeyword<ParserKeywords::MISCIBLE>()) {
-                const auto& keyword = deck.getKeyword<ParserKeywords::MISCIBLE>();
-                const auto& record = keyword.getRecord(0);
-                numMiscibleTables =  static_cast<size_t>(record.getItem<ParserKeywords::MISCIBLE::NTMISC>().get< int >(0));
-            }
-            initSimpleTableContainer<SorwmisTable>(deck, "SORWMIS", numMiscibleTables);
-            initSimpleTableContainer<SgcwmisTable>(deck, "SGCWMIS", numMiscibleTables);
-            initSimpleTableContainer<MiscTable>(deck, "MISC", numMiscibleTables);
-            initSimpleTableContainer<PmiscTable>(deck, "PMISC", numMiscibleTables);
-            initSimpleTableContainer<TlpmixpaTable>(deck, "TLPMIXPA", numMiscibleTables);
-
-        }
 
         initSimpleTableContainer<PvdgTable>(deck, "PVDG", m_tabdims.getNumPVTTables());
         initSimpleTableContainer<PvdoTable>(deck, "PVDO", m_tabdims.getNumPVTTables());
@@ -287,7 +259,6 @@ namespace Opm {
         initRocktabTables(deck);
         initPlyshlogTables(deck);
     }
-
 
     void TableManager::initRTempTables(const Deck& deck) {
         // the temperature vs depth table. the problem here is that
@@ -374,7 +345,7 @@ namespace Opm {
             return;
         }
 
-        const auto& keyword = deck.getKeyword<ParserKeywords::PLYROCK>();
+        const auto& keyword = deck.getKeyword( "PLYROCK" );
         auto& container = forceGetTables(keywordName , numTables);
         for (size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord( tableIdx );
@@ -396,7 +367,7 @@ namespace Opm {
             return;
         }
 
-        const auto& keyword = deck.getKeyword<ParserKeywords::PLYMAX>();
+        const auto& keyword = deck.getKeyword( "PLYMAX" );
         auto& container = forceGetTables(keywordName , numTables);
         for (size_t tableIdx = 0; tableIdx < keyword.size(); ++tableIdx) {
             const auto& tableRecord = keyword.getRecord( tableIdx );
@@ -415,18 +386,18 @@ namespace Opm {
             complainAboutAmbiguousKeyword(deck, "ROCKTAB");
             return;
         }
-        const auto& rockcompKeyword = deck.getKeyword<ParserKeywords::ROCKCOMP>();
+        const auto& rockcompKeyword = deck.getKeyword( "ROCKCOMP" );
         const auto& record = rockcompKeyword.getRecord( 0 );
-        size_t numTables = record.getItem<ParserKeywords::ROCKCOMP::NTROCC>().get< int >(0);
+        size_t numTables = record.getItem( "NTROCC" ).get< int >(0);
         auto& container = forceGetTables("ROCKTAB" , numTables);
         const auto rocktabKeyword = deck.getKeyword("ROCKTAB");
 
-        bool isDirectional = deck.hasKeyword<ParserKeywords::RKTRMDIR>();
+        bool isDirectional = deck.hasKeyword( "RKTRMDIR" );
         bool useStressOption = false;
-        if (deck.hasKeyword<ParserKeywords::ROCKOPTS>()) {
-            const auto rockoptsKeyword = deck.getKeyword<ParserKeywords::ROCKOPTS>();
+        if( deck.hasKeyword( "ROCKOPTS" ) ) {
+            const auto rockoptsKeyword = deck.getKeyword( "ROCKOPTS" );
             const auto& rockoptsRecord = rockoptsKeyword.getRecord(0);
-            const auto& item = rockoptsRecord.getItem<ParserKeywords::ROCKOPTS::METHOD>();
+            const auto& item = rockoptsRecord.getItem( "METHOD" );
             useStressOption = (item.getTrimmedString(0) == "STRESS");
         }
 
@@ -444,12 +415,12 @@ namespace Opm {
 
     void TableManager::initVFPProdTables(const Deck& deck,
                                           std::map<int, VFPProdTable>& tableMap) {
-        if (!deck.hasKeyword(ParserKeywords::VFPPROD::keywordName)) {
-            return;
-        }
 
-        int num_tables = deck.count(ParserKeywords::VFPPROD::keywordName);
-        const auto& keywords = deck.getKeywordList<ParserKeywords::VFPPROD>();
+        if( !deck.hasKeyword( "VFPPROD" ) )
+            return;
+
+        int num_tables = deck.count( "VFPPROD" );
+        const auto& keywords = deck.getKeywordList( "VFPPROD" );
         const auto& unit_system = deck.getActiveUnitSystem();
         for (int i=0; i<num_tables; ++i) {
             const auto& keyword = *keywords[i];
@@ -471,12 +442,11 @@ namespace Opm {
 
     void TableManager::initVFPInjTables(const Deck& deck,
                                         std::map<int, VFPInjTable>& tableMap) {
-        if (!deck.hasKeyword(ParserKeywords::VFPINJ::keywordName)) {
+        if( !deck.hasKeyword( "VFPINJ" ) )
             return;
-        }
 
-        int num_tables = deck.count(ParserKeywords::VFPINJ::keywordName);
-        const auto& keywords = deck.getKeywordList<ParserKeywords::VFPINJ>();
+        int num_tables = deck.count( "VFPINJ" );
+        const auto& keywords = deck.getKeywordList( "VFPINJ" );
         const auto& unit_system = deck.getActiveUnitSystem();
         for (int i=0; i<num_tables; ++i) {
             const auto& keyword = *keywords[i];

--- a/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -472,12 +472,12 @@ PlyshlogTable::PlyshlogTable(
         const DeckRecord& dataRecord ) {
 
     {
-        const auto& item = indexRecord.getItem<ParserKeywords::PLYSHLOG::REF_POLYMER_CONCENTRATION>();
+        const auto& item = indexRecord.getItem( "REF_POLYMER_CONCENTRATION" );
         setRefPolymerConcentration(item.get< double >(0));
     }
 
     {
-        const auto& item = indexRecord.getItem<ParserKeywords::PLYSHLOG::REF_SALINITY>();
+        const auto& item = indexRecord.getItem( "REF_SALINITY" );
         if (item.hasValue(0)) {
             setHasRefSalinity(true);
             setRefSalinity(item.get< double >(0));
@@ -486,7 +486,7 @@ PlyshlogTable::PlyshlogTable(
     }
 
     {
-        const auto& item = indexRecord.getItem<ParserKeywords::PLYSHLOG::REF_TEMPERATURE>();
+        const auto& item = indexRecord.getItem( "REF_TEMPERATURE" );
         if (item.hasValue(0)) {
             setHasRefTemperature(true);
             setRefTemperature(item.get< double >(0));
@@ -497,7 +497,7 @@ PlyshlogTable::PlyshlogTable(
     m_schema.addColumn( ColumnSchema("WaterVelocity"   , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE));
     m_schema.addColumn( ColumnSchema("ShearMultiplier" , Table::RANDOM , Table::DEFAULT_NONE));
 
-    SimpleTable::init( dataRecord.getItem<ParserKeywords::PLYSHLOG::DATA>() );
+    SimpleTable::init( dataRecord.getItem( "DATA" ) );
 }
 
 double PlyshlogTable::getRefPolymerConcentration() const {
@@ -578,7 +578,7 @@ const TableColumn& WatvisctTable::getWaterViscosityColumn() const {
 } 
 
 GasvisctTable::GasvisctTable( const Deck& deck, const DeckItem& deckItem ) {
-    int numComponents = deck.getKeyword<ParserKeywords::COMPS>().getRecord(0).getItem(0).get< int >(0);
+    int numComponents = deck.getKeyword( "COMPS" ).getRecord(0).getItem(0).get< int >(0);
 
     auto temperatureDimension = deck.getActiveUnitSystem().getDimension("Temperature");
     auto viscosityDimension = deck.getActiveUnitSystem().getDimension("Viscosity");

--- a/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/VFPProdTable.cpp
@@ -158,8 +158,6 @@ void VFPProdTable::init(int table_num,
 }
 
 void VFPProdTable::init( const DeckKeyword& table, const UnitSystem& deck_unit_system) {
-    using ParserKeywords::VFPPROD;
-
     //Check that the table has enough records
     if (table.size() < 7) {
         throw std::invalid_argument("VFPPROD table does not appear to have enough records to be valid");
@@ -169,25 +167,25 @@ void VFPProdTable::init( const DeckKeyword& table, const UnitSystem& deck_unit_s
     const auto& header = table.getRecord(0);
 
     //Get the different header items
-    m_table_num   = header.getItem<VFPPROD::TABLE>().get< int >(0);
-    m_datum_depth = header.getItem<VFPPROD::DATUM_DEPTH>().getSIDouble(0);
+    m_table_num   = header.getItem( "TABLE" ).get< int >(0);
+    m_datum_depth = header.getItem( "DATUM_DEPTH" ).getSIDouble(0);
 
-    m_flo_type = Opm::getFloType(header.getItem<VFPPROD::RATE_TYPE>());
-    m_wfr_type = Opm::getWFRType(header.getItem<VFPPROD::WFR>());
-    m_gfr_type = Opm::getGFRType(header.getItem<VFPPROD::GFR>());
+    m_flo_type = Opm::getFloType(header.getItem( "RATE_TYPE" ));
+    m_wfr_type = Opm::getWFRType(header.getItem( "WFR" ));
+    m_gfr_type = Opm::getGFRType(header.getItem( "GFR" ));
 
     //Not used, but check that PRESSURE_DEF is indeed THP
-    std::string quantity_string = header.getItem<VFPPROD::PRESSURE_DEF>().get< std::string >(0);
+    std::string quantity_string = header.getItem( "PRESSURE_DEF" ).get< std::string >(0);
     if (quantity_string != "THP") {
         throw std::invalid_argument("PRESSURE_DEF is required to be THP");
     }
 
-    m_alq_type = Opm::getALQType(header.getItem<VFPPROD::ALQ_DEF>());
+    m_alq_type = Opm::getALQType(header.getItem( "ALQ_DEF" ));
 
     //Check units used for this table
     std::string units_string = "";
-    if (header.getItem<VFPPROD::UNITS>().hasValue(0)) {
-        units_string = header.getItem<VFPPROD::UNITS>().get< std::string >(0);
+    if( header.getItem( "UNITS" ).hasValue(0) ) {
+        units_string = header.getItem( "UNITS" ).get< std::string >(0);
     }
     else {
         //If units does not exist in record, the default value is the
@@ -223,7 +221,7 @@ void VFPProdTable::init( const DeckKeyword& table, const UnitSystem& deck_unit_s
     }
 
     //Quantity in the body of the table
-    std::string body_string = header.getItem<VFPPROD::BODY_DEF>().get< std::string >(0);
+    std::string body_string = header.getItem( "BODY_DEF" ).get< std::string >(0);
     if (body_string == "TEMP") {
         throw std::invalid_argument("Invalid BODY_DEF string: TEMP not supported");
     }
@@ -236,23 +234,23 @@ void VFPProdTable::init( const DeckKeyword& table, const UnitSystem& deck_unit_s
 
 
     //Get actual rate / flow values
-    m_flo_data = table.getRecord(1).getItem<VFPPROD::FLOW_VALUES>().getData< double >();
+    m_flo_data = table.getRecord(1).getItem( "FLOW_VALUES" ).getData< double >();
     convertFloToSI(m_flo_type, m_flo_data, deck_unit_system);
 
     //Get actual tubing head pressure values
-    m_thp_data = table.getRecord(2).getItem<VFPPROD::THP_VALUES>().getData< double >();
+    m_thp_data = table.getRecord(2).getItem( "THP_VALUES" ).getData< double >();
     convertTHPToSI(m_thp_data, deck_unit_system);
 
     //Get actual water fraction values
-    m_wfr_data = table.getRecord(3).getItem<VFPPROD::WFR_VALUES>().getData< double >();
+    m_wfr_data = table.getRecord(3).getItem( "WFR_VALUES" ).getData< double >();
     convertWFRToSI(m_wfr_type, m_wfr_data, deck_unit_system);
 
     //Get actual gas fraction values
-    m_gfr_data = table.getRecord(4).getItem<VFPPROD::GFR_VALUES>().getData< double >();
+    m_gfr_data = table.getRecord(4).getItem( "GFR_VALUES" ).getData< double >();
     convertGFRToSI(m_gfr_type, m_gfr_data, deck_unit_system);
 
     //Get actual gas fraction values
-    m_alq_data = table.getRecord(5).getItem<VFPPROD::ALQ_VALUES>().getData< double >();
+    m_alq_data = table.getRecord(5).getItem( "ALQ_VALUES" ).getData< double >();
     convertALQToSI(m_alq_type, m_alq_data, deck_unit_system);
 
     //Finally, read the actual table itself.
@@ -280,13 +278,13 @@ void VFPProdTable::init( const DeckKeyword& table, const UnitSystem& deck_unit_s
     for (size_t i=6; i<table.size(); ++i) {
         const auto& record = table.getRecord(i);
         //Get indices (subtract 1 to get 0-based index)
-        int t = record.getItem<VFPPROD::THP_INDEX>().get< int >(0) - 1;
-        int w = record.getItem<VFPPROD::WFR_INDEX>().get< int >(0) - 1;
-        int g = record.getItem<VFPPROD::GFR_INDEX>().get< int >(0) - 1;
-        int a = record.getItem<VFPPROD::ALQ_INDEX>().get< int >(0) - 1;
+        int t = record.getItem( "THP_INDEX" ).get< int >(0) - 1;
+        int w = record.getItem( "WFR_INDEX" ).get< int >(0) - 1;
+        int g = record.getItem( "GFR_INDEX" ).get< int >(0) - 1;
+        int a = record.getItem( "ALQ_INDEX" ).get< int >(0) - 1;
 
         //Rest of values (bottom hole pressure or tubing head temperature) have index of flo value
-        const std::vector<double>& bhp_tht = record.getItem<VFPPROD::VALUES>().getData< double >();
+        const std::vector<double>& bhp_tht = record.getItem( "VALUES" ).getData< double >();
 
         if (bhp_tht.size() != nf) {
             throw std::invalid_argument("VFPPROD table does not contain enough FLO values.");

--- a/opm/parser/eclipse/EclipseState/Tables/tests/PvtxTableTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/PvtxTableTests.cpp
@@ -54,9 +54,9 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables1 ) {
     boost::filesystem::path deckFile("testdata/integration_tests/TABLES/PVTX1.DATA");
     ParseContext parseContext;
     auto deck =  parser.parseFile(deckFile.string(), parseContext);
-    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>()) , 1);
+    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword( "PVTO" )) , 1);
 
-    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
+    auto ranges = PvtxTable::recordRanges( deck.getKeyword( "PVTO" ) );
     auto range = ranges[0];
     BOOST_CHECK_EQUAL( range.first , 0 );
     BOOST_CHECK_EQUAL( range.second , 2 );
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables2 ) {
     boost::filesystem::path deckFile("testdata/integration_tests/TABLES/PVTO2.DATA");
     ParseContext parseContext;
     auto deck =  parser.parseFile(deckFile.string(), parseContext);
-    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword<ParserKeywords::PVTO>()) , 3);
+    BOOST_CHECK_EQUAL( PvtxTable::numTables( deck.getKeyword( "PVTO" )) , 3);
 
-    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
+    auto ranges = PvtxTable::recordRanges( deck.getKeyword( "PVTO" ) );
     auto range1 = ranges[0];
     BOOST_CHECK_EQUAL( range1.first , 0 );
     BOOST_CHECK_EQUAL( range1.second , 41 );
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE( PvtxNumTables3 ) {
     Opm::Parser parser;
     auto deck = parser.parseString(deckData, Opm::ParseContext());
 
-    auto ranges = PvtxTable::recordRanges( deck.getKeyword<ParserKeywords::PVTO>() );
+    auto ranges = PvtxTable::recordRanges( deck.getKeyword( "PVTO" ) );
     BOOST_CHECK_EQUAL( 2 ,ranges.size() );
 
     auto range1 = ranges[0];

--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -665,7 +665,7 @@ bool parseState( ParserState& parserState, const Parser& parser ) {
         if( !ParserKeyword::validDeckName( name ) )
             return false;
 
-        if( m_deckParserKeywords.count( name ) )
+        if( m_deckParserKeywords.count( name.string() ) )
             return true;
 
         return bool( matchingKeyword( name ) );

--- a/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserKeywordTests.cpp
@@ -302,7 +302,7 @@ BOOST_AUTO_TEST_CASE(AddDataKeywordFromJson_correctlyConfigured) {
     BOOST_CHECK( parserKeyword->hasFixedSize( ) );
     BOOST_CHECK_EQUAL(1U , parserKeyword->getFixedSize() );
 
-    BOOST_CHECK_EQUAL( item.name() , ParserKeywords::ACTNUM::data::itemName );
+    BOOST_CHECK_EQUAL( item.name() , "data" );
     BOOST_CHECK_EQUAL( ParserItem::item_size::ALL, item.sizeType() );
 }
 

--- a/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
+++ b/opm/parser/eclipse/Units/tests/COMPSEGUnits.cpp
@@ -46,9 +46,9 @@ inline Deck createCOMPSEGSDeck() {
 
 BOOST_AUTO_TEST_CASE(CreateDimension) {
     auto deck = createCOMPSEGSDeck();
-    const auto& keyword = deck.getKeyword<ParserKeywords::COMPSEGS>();
+    const auto& keyword = deck.getKeyword( "COMPSEGS" );
     const auto& record = keyword.getRecord(1);
-    BOOST_CHECK_NO_THROW( record.getItem<ParserKeywords::COMPSEGS::DISTANCE_START>().getSIDouble(0) );
+    BOOST_CHECK_NO_THROW( record.getItem( "DISTANCE_START" ).getSIDouble(0) );
 }
 
 


### PR DESCRIPTION
These definitions are hardly used and represent a significant portion of
build times. By removing them and using their string cousins instead,
which are less safe but makes the code compile faster, we also open up
for changing the form of the auto-generated code itself.