### PR TITLE
Understand STONE1EX.

### DIFF
--- a/opm/parser/eclipse/CMakeLists.txt
+++ b/opm/parser/eclipse/CMakeLists.txt
@@ -242,6 +242,7 @@ EclipseState/Tables/PvdsTable.hpp
 EclipseState/Tables/SimpleTable.hpp
 EclipseState/Tables/PlymaxTable.hpp
 EclipseState/Tables/PlyrockTable.hpp
+EclipseState/Tables/Stone1exTable.hpp
 EclipseState/Tables/SwofTable.hpp
 EclipseState/Tables/SgwfnTable.hpp
 EclipseState/Tables/SwfnTable.hpp

--- a/opm/parser/eclipse/EclipseState/Tables/Stone1exTable.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Stone1exTable.hpp
@@ -1,0 +1,37 @@
+/*
+  Copyright (C) 2016 by Statoil ASA
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+#ifndef OPM_PARSER_STONE1EX_TABLE_HPP
+#define OPM_PARSER_STONE1EX_TABLE_HPP
+
+#include "SimpleTable.hpp"
+
+namespace Opm {
+
+    class DeckItem;
+
+    class Stone1exTable : public SimpleTable {
+    public:
+        Stone1exTable( const DeckItem& item );
+        const TableColumn& getExpColumn() const;
+    };
+}
+
+#endif
+
+

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -64,6 +64,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Stone1exTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
 
@@ -189,6 +190,8 @@ namespace Opm {
         addTables( "SSFN",  m_tabdims.getNumSatTables() );
         addTables( "MSFN",  m_tabdims.getNumSatTables() );
 
+        addTables( "STONE1EX", m_tabdims.getNumSatTables() );
+
         addTables( "PLYADS", m_tabdims.getNumSatTables() );
         addTables( "PLYROCK", m_tabdims.getNumSatTables());
         addTables( "PLYVISC", m_tabdims.getNumPVTTables());
@@ -246,6 +249,7 @@ namespace Opm {
         }
 
 
+        initSimpleTableContainer<Stone1exTable>(deck, "STONE1EX", m_tabdims.getNumSatTables());
         initSimpleTableContainer<SgwfnTable>(deck, "SGWFN", m_tabdims.getNumSatTables());
         initSimpleTableContainer<Sof2Table>(deck, "SOF2" , m_tabdims.getNumSatTables());
         initSimpleTableContainer<Sof3Table>(deck, "SOF3" , m_tabdims.getNumSatTables());
@@ -644,6 +648,10 @@ namespace Opm {
 
     const TableContainer& TableManager::getPlyshlogTables() const {
         return getTables("PLYSHLOG");
+    }
+
+    const TableContainer& TableManager::getStone1exTables() const {
+        return getTables("STONE1EX");
     }
 
     const std::vector<PvtgTable>& TableManager::getPvtgTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -92,6 +92,7 @@ namespace Opm {
         const TableContainer& getPlymaxTables() const;
         const TableContainer& getPlyrockTables() const;
         const TableContainer& getPlyshlogTables() const;
+        const TableContainer& getStone1exTables() const;
 
         const TableContainer& getSorwmisTables() const;
         const TableContainer& getSgcwmisTables() const;

--- a/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/Tables.cpp
@@ -65,6 +65,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/SorwmisTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SsfnTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwfnTable.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/Stone1exTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/SwofTable.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/TableContainer.hpp>
 #include <opm/parser/eclipse/EclipseState/Tables/WatvisctTable.hpp>
@@ -131,6 +132,15 @@ const TableColumn& SwofTable::getPcowColumn() const {
 const TableColumn& SwofTable::getJFuncColumn() const {
     SimpleTable::assertJFuncPressure(true);
     return SimpleTable::getColumn(3);
+}
+
+Stone1exTable::Stone1exTable( const DeckItem& item ) {
+    m_schema.addColumn( ColumnSchema( "EXP", Table::RANDOM, item.get< double >( 0 ) ) );
+    SimpleTable::init( item );
+}
+
+const TableColumn& Stone1exTable::getExpColumn() const {
+    return SimpleTable::getColumn(0);
 }
 
 SgwfnTable::SgwfnTable( const DeckItem& item ) {

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -1296,3 +1296,87 @@ BOOST_AUTO_TEST_CASE( TestParseTABDIMS ) {
     Opm::Parser parser;
     BOOST_CHECK_NO_THROW( parser.parseString(data, Opm::ParseContext()));
 }
+
+BOOST_AUTO_TEST_CASE( TestParseSTONE1X_defaulted ) {
+    const std::string input = R"(
+        RUNSPEC
+        PROPS
+        TABDIMS
+            3 /
+
+        STONE1EX
+            * /
+            * /
+            * /
+    )";
+
+    TableManager tm( Parser{}.parseString( input, ParseContext() ) );
+    BOOST_CHECK_CLOSE( 1.0, tm.getStone1exTables()[ 0 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 1.0, tm.getStone1exTables()[ 1 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 1.0, tm.getStone1exTables()[ 2 ].get( 0, 0 ), 1e-5 );
+}
+
+BOOST_AUTO_TEST_CASE_EXPECTED_FAILURES( TestParseSTONE1X_first_set_rest_defaulted, 2 );
+BOOST_AUTO_TEST_CASE( TestParseSTONE1X_first_set_rest_defaulted ) {
+    const std::string input = R"(
+        RUNSPEC
+        PROPS
+        TABDIMS
+            3 /
+
+        STONE1EX
+            2.1 /
+            * /
+            * /
+    )";
+
+    TableManager tm( Parser{}.parseString( input, ParseContext() ) );
+    /*
+     * There's currently a bug in the SimpleTable implementation for keywords
+     * like STONE1EX - the manual says that a defaulted value should copy the
+     * previous table's entry, but there's no local knowledge of the previous
+     * table's corresponding when the table entry is determined, so we need to
+     * fall back to the item default (1.0).
+     */
+    BOOST_CHECK_CLOSE( 2.1, tm.getStone1exTables()[ 0 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2.1, tm.getStone1exTables()[ 1 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2.1, tm.getStone1exTables()[ 2 ].get( 0, 0 ), 1e-5 );
+}
+
+BOOST_AUTO_TEST_CASE( TestParseSTONE1X ) {
+    const std::string input = R"(
+        RUNSPEC
+        PROPS
+        TABDIMS
+            3 /
+
+        STONE1EX
+            1.1 /
+            2.1 /
+            3.1 /
+    )";
+
+    TableManager tm( Parser{}.parseString( input, ParseContext() ) );
+    BOOST_CHECK_CLOSE( 1.1, tm.getStone1exTables()[ 0 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2.1, tm.getStone1exTables()[ 1 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 3.1, tm.getStone1exTables()[ 2 ].get( 0, 0 ), 1e-5 );
+}
+
+BOOST_AUTO_TEST_CASE( TestParseSTONE1X_first_defaulted ) {
+    const std::string input = R"(
+        RUNSPEC
+        PROPS
+        TABDIMS
+            3 /
+
+        STONE1EX
+            * /
+            2.1 /
+            3.1 /
+    )";
+
+    TableManager tm( Parser{}.parseString( input, ParseContext() ) );
+    BOOST_CHECK_CLOSE( 1.0, tm.getStone1exTables()[ 0 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 2.1, tm.getStone1exTables()[ 1 ].get( 0, 0 ), 1e-5 );
+    BOOST_CHECK_CLOSE( 3.1, tm.getStone1exTables()[ 2 ].get( 0, 0 ), 1e-5 );
+}


### PR DESCRIPTION
Understand and expose the STONE1EX table. It has a known bug when values
are defaulted - it won't copy the previous table's entry, but rather
insert 1.0.