### PR TITLE
WIP Scaled saturation function support

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -81,6 +81,7 @@ EclipseState/EclipseConfig.cpp
 EclipseState/Eclipse3DProperties.cpp
 EclipseState/Runspec.cpp
 EclipseState/EndpointScaling.cpp
+EclipseState/saturation.cpp
 #
 EclipseState/checkDeck.cpp
 #

--- a/opm/parser/eclipse/EclipseState/Grid/tests/CMakeLists.txt
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/CMakeLists.txt
@@ -2,7 +2,8 @@ foreach(tapp EclipseGridTests MULTREGTScannerTests GridPropertyTests
              FaceDirTests GridPropertiesTests BoxTests PORVTests
              BoxManagerTests TransMultTests FaultTests
              EqualRegTests MultiRegTests ADDREGTests CopyRegTests
-             SatfuncPropertyInitializersTests)
+             SatfuncPropertyInitializersTests
+             SaturationTests)
   opm_add_test(run${tapp} SOURCES ${tapp}.cpp
                           LIBRARIES opmparser ${Boost_LIBRARIES})
 endforeach()

--- a/opm/parser/eclipse/EclipseState/Grid/tests/SaturationTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Grid/tests/SaturationTests.cpp
@@ -1,0 +1,163 @@
+#define BOOST_TEST_MODULE EclipseGridTests
+
+#include <boost/test/unit_test.hpp>
+
+#include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
+#include <opm/parser/eclipse/Parser/Parser.hpp>
+
+#include <opm/parser/eclipse/EclipseState/saturation.hpp>
+
+using namespace Opm;
+
+const std::string base_input = R"(
+RUNSPEC
+
+METRIC
+
+OIL
+GAS
+WATER
+
+-- three saturation tables to verify SATNUM region specific modifications of
+-- curves
+TABDIMS
+    3 / 
+
+DIMENS
+    7 3 5 / -- grid of distinct, all-prime dimensions, total of 105 cells
+
+ENDSCALE
+    /
+
+PROPS
+
+SWL
+    105*0.2 /
+
+SWU
+    105*0.9 /
+
+REGIONS
+
+)";
+
+const std::string base_input_end = R"(
+
+SATNUM -- evenly divided regions
+    35*1 35*2 35*3 /
+
+SOLUTION
+
+SCHEDULE
+
+)";
+
+const std::string familyI = R"(
+
+SWOF
+--  Sw      Krw     Krow     Pcow
+    0.1     0       1.0      2.0
+    0.15    0       0.9      1.0
+    0.2     0.01    0.5      0.5
+    0.93    0.91    0.0      0.0
+    /
+    0.00    0       1.0      2.0
+    0.05    0.01    1.0      2.0
+    0.15    0.03    0.5      0.5
+    0.852   1.00    0.0      0.0
+    /
+    0.00    0.00    0.9      2.0
+    0.05    0.02    0.8      1.0
+    0.10    0.03    0.5      0.5
+    0.801   1.00    0.0      0.0
+    /
+
+SGOF
+--  Sg      Krg     Kro     Pcog
+    0.00    0.00    0.9     2.0
+    0.05    0.02    0.8     1.0
+    0.10    0.03    0.5     0.5
+    0.80    1.00    0.0     0.0
+    /
+    0.05    0.00    1.0     2
+    0.10    0.02    0.9     1
+    0.15    0.03    0.5     0.5
+    0.85    1.00    0.0     0
+    /
+    0.1     0       1.0     2
+    0.15    0       0.9     1
+    0.2     0.01    0.5     0.5
+    0.9     0.91    0.0     0
+    /
+)";
+
+const std::string familyII = R"(
+SWFN
+--  Sw      Krw     Pcow
+    0.1     0       2.0
+    0.15    0       1.0
+    0.2     0.01    0.5
+    0.93    0.91    0.0
+    /
+    0.00    0       2.0
+    0.05    0.01    2.0
+    0.15    0.03    0.5
+    0.852   1.00    0.0
+    /
+    0.00    0.00    2.0
+    0.05    0.02    1.0
+    0.10    0.03    0.5
+    0.801   1.00    0.0
+    /
+
+SGFN
+--  Sg      Krg     Pcog
+    0.00    0.00    2.0
+    0.05    0.02    1.0
+    0.10    0.03    0.5
+    0.80    1.00    0.0
+    /
+    0.05    0.00    2
+    0.10    0.02    1
+    0.15    0.03    0.5
+    0.85    1.00    0
+    /
+    0.1     0       2
+    0.15    0       1
+    0.2     0.01    0.5
+    0.9     0.91    0
+    /
+
+SOF3
+--  So      Krow    Krog
+    0.07    0.0     0.0
+    0.8     0.5     0.5
+    0.85    0.9     1.0
+    0.9     1.0     2.0
+    /
+    0.148   0.0     0.0
+    0.85    0.5     0.5
+    0.05    1.0     2.0
+    1.00    1.0     2.0
+    /
+    0.199   0.0     0.0
+    0.90    0.5     0.5
+    0.95    0.8     1.0
+    1.00    0.9     2.0
+    /
+)";
+
+
+BOOST_AUTO_TEST_CASE( testsat ) {
+    Parser parser;
+    const auto inputI  = base_input + familyI  + base_input_end;
+    const auto inputII = base_input + familyII + base_input_end;
+    auto deckI = parser.parseString( inputI, ParseContext{} );
+    auto deckII = parser.parseString( inputII, ParseContext{} );
+
+    saturation satI( deckI, 3 * 5 * 7 );
+    saturation satII( deckII, 3 * 5 * 7 );
+    BOOST_CHECK( satI == satII );
+
+    BOOST_CHECK_CLOSE( 1, satI.oil_relperm( 0, 0.24217 ), 1e-5 );
+}

--- a/opm/parser/eclipse/EclipseState/saturation.cpp
+++ b/opm/parser/eclipse/EclipseState/saturation.cpp
@@ -1,0 +1,255 @@
+#include <iostream>
+
+#include <opm/parser/eclipse/Deck/Deck.hpp>
+#include <opm/parser/eclipse/EclipseState/saturation.hpp>
+#include <opm/parser/eclipse/EclipseState/Runspec.hpp>
+
+namespace Opm {
+
+struct satfuns {
+
+    static std::vector< std::vector< saturation::water_oil > >
+    woSWOF( const DeckKeyword& kw ) {
+        decltype( woSWOF( kw ) ) v;
+        v.emplace_back();
+
+        for( const auto& record : kw ) {
+            v.emplace_back();
+            auto& current = v.back();
+
+            for( const auto& item : record ) {
+                assert( item.size() % 4 == 0 );
+
+                for( int i = 0; i < int( item.size() ); i += 4 ) {
+                    current.push_back(
+                        saturation::water_oil {
+                            item.get< double >( i + 0 ),
+                            item.get< double >( i + 1 ),
+                            item.get< double >( i + 3 ),
+                            item.get< double >( i + 0 ),
+                            item.get< double >( i + 2 ),
+                            }
+                        );
+                }
+            }
+        }
+
+        return v;
+    }
+
+    static std::vector< std::vector< saturation::water_oil > >
+    woSWFN( const DeckKeyword& kw, std::vector< std::vector< saturation::water_oil > > res ) {
+        res.resize( kw.size() + 1 );
+
+        int reci = 1;
+        for( const auto& record : kw ) {
+            auto& current = res[ reci++ ];
+
+            for( const auto& item : record ) {
+                assert( item.size() % 3 == 0 );
+
+                current.resize( item.size() / 3 );
+
+                for( int i = 0; i < int( item.size() / 3 ); ++i ) {
+                    current[ i ].Sw   = item.get< double >( (i * 3) + 0 );
+                    current[ i ].Krw  = item.get< double >( (i * 3) + 1 );
+                    current[ i ].Pcow = item.get< double >( (i * 3) + 2 );
+                }
+            }
+        }
+
+        return res;
+    }
+
+    static std::vector< std::vector< saturation::water_oil > >
+    woSOF3( const DeckKeyword& kw, std::vector< std::vector< saturation::water_oil > > res ) {
+        res.resize( kw.size() + 1 );
+
+        int reci = 1;
+        for( const auto& record : kw ) {
+            auto& current = res.at( reci++ );
+
+            for( const auto& item : record ) {
+                assert( item.size() % 3 == 0 );
+
+                current.resize( item.size() / 3 );
+
+                int sz = (item.size() / 3) - 1;
+                for( int i = 0; i < int( item.size() / 3 ); ++i ) {
+                    current.at( sz - i ).Sw_  = 1.0 - item.get< double >( (i * 3) + 0 );
+                    current.at( sz - i ).Krow = item.get< double >( (i * 3) + 1 );
+                }
+            }
+        }
+
+        return res;
+    }
+};
+
+
+inline bool consistent_families( const Deck& deck, const Phases& phases ) {
+    const bool swof  = deck.hasKeyword( "SWOF" );
+    const bool sgof  = deck.hasKeyword( "SGOF" );
+    const bool slgof = deck.hasKeyword( "SLGOF" );
+
+    const bool swfn  = deck.hasKeyword( "SWFN" );
+    const bool sgfn  = deck.hasKeyword( "SGFN" );
+    const bool sof2  = deck.hasKeyword( "SOF2" );
+    const bool sof3  = deck.hasKeyword( "SOF3" );
+    const bool sgwfn = deck.hasKeyword( "SGWFN" );
+
+    const bool familyI  = swof || sgof || slgof;
+    const bool familyII = swfn || sgfn || sof2 || sof3 || sgwfn;
+
+    if( familyI && familyII ) return false;
+
+    const bool wat = phases.active( Phase::WATER );
+    const bool oil = phases.active( Phase::OIL );
+    const bool gas = phases.active( Phase::GAS );
+
+    if( swof  && !( wat && oil ) ) return false;
+    if( sgof  && !( gas && oil ) ) return false;
+    if( slgof && !( gas && oil ) ) return false;
+
+    if( swfn && !wat ) return false;
+    if( sgfn && !gas ) return false;
+    if( sof2 && !oil && phases.size() != 2 ) return false;
+    if( sof3 && !oil && phases.size() != 3 ) return false;
+    if( sgwfn && !( gas && wat ) ) return false;
+
+    return true;
+}
+
+saturation::saturation( const Deck& deck, int grid_size ) :
+    og( grid_size ) {
+
+    const auto& satnum = deck.getKeyword( "SATNUM" ).getIntData();
+    const auto maxsat = deck.getKeyword( "TABDIMS" ).getRecord( 0 ).getItem( 0 ).get< int >( 0 );
+
+    auto runspec = Runspec( deck );
+    if( !consistent_families( deck, runspec.phases() ) )
+        throw std::invalid_argument( "Inconsistent families" );
+
+    decltype( this->wo ) watoil;
+    if( deck.hasKeyword( "SWOF" ) ) {
+        const auto& swof = deck.getKeyword( "SWOF" );
+        assert( int( swof.size() ) == maxsat );
+        watoil = satfuns::woSWOF( swof );
+    } else {
+        const auto& swfn = deck.getKeyword( "SWFN" );
+        assert( int( swfn.size() ) == maxsat );
+        watoil = satfuns::woSWFN( swfn, watoil );
+
+        const auto& sof3 = deck.getKeyword( "SOF3" );
+        assert( int( sof3.size() ) == maxsat );
+        watoil = satfuns::woSOF3( sof3, watoil );
+    }
+
+    for( int i = 0; i < grid_size; ++i ) {
+        this->wo.push_back( watoil.at( satnum.at( i ) ) );
+    }
+
+    if( !deck.hasKeyword( "ENDSCALE" ) ) {
+        /* default all directions so that scaled_swat = unscaled_swat */
+        for( size_t i = 0; i < this->wo.size(); ++i ) {
+            const double Swco = this->wo[ i ].front().Sw;
+            const double Swmax = this->wo[ i ].back().Sw;
+
+            this->conwat.push_back( connate_water { Swco, Swco, Swco, Swco, Swco, Swco } );
+            this->maxwat.push_back( maximum_water { Swmax, Swmax, Swmax, Swmax, Swmax, Swmax } );
+        }
+
+    }
+    else {
+        const auto& swl = deck.getKeyword( "SWL" ).getSIDoubleData();
+        const auto& swu = deck.getKeyword( "SWU" ).getSIDoubleData();
+
+        std::cout << "Have SWL, SWU " << std::endl;
+
+        for( int i = 0; i < grid_size; ++i ) {
+            const double Swco = swl.at( i );
+            const double Swmax = swu.at( i );
+            this->conwat.push_back( connate_water { Swco, Swco, Swco, Swco, Swco, Swco } );
+            this->maxwat.push_back( maximum_water { Swmax, Swmax, Swmax, Swmax, Swmax, Swmax } );
+        }
+    }
+}
+
+double saturation::oil_relperm( size_t index, double swat ) const {
+    const double swat1 = this->swat_scaled( index, swat );
+
+    auto fn = std::find_if( this->wo.at( index ).begin(),
+                            this->wo.at( index ).end(),
+            [=]( const water_oil& x ) {
+                constexpr const auto epsilon = 1e-5;
+                return std::abs(swat1 - x.Sw) < epsilon;
+            } );
+
+    if( fn == this->wo.at( index ).end() )
+        throw std::invalid_argument( "Saturation entry " + std::to_string( swat1 )
+                                     + " does not exist in cell " + std::to_string( index ) );
+
+    std::cout << "Unscaled swat: " << swat1
+              << ". Scaled swat: " << swat
+              << ". Found swat: " << fn->Sw << std::endl;
+
+    return fn->Pcow;
+}
+
+double saturation::swat_scaled( size_t index, double Sw, direction dir ) const {
+    double Swc, Swu;
+
+    switch( dir ) {
+        case direction::undir:
+        case direction::Xp:
+            Swc = this->conwat[ index ].Xp;
+            Swu = this->maxwat[ index ].Xp;
+            break;
+
+        case direction::Xm:
+            Swc = this->conwat[ index ].Xm;
+            Swu = this->maxwat[ index ].Xm;
+            break;
+
+        case direction::Yp:
+            Swc = this->conwat[ index ].Yp;
+            Swu = this->maxwat[ index ].Yp;
+            break;
+
+        case direction::Ym:
+            Swc = this->conwat[ index ].Ym;
+            Swu = this->maxwat[ index ].Ym;
+            break;
+
+        case direction::Zp:
+            Swc = this->conwat[ index ].Zp;
+            Swu = this->maxwat[ index ].Zp;
+            break;
+
+        case direction::Zm:
+            Swc = this->conwat[ index ].Zm;
+            Swu = this->maxwat[ index ].Zm;
+            break;
+    }
+
+    std::cout << "Swc, Swu: " << Swc << " " << Swu << std::endl;
+
+    const auto& tab = this->wo.at( index );
+    double Swco = tab.front().Sw;
+    double Swcmax = tab.back().Sw;
+
+    return Swco +  ( (Sw - Swc) * ( Swcmax - Swco )
+                                / ( Swu - Swc ) );
+}
+
+bool saturation::operator==( const saturation& rhs ) const {
+
+    for( size_t i = 0; i < this->wo.size(); ++i ) {
+        if( !std::equal( this->wo.at( i ).begin(), this->wo.at( i ).end(),
+                         rhs.wo.at( i ).begin() ) ) return false;
+    }
+
+    return true;
+}
+
+}

--- a/opm/parser/eclipse/EclipseState/saturation.hpp
+++ b/opm/parser/eclipse/EclipseState/saturation.hpp
@@ -1,0 +1,98 @@
+#ifndef OPM_SATURATION_HPP
+#define OPM_SATURATION_HPP
+
+#include <iosfwd>
+#include <vector>
+
+namespace Opm {
+
+class Deck;
+
+class saturation {
+    public:
+        saturation() = default;
+        saturation( const Deck&, int );
+
+        enum class direction {
+            undir,
+            Xp,
+            Xm,
+            Yp,
+            Ym,
+            Zp,
+            Zm,
+        };
+
+        bool operator!=( const saturation& rhs ) const { return !( *this == rhs ); }
+        bool operator==( const saturation& ) const;
+
+        double oil_relperm( size_t cell_index, double swat ) const;
+
+    private:
+        struct oil_gas {
+            double So;
+
+            double Krg;
+            double Krog;
+            double Pcog;
+
+            bool operator!=( const oil_gas& rhs ) const { return !( *this == rhs ); }
+            bool operator==( const oil_gas& rhs ) const {
+                return this->So   == rhs.So
+                    && this->Krg  == rhs.Krg
+                    && this->Krog == rhs.Krog
+                    && this->Pcog == rhs.Pcog;
+            }
+        };
+
+        struct water_oil {
+            double Sw;
+            double Krw;
+            double Pcow;
+
+            double Sw_;
+            double Krow;
+
+            bool operator!=( const water_oil& rhs ) const { return !( *this == rhs ); }
+            bool operator==( const water_oil& rhs ) const {
+                constexpr const auto epsilon = 1e-10;
+
+                return this->Sw   - rhs.Sw   < epsilon
+                    && this->Sw_  - rhs.Sw_  < epsilon
+                    && this->Krw  - rhs.Krw  < epsilon
+                    && this->Krow - rhs.Krow < epsilon
+                    && this->Pcow - rhs.Pcow < epsilon;
+            }
+        };
+
+        double swat_scaled( size_t index, double swat, direction dir = direction::undir ) const;
+
+        struct connate_water {
+            double Xp;
+            double Xm;
+            double Yp;
+            double Ym;
+            double Zp;
+            double Zm;
+        };
+
+        struct maximum_water {
+            double Xp;
+            double Xm;
+            double Yp;
+            double Ym;
+            double Zp;
+            double Zm;
+        };
+
+        std::vector< std::vector< water_oil > > wo;
+        std::vector< std::vector< oil_gas > > og;
+        std::vector< connate_water > conwat;
+        std::vector< maximum_water > maxwat;
+
+        friend struct satfuns;
+};
+
+}
+
+#endif //OPM_SATURATION_HPP


### PR DESCRIPTION
The goal is to support (scaled) saturation functions from opm-parser, rather than downstream having to interpret tables.

This is highly experimental and still in its *very* early stages, but I'm publishing it now for discussion, thoughts, observations, wishes and warm fuzzy feelings. I encourage downstream to chime in and let us know what exactly you need from the saturation functions, how you intend to use them and represent them, in order for the interface to be nice and simple.

I intend for this effort to also give us some nice documentation on edge cases and subtle interactions, and more importantly, good tests.

If everything goes as I hope it will, downstream won't have to touch 3d properties or tables again.