### PR TITLE
added BUILD_SHARED_LIBS to option in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 set( OPM_COMMON_ROOT "" CACHE PATH "Root directory containing OPM related cmake modules")
 option(SIBLING_SEARCH "Search for other modules in sibling directories?" ON)
 option(BUILD_TESTING "Build test applications by default?" ON)
+option(BUILD_SHARED_LIBS  "Build dynamically?  (Python needs this.)" ON)
 
 if(NOT OPM_COMMON_ROOT)
   find_package(opm-common QUIET)


### PR DESCRIPTION
This adds `BUILD_SHARED_LIBS` as a `CMake` option so it is possible to toggle in `ccmake`.
