### PR TITLE
Replace backslash in INCLUDE paths

### DIFF
--- a/opm/parser/eclipse/Parser/Parser.cpp
+++ b/opm/parser/eclipse/Parser/Parser.cpp
@@ -372,6 +372,13 @@ boost::filesystem::path ParserState::getIncludeFilePath( std::string path ) cons
         boost::replace_all(path, pathKeywordPrefix + stringToFind, stringToReplace);
     }
 
+    // Check if there are any backslashes in the path...
+    if (path.find('\\') != std::string::npos) {
+        // ... if so, replace with slashes and create a warning.
+        std::replace(path.begin(), path.end(), '\\', '/');
+        deck.getMessageContainer().warning("Replaced one or more backslash with a slash in an INCLUDE path.");
+    }
+
     boost::filesystem::path includeFilePath(path);
 
     if (includeFilePath.is_relative())

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -288,8 +288,8 @@ BOOST_AUTO_TEST_CASE( PATHS_has_global_scope ) {
     ParseContext parseContext;
 
     parseContext.update( ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION);
-    parser.parseFile( "testdata/parser/PATHSInInclude.data", parseContext );
-    BOOST_CHECK(parser.hasKeyword("OIL"));
+    const auto deck = parser.parseFile( "testdata/parser/PATHSInInclude.data", parseContext );
+    BOOST_CHECK(deck.hasKeyword("OIL"));
     BOOST_CHECK_THROW( parser.parseFile( "testdata/parser/PATHSInIncludeInvalid.data", ParseContext() ), std::invalid_argument );
 }
 
@@ -298,8 +298,8 @@ BOOST_AUTO_TEST_CASE( PATHS_with_backslashes ) {
     ParseContext parseContext;
 
     parseContext.update( ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION);
-    parser.parseFile( "testdata/parser/PATHSWithBackslashes.data", parseContext );
-    BOOST_CHECK(parser.hasKeyword("OIL"));
+    const auto deck = parser.parseFile( "testdata/parser/PATHSWithBackslashes.data", parseContext );
+    BOOST_CHECK(deck.hasKeyword("OIL"));
 }
 
 BOOST_AUTO_TEST_CASE( handle_empty_title ) {

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -289,6 +289,7 @@ BOOST_AUTO_TEST_CASE( PATHS_has_global_scope ) {
 
     parseContext.update( ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION);
     parser.parseFile( "testdata/parser/PATHSInInclude.data", parseContext );
+    BOOST_CHECK(parser.hasKeyword("OIL"));
     BOOST_CHECK_THROW( parser.parseFile( "testdata/parser/PATHSInIncludeInvalid.data", ParseContext() ), std::invalid_argument );
 }
 
@@ -298,6 +299,7 @@ BOOST_AUTO_TEST_CASE( PATHS_with_backslashes ) {
 
     parseContext.update( ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION);
     parser.parseFile( "testdata/parser/PATHSWithBackslashes.data", parseContext );
+    BOOST_CHECK(parser.hasKeyword("OIL"));
 }
 
 BOOST_AUTO_TEST_CASE( handle_empty_title ) {

--- a/opm/parser/eclipse/Parser/tests/ParserTests.cpp
+++ b/opm/parser/eclipse/Parser/tests/ParserTests.cpp
@@ -292,6 +292,14 @@ BOOST_AUTO_TEST_CASE( PATHS_has_global_scope ) {
     BOOST_CHECK_THROW( parser.parseFile( "testdata/parser/PATHSInIncludeInvalid.data", ParseContext() ), std::invalid_argument );
 }
 
+BOOST_AUTO_TEST_CASE( PATHS_with_backslashes ) {
+    Parser parser;
+    ParseContext parseContext;
+
+    parseContext.update( ParseContext::PARSE_MISSING_INCLUDE , Opm::InputError::THROW_EXCEPTION);
+    parser.parseFile( "testdata/parser/PATHSWithBackslashes.data", parseContext );
+}
+
 BOOST_AUTO_TEST_CASE( handle_empty_title ) {
     const auto* input_deck = "RUNSPEC\n\n"
                              "TITLE\n\n"

--- a/testdata/parser/PATHSWithBackslashes.data
+++ b/testdata/parser/PATHSWithBackslashes.data
@@ -1,0 +1,7 @@
+INCLUDE
+ 'include\foobackslash.inc'
+/
+
+INCLUDE
+ '$FOOPATH\foo_target.inc'
+/

--- a/testdata/parser/include/foobackslash.inc
+++ b/testdata/parser/include/foobackslash.inc
@@ -1,0 +1,3 @@
+PATHS
+ 'FOOPATH' 'include\foopath' /
+/


### PR DESCRIPTION
The following addresses #1033 by converting backslashes in include path strings to slashes. This is done after all other processing such as expanding mapped paths (of the `$PATH_KEY` kind), just before creating the boost::filesystem::path object.

I believe it is a better solution than using a conversion script since:
 - requiring such a script is likely to reduce usage by casual users (it doubles the number of commands to remember...)
 - writing such a script in such a way that it only does what it is supposed to do might be hard, the current solution can only affect INCLUDE paths
 - we can (and do) give a warning about this, so that users can choose to make the paths universal (using slashes) but do not require it

@hnil can you verify that this PR solves the observed problem?