### PR TITLE
Skip AITS and ROCKNUM

### DIFF
--- a/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -187,16 +187,19 @@ namespace Opm {
 
     static std::vector< GridProperties< int >::SupportedKeywordInfo >
     makeSupportedIntKeywords() {
-        return { GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "IMBNUM" , 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "PVTNUM" , 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "EQLNUM" , 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "ENDNUM" , 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "FLUXNUM", 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "MULTNUM", 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "FIPNUM" , 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "MISCNUM", 1, "1" ),
-                GridProperties< int >::SupportedKeywordInfo( "OPERNUM", 1, "1" ) };
+        return {
+            GridProperties< int >::SupportedKeywordInfo( "ENDNUM" , 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "EQLNUM" , 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "FIPNUM" , 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "FLUXNUM", 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "IMBNUM" , 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "MISCNUM", 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "MULTNUM", 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "OPERNUM", 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "PVTNUM" , 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "ROCKNUM", 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" )
+        };
     }
 
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.cpp
@@ -88,6 +88,17 @@ namespace Opm {
     }
 
 
+    bool Well::operator==(const Well& other) const {
+        return this->m_creationTimeStep == other.m_creationTimeStep
+            && this->m_name == other.m_name
+            && this->m_preferredPhase == other.m_preferredPhase
+            && this->timesteps == other.timesteps;
+    }
+
+    bool Well::operator!=(const Well& other) const {
+        return !(*this == other);
+    }
+
     double Well::production_rate( Phase phase, size_t timestep ) const {
         if( !this->isProducer( timestep ) ) return 0.0;
 

--- a/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -105,6 +105,9 @@ namespace Opm {
         double production_rate( Phase phase, size_t timestep ) const;
         double injection_rate( Phase phase, size_t timestep ) const;
 
+        bool operator==(const Well&) const;
+        bool operator!=(const Well&) const;
+
         bool                            setProductionProperties(size_t timeStep , const WellProductionProperties properties);
         WellProductionProperties        getProductionPropertiesCopy(size_t timeStep) const;
         const WellProductionProperties& getProductionProperties(size_t timeStep)  const;

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellTests.cpp
@@ -55,6 +55,9 @@ namespace Opm {
 inline std::ostream& operator<<( std::ostream& stream, const Completion& c ) {
     return stream << "(" << c.getI() << "," << c.getJ() << "," << c.getK() << ")";
 }
+inline std::ostream& operator<<( std::ostream& stream, const Well& well ) {
+    return stream << "(" << well.name() << ")";
+}
 }
 
 BOOST_AUTO_TEST_CASE(CreateWell_CorrectNameAndDefaultValues) {
@@ -63,6 +66,23 @@ BOOST_AUTO_TEST_CASE(CreateWell_CorrectNameAndDefaultValues) {
     BOOST_CHECK_EQUAL( "WELL1" , well.name() );
     BOOST_CHECK_EQUAL(0.0 , well.getProductionPropertiesCopy(5).OilRate);
 }
+
+BOOST_AUTO_TEST_CASE(CreateWell_Equals) {
+    auto timeMap = createXDaysTimeMap(10);
+    auto timeMap2 = createXDaysTimeMap(11);
+    Opm::Well well1("WELL1" ,  0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well2("WELL1" ,  0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well3("WELL3" ,  0, 0, 0.0, Opm::Phase::OIL, timeMap , 0);
+    Opm::Well well4("WELL3" ,  0, 0, 0.0, Opm::Phase::OIL, timeMap2 , 0);
+    BOOST_CHECK_EQUAL( well1, well1 );
+    BOOST_CHECK_EQUAL( well2, well1 );
+    BOOST_CHECK( well1 == well2 );
+    BOOST_CHECK( well1 != well3 );
+    BOOST_CHECK( well3 != well2 );
+    BOOST_CHECK( well3 == well3 );
+    BOOST_CHECK( well4 != well3 );
+}
+
 
 BOOST_AUTO_TEST_CASE(CreateWell_GetProductionPropertiesShouldReturnSameObject) {
     auto timeMap = createXDaysTimeMap(10);

--- a/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/tests/Eclipse3DPropertiesTests.cpp
@@ -74,6 +74,8 @@ static Opm::Deck createDeck() {
             "1000*1 /\n"
             "SATNUM\n"
             "1000*2 /\n"
+            "ROCKNUM\n"
+            "200*1 200*2 200*3 400*4 /\n"
             "\n";
 
     Opm::Parser parser;
@@ -194,7 +196,7 @@ BOOST_AUTO_TEST_CASE(SupportsProperty) {
     Setup s(createDeck());
     std::vector<std::string> keywordList = {
         // int props
-        "ACTNUM", "SATNUM", "IMBNUM", "PVTNUM", "EQLNUM", "ENDNUM", "FLUXNUM", "MULTNUM", "FIPNUM", "MISCNUM", "OPERNUM",
+        "ACTNUM", "SATNUM", "IMBNUM", "PVTNUM", "EQLNUM", "ENDNUM", "FLUXNUM", "MULTNUM", "FIPNUM", "MISCNUM", "OPERNUM", "ROCKNUM",
         // double props
         "TEMPI", "MULTPV", "PERMX", "permy", "PERMZ", "SWATINIT", "THCONR", "NTG"
     };
@@ -242,6 +244,25 @@ BOOST_AUTO_TEST_CASE(AddregIntSetCorrectly) {
                 BOOST_CHECK_EQUAL(21, property.iget(i, j, 0));
         }
 
+}
+
+BOOST_AUTO_TEST_CASE(RocknumTest) {
+    Setup s(createDeck());
+    const auto& rocknum = s.props.getIntGridProperty("ROCKNUM");
+    for (size_t i = 0; i < 10; i++) {
+        for (size_t j = 0; j < 10; j++) {
+            for (size_t k = 0; k < 10; k++) {
+                if (k < 2)
+                    BOOST_CHECK_EQUAL(1, rocknum.iget(i, j, k));
+                else if (k < 4)
+                    BOOST_CHECK_EQUAL(2, rocknum.iget(i, j, k));
+                else if (k < 6)
+                    BOOST_CHECK_EQUAL(3, rocknum.iget(i, j, k));
+                else
+                    BOOST_CHECK_EQUAL(4, rocknum.iget(i, j, k));
+            }
+        }
+    }
 }
 
 BOOST_AUTO_TEST_CASE(PermxUnitAppliedCorrectly) {

--- a/opm/parser/share/keywords/000_Eclipse100/A/AITS
+++ b/opm/parser/share/keywords/000_Eclipse100/A/AITS
@@ -1,0 +1,1 @@
+{"name" : "AITS", "sections" : ["RUNSPEC", "SCHEDULE"]}

--- a/opm/parser/share/keywords/000_Eclipse100/R/ROCKNUM
+++ b/opm/parser/share/keywords/000_Eclipse100/R/ROCKNUM
@@ -1,0 +1,1 @@
+{"name" : "ROCKNUM" , "sections" : ["REGIONS"], "data" : {"value_type" : "INT"}}

--- a/opm/parser/share/keywords/000_Eclipse100/W/WPAVEDEP
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WPAVEDEP
@@ -1,0 +1,4 @@
+{"name" : "WPAVEDEP" , "sections" : ["SCHEDULE"], "size" : 1 , "items" : [
+        {"name" : "WELLNAME" ,  "value_type" : "STRING"},
+        {"name" : "REFDEPTH" , "value_type" : "DOUBLE" , "default" : 0}
+]}


### PR DESCRIPTION
Commit 1.  Implements `operator==` and `operator!=` for `Well`.

Commit 2.  Parser now handles `AITS` (but ignores it).

Commit 2.  Internalize `ROCKNUM` and added test.