### PR TITLE
Remove pessimizing move() in return statements.

### DIFF
--- a/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -278,7 +278,7 @@ RPTRST_integer( const std::vector< int >& ints ) {
         mnemonics[ "PCOG" ] = ints[ PCO_index ];
     }
 
-    return std::move( mnemonics );
+    return mnemonics;
 }
 
 inline std::map< std::string, int >
@@ -289,7 +289,7 @@ RPTSCHED_integer( const std::vector< int >& ints ) {
     for( size_t i = 0; i < size; ++i )
         mnemonics[ SCHEDIntegerKeywords[ i ] ] = ints[ i ];
 
-    return std::move( mnemonics );
+    return mnemonics;
 }
 
 template< typename F, typename G >
@@ -328,7 +328,7 @@ inline std::map< std::string, int > RPT( const DeckKeyword& keyword,
         mnemonics.emplace( base, val );
     }
 
-    return std::move( mnemonics );
+    return mnemonics;
 }
 
 inline void expand_RPTRST_mnemonics(std::map< std::string, int >& mnemonics) {

--- a/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
@@ -77,7 +77,7 @@ static Opm::Deck createDeck() {
             "\n";
 
     Opm::Parser parser;
-    return std::move( parser.parseString(deckData, Opm::ParseContext() ) );
+    return parser.parseString(deckData, Opm::ParseContext() );
 }
 
 
@@ -116,7 +116,7 @@ static Opm::Deck createValidIntDeck() {
             "\n";
 
     Opm::Parser parser;
-    return std::move( parser.parseString(deckData, Opm::ParseContext() ) );
+    return parser.parseString(deckData, Opm::ParseContext() );
 }
 
 static Opm::Deck createValidPERMXDeck() {
@@ -162,7 +162,7 @@ static Opm::Deck createValidPERMXDeck() {
             "\n";
 
     Opm::Parser parser;
-    return std::move( parser.parseString(deckData, Opm::ParseContext() ) );
+    return parser.parseString(deckData, Opm::ParseContext() );
 }
 
 


### PR DESCRIPTION
This removes occurences of the anti-pattern of moving the return value. This prevents compile warnings on new compilers (at least clang), is simpler to read and understand, and can be faster.