### PR TITLE
REFs hack for opm-material

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -105,6 +105,54 @@ namespace Opm {
         if( deck.hasKeyword( "WATDENT" ) )
             this->m_watdentTable = WatdentTable( deck.getKeyword( "WATDENT" ) );
 
+        if( deck.hasKeyword( "THERMEX1" ) ) {
+            const auto& thermex1 = deck.getKeyword( "THERMEX1" )
+                                       .getRecord( 0 )
+                                       .getItem( 0 );
+
+                this->refs_material.THERMEX1 = thermex1.getSIDoubleData();
+        }
+
+        if( deck.hasKeyword( "TREF" ) ) {
+            const auto& thermex1 = deck.getKeyword( "TREF" )
+                                       .getRecord( 0 )
+                                       .getItem( 0 );
+
+                this->refs_material.TREF = thermex1.getSIDoubleData();
+        }
+
+        if( deck.hasKeyword( "PREF" ) ) {
+            const auto& thermex1 = deck.getKeyword( "PREF" )
+                                       .getRecord( 0 )
+                                       .getItem( 0 );
+
+                this->refs_material.PREF = thermex1.getSIDoubleData();
+        }
+
+        if( deck.hasKeyword( "CREF" ) ) {
+            const auto& thermex1 = deck.getKeyword( "CREF" )
+                                       .getRecord( 0 )
+                                       .getItem( 0 );
+
+                this->refs_material.CREF = thermex1.getSIDoubleData();
+        }
+
+        if( deck.hasKeyword( "OCOMPIDX" ) ) {
+            this->refs_material.oil_component_index =
+                 deck.getKeyword( "OCOMOPIDX" )
+                .getRecord( 0 )
+                .getItem( "OIL_COMPONENT_INDEX" )
+                .get< int >( 0 ) - 1;
+        }
+
+        if( deck.hasKeyword( "GCOMPIDX" ) ) {
+            this->refs_material.oil_component_index =
+                 deck.getKeyword( "GCOMOPIDX" )
+                .getRecord( 0 )
+                .getItem( "GAS_COMPONENT_INDEX" )
+                .get< int >( 0 ) - 1;
+        }
+
         initVFPProdTables(deck, m_vfpprodTables);
         initVFPInjTables(deck,  m_vfpinjTables);
     }
@@ -734,6 +782,10 @@ namespace Opm {
 
     MessageContainer& TableManager::getMessageContainer() {
         return m_messages;
+    }
+
+    const TableManager::REFs TableManager::get_refs_material() const {
+        return this->refs_material;
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -128,6 +128,23 @@ namespace Opm {
         const MessageContainer& getMessageContainer() const;
         MessageContainer& getMessageContainer();
 
+        /*
+         * REFs largely exists for opm-material and can change at any moment.
+         * Temperature support in parser is poor. These reference tables are
+         * used downstream, but there's no real support here. Reading REFs data
+         * is *not* recommended, until a better solution supersedes this.
+         */
+        struct REFs {
+            std::vector< double > TREF;
+            std::vector< double > PREF;
+            std::vector< double > CREF;
+            std::vector< double > THERMEX1;
+            int oil_component_index = -1;
+            int gas_component_index = -1;
+        };
+
+        const REFs get_refs_material() const;
+
     private:
         TableContainer& forceGetTables( const std::string& tableName , size_t numTables);
 
@@ -289,6 +306,8 @@ namespace Opm {
         RockTable m_rockTable;
         ViscrefTable m_viscrefTable;
         WatdentTable m_watdentTable;
+
+        REFs refs_material;
 
         Tabdims m_tabdims;
         std::shared_ptr<Regdims> m_regdims;


### PR DESCRIPTION
This is to facilitate the privatisation of the Deck object and
redefinition of the opm-parser interfaces. The opm-material module reads
the deck directly to extract temperature information, but this is
largely unsupported in opm-parser.

In order to not break downstream functionality we take ownership of
the opm-material implemented parsing of THERMX1 and friends and expose
their raw values via the REFs and get_refs_material function. This is
ONLY meant for compatibility and SHOULD NOT BE CALLED in new code.