### PR TITLE
Endscale rename

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -175,6 +175,7 @@ EclipseState/EclipseState.hpp
 EclipseState/EclipseConfig.hpp
 EclipseState/Eclipse3DProperties.hpp
 EclipseState/Runspec.hpp
+EclipseState/EndpointScaling.hpp
 #
 EclipseState/checkDeck.hpp
 #

--- a/opm/parser/eclipse/EclipseState/EndpointScaling.cpp
+++ b/opm/parser/eclipse/EclipseState/EndpointScaling.cpp
@@ -1,5 +1,5 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+#include <opm/parser/eclipse/EclipseState/EndpointScaling.hpp>
 #include <opm/parser/eclipse/Utility/String.hpp>
 
 namespace Opm {

--- a/opm/parser/eclipse/EclipseState/EndpointScaling.hpp
+++ b/opm/parser/eclipse/EclipseState/EndpointScaling.hpp
@@ -1,0 +1,56 @@
+/*
+  Copyright 2017  Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify it under the terms
+  of the GNU General Public License as published by the Free Software
+  Foundation, either version 3 of the License, or (at your option) any later
+  version.
+
+  OPM is distributed in the hope that it will be useful, but WITHOUT ANY
+  WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR
+  A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along with
+  OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef OPM_ENDPOINTSCALING_HPP
+#define OPM_ENDPOINTSCALING_HPP
+
+#include <bitset>
+
+namespace Opm {
+class Deck;
+
+
+class EndpointScaling {
+    public:
+        EndpointScaling() noexcept = default;
+        explicit EndpointScaling( const Deck& );
+
+        /* true if endpoint scaling is enabled, otherwise false */
+        operator bool() const noexcept;
+
+        bool directional() const noexcept;
+        bool nondirectional() const noexcept;
+        bool reversible() const noexcept;
+        bool irreversible() const noexcept;
+        bool twopoint() const noexcept;
+        bool threepoint() const noexcept;
+
+    private:
+        enum class option {
+            any         = 0,
+            directional = 1,
+            reversible  = 2,
+            threepoint  = 3,
+        };
+
+        using ue = std::underlying_type< option >::type;
+        std::bitset< 4 > options;
+};
+}
+
+#endif

--- a/opm/parser/eclipse/EclipseState/Runspec.cpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.cpp
@@ -80,7 +80,7 @@ const Tabdims& Runspec::tabdims() const noexcept {
     return this->m_tabdims;
 }
 
-const EndpointScaling& Runspec::endpoint_scaling() const noexcept {
+const EndpointScaling& Runspec::endpointScaling() const noexcept {
     return this->endscale;
 }
 

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -58,7 +58,7 @@ class Runspec {
 
         const Phases& phases() const noexcept;
         const Tabdims&  tabdims() const noexcept;
-        const EndpointScaling& endpoint_scaling() const noexcept;
+        const EndpointScaling& endpointScaling() const noexcept;
 
     private:
         Phases active_phases;

--- a/opm/parser/eclipse/EclipseState/Runspec.hpp
+++ b/opm/parser/eclipse/EclipseState/Runspec.hpp
@@ -19,15 +19,15 @@
 #ifndef OPM_RUNSPEC_HPP
 #define OPM_RUNSPEC_HPP
 
-#include <bitset>
 #include <iosfwd>
 #include <string>
 
 #include <opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp>
+#include <opm/parser/eclipse/EclipseState/EndpointScaling.hpp>
 
 namespace Opm {
-
 class Deck;
+
 
 enum class Phase {
     OIL     = 0,
@@ -51,35 +51,9 @@ class Phases {
         std::bitset< 4 > bits;
 };
 
-class EndpointScaling {
-    public:
-        EndpointScaling() noexcept = default;
-        explicit EndpointScaling( const Deck& );
-
-        /* true if endpoint scaling is enabled, otherwise false */
-        operator bool() const noexcept;
-
-        bool directional() const noexcept;
-        bool nondirectional() const noexcept;
-        bool reversible() const noexcept;
-        bool irreversible() const noexcept;
-        bool twopoint() const noexcept;
-        bool threepoint() const noexcept;
-
-    private:
-        enum class option {
-            any         = 0,
-            directional = 1,
-            reversible  = 2,
-            threepoint  = 3,
-        };
-
-        using ue = std::underlying_type< option >::type;
-        std::bitset< 4 > options;
-};
 
 class Runspec {
-    public:
+   public:
         explicit Runspec( const Deck& );
 
         const Phases& phases() const noexcept;

--- a/opm/parser/eclipse/EclipseState/tests/RunspecTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/RunspecTests.cpp
@@ -113,7 +113,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingWithoutENDSCALE ) {
     )";
 
     Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-    const auto& endscale = runspec.endpoint_scaling();
+    const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( !endscale );
     BOOST_CHECK( !endscale.directional() );
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingDefaulted ) {
     )";
 
     Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-    const auto& endscale = runspec.endpoint_scaling();
+    const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
     BOOST_CHECK( !endscale.directional() );
@@ -147,7 +147,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingDIRECT ) {
     )";
 
     Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-    const auto& endscale = runspec.endpoint_scaling();
+    const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
     BOOST_CHECK( endscale.directional() );
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE( EndpointScalingDIRECT_IRREVERS ) {
     )";
 
     Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-    const auto& endscale = runspec.endpoint_scaling();
+    const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
     BOOST_CHECK( endscale.directional() );
@@ -181,7 +181,7 @@ BOOST_AUTO_TEST_CASE( SCALECRS_without_ENDSCALE ) {
     )";
 
     Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-    const auto& endscale = runspec.endpoint_scaling();
+    const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( !endscale );
     BOOST_CHECK( !endscale.twopoint() );
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE( SCALECRS_N ) {
 
     for( const auto& input : { N, defaulted } ) {
         Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-        const auto& endscale = runspec.endpoint_scaling();
+        const auto& endscale = runspec.endpointScaling();
 
         BOOST_CHECK( endscale );
         BOOST_CHECK( endscale.twopoint() );
@@ -225,7 +225,7 @@ BOOST_AUTO_TEST_CASE( SCALECRS_Y ) {
     )";
 
     Runspec runspec( Parser{}.parseString( input, ParseContext{} ) );
-    const auto& endscale = runspec.endpoint_scaling();
+    const auto& endscale = runspec.endpointScaling();
 
     BOOST_CHECK( endscale );
     BOOST_CHECK( !endscale.twopoint() );


### PR DESCRIPTION
In liue of the [comment]( https://github.com/OPM/opm-parser/pull/1020#pullrequestreview-14974521) I have concluded that I merged #1020 a bit prematurely, as @andlaus commented the methodname `Runspec::endpoint_scaling()` is quite different from the main pattern in opm-parser.

Personally I find this a quite difficult subject to weigh down on.

1. A consistent codebase is obviously easier for everyone to navigate, and the information implicitly conveyed in a consistent codebase will catch bugs before they happen. 

2. Being a developer is a form of creative work - we are nearly artists; and I guess the freedom to make such slightly arbitrary choices like `Runspec::endpoint_scaling()` versus `Runspec::endpointScaling()` is valued by many of us. As developers we also change and mature; and it would be counterproductive to stick to bad decisions in the name of consistency. As @atgeirr once commented I feel there is something *fascistoid* to be said about insisting on a very uniform and consistent codebase; a *slightly* inconsistent codebase feels more alive.

But I do feel that the public name `Runspec::endpoint_scaling()` is *quite different* from the main pattern used in opm-parser, and combined with comments from @jokva which gave me the impression that he might be planning a wholesale rename, made me call for a timeout with this PR. 

Since opm-parser is (nearly) the most upstream of all modules the conventions applied here (at least in the public api) is relevant for all developers in the opm community, I would therefor be grateful if other developers mainly working downstream voiced their opinion and general thought on the matter. Observe that I do *not* hold any absolute views on whether `Runspec::endpoint_scaling()` or `Runspec::endpointScaling()` is "better". The question is mainly as @andlaus pointed out - is this a move *towards* the rest of the opm codebase, or *away* from it - and does it matter?

I have previously been slightly hostile - or at least quite uninterested - in things like common opm style guides; I am warming to the idea now. But if we are to go in that direction I think we must:

1. Have a broad discussion involving many developers; quite few of us feel any sort of ownership to the style guide found on the opm-wiki.
2. More concious separation of internal details (e.g. `m_xxx` versus `xxxx_` for private members) and the public api.
3. **Implement a solution with e.g. `cpplint` to [enforce a C++ style](http://www.ostricher.com/2014/11/use-cpplint-to-check-your-c-code-against-googles-style-guide/) as part of build testing.**
