### PR TITLE
TableManager: export the Eqldims object

### DIFF
--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -520,6 +520,9 @@ namespace Opm {
         return m_tabdims;
     }
 
+    const Eqldims& TableManager::getEqldims() const {
+        return *m_eqldims;
+    }
 
     /*
       const std::vector<SwofTable>& TableManager::getSwofTables() const {

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -60,8 +60,8 @@ namespace Opm {
         const TableContainer& operator[](const std::string& tableName) const;
         bool hasTables( const std::string& tableName ) const;
 
-
         const Tabdims& getTabdims() const;
+        const Eqldims& getEqldims() const;
 
         const TableContainer& getSwofTables() const;
         const TableContainer& getSgwfnTables() const;


### PR DESCRIPTION
this object corresponds to the EQLDIMS keyword. Probably it is not the most intuitive place to provide access to this keyword, but as far as I can see, the table manager is the only place where this object is already properly instantiated.