### PR TITLE
Add extra braces for C++11 compilers.

### DIFF
--- a/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -738,9 +738,9 @@ namespace Opm {
     }
 
     ZcornMapper::ZcornMapper(size_t nx , size_t ny, size_t nz)
-        : dims( {nx,ny,nz} ),
-          stride( {2 , 4*nx, 8*nx*ny} ),
-          cell_shift( {0 , 1 , 2*nx , 2*nx + 1 , 4*nx*ny , 4*nx*ny + 1, 4*nx*ny + 2*nx , 4*nx*ny + 2*nx + 1 })
+        : dims( {{nx,ny,nz}} ),
+          stride( {{2 , 4*nx, 8*nx*ny}} ),
+          cell_shift( {{0 , 1 , 2*nx , 2*nx + 1 , 4*nx*ny , 4*nx*ny + 1, 4*nx*ny + 2*nx , 4*nx*ny + 2*nx + 1 }})
     {
     }
 

--- a/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/GridDims.cpp
@@ -63,7 +63,7 @@ namespace Opm {
     }
 
     const std::array<int, 3> GridDims::getNXYZ() const {
-        return std::array<int, 3> {int( m_nx ), int( m_ny ), int( m_nz )};
+        return std::array<int, 3> {{int( m_nx ), int( m_ny ), int( m_nz )}};
     }
 
     size_t GridDims::getGlobalIndex(size_t i, size_t j, size_t k) const {


### PR DESCRIPTION
With C++14 the warnings generated will probably disappear, but for now this keeps clang happy (warning-free).