### PR TITLE
(Discuss) new way to handle WCONHIST

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -433,8 +433,8 @@ namespace Opm {
                     properties = WellProductionProperties::prediction( record, addGrupProductionControl );
                 } else {
                     const WellProductionProperties& prev_properties = well->getProductionProperties(currentStep);
-                    double BHPLimit = prev_properties.BHPLimit;
-                    properties = WellProductionProperties::history( BHPLimit , record, m_phases);
+                    const double BHPLimit = prev_properties.BHPLimit;
+                    properties = WellProductionProperties::history(BHPLimit, record);
                 }
 
                 if (status != WellCommon::SHUT) {

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -41,49 +41,34 @@ namespace Opm {
     {}
 
 
-    WellProductionProperties WellProductionProperties::history(double BHPLimit, const DeckRecord& record, const Phases &phases)
+    WellProductionProperties WellProductionProperties::history(const double BHPLimit, const DeckRecord& record)
     {
-        // Modes supported in WCONHIST just from {O,W,G}RAT values
-        //
-        // Note: The default value of observed {O,W,G}RAT is zero
-        // (numerically) whence the following control modes are
-        // unconditionally supported.
         WellProductionProperties p(record);
         p.predictionMode = false;
 
         namespace wp = WellProducer;
-        if(phases.active(Phase::OIL))
-            p.addProductionControl( wp::ORAT );
-
-        if(phases.active(Phase::WATER))
-            p.addProductionControl( wp::WRAT );
-
-        if(phases.active(Phase::GAS))
-            p.addProductionControl( wp::GRAT );
-
-        for( auto cmode : { wp::LRAT, wp::RESV, wp::GRUP } ) {
-            p.addProductionControl( cmode );
-        }
-
-        /*
-          We do not update the BHPLIMIT based on the BHP value given
-          in WCONHIST, that is purely a historical value; instead we
-          copy the old value of the BHP limit from the previous
-          timestep.
-
-          To actually set the BHPLIMIT in historical mode you must
-          use the WELTARG keyword.
-        */
-        p.BHPLimit = BHPLimit;
 
         const auto& cmodeItem = record.getItem("CMODE");
         if (!cmodeItem.defaultApplied(0)) {
-            const auto cmode = WellProducer::ControlModeFromString( cmodeItem.getTrimmedString( 0 ) );
+            const std::string cmode_string = cmodeItem.getTrimmedString( 0 );
+            const auto cmode = WellProducer::ControlModeFromString(cmode_string);
 
-            if (p.hasProductionControl( cmode ))
+            if (cmode == wp::LRAT || cmode == wp::RESV || cmode == wp::ORAT ||
+                cmode == wp::WRAT || cmode == wp::GRAT || cmode == wp::BHP) {
+                p.addProductionControl( cmode );
                 p.controlMode = cmode;
-            else
-                throw std::invalid_argument("Setting CMODE to unspecified control");
+            } else {
+                const std::string msg = "unsupported control mode " + cmode_string + " for WCONHIST";
+                throw std::invalid_argument(msg);
+            }
+
+            if (cmode == wp::BHP) {
+                p.BHPLimit = record.getItem( "BHP" ).getSIDouble( 0 );
+            } else {
+                // When the control mode is not BHP, we should add a BHP limit as 1 atm.
+                p.addProductionControl( wp::BHP );
+                p.BHPLimit = BHPLimit;
+            }
         }
 
         return p;

--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -49,7 +49,7 @@ namespace Opm {
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
 
-        static WellProductionProperties history(double BHPLimit, const DeckRecord& record, const Phases &phases = Phases(true, true, true) );
+        static WellProductionProperties history(const double BHPLimit, const DeckRecord& record);
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/ScheduleTests.cpp
@@ -984,9 +984,8 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     Schedule schedule(parseContext , grid, deck, Phases(true, true, true) );
     auto* well_p = schedule.getWell("P");
 
-    BOOST_CHECK_EQUAL(well_p->getProductionProperties(0).BHPLimit, 0); //start
+    BOOST_CHECK_EQUAL(well_p->getProductionProperties(0).BHPLimit, 0.); //start
     BOOST_CHECK_EQUAL(well_p->getProductionProperties(1).BHPLimit, 50 * 1e5); // 1
-    // The BHP limit should not be effected by WCONHIST
     BOOST_CHECK_EQUAL(well_p->getProductionProperties(2).BHPLimit, 50 * 1e5); // 2
 
     auto* well_i = schedule.getWell("I");

--- a/opm/parser/eclipse/EclipseState/Schedule/tests/WellPropertiesTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/tests/WellPropertiesTests.cpp
@@ -89,7 +89,7 @@ namespace {
 
             auto deck = parser.parseString(input, Opm::ParseContext());
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
-            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history( 100 , record);;
+            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(100., record);
 
             return hist;
         }


### PR DESCRIPTION
Wells under WCONHIST control should only have only one active control mode, and also a lower BHP limit when not under BHP control. Switching to BHP control is not very desirable, while we need a BHP limit there. 

It is different from the WCONPROD, which has one active control, while there are many other limits that can potentially become a control. 

It fixes OPM/opm-simulators#1011, while needs detailed testing. 