### PR TITLE
Adding 1 atma deafult BHP for keyword WCONPROD

### DIFF
--- a/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -107,14 +107,16 @@ namespace Opm {
         using mode = std::pair< const char*, wp::ControlModeEnum >;
         static const mode modes[] = {
             { "ORAT", wp::ORAT }, { "WRAT", wp::WRAT }, { "GRAT", wp::GRAT },
-            { "LRAT", wp::LRAT }, { "RESV", wp::RESV }, { "BHP", wp::BHP },
-            { "THP", wp::THP }
+            { "LRAT", wp::LRAT }, { "RESV", wp::RESV }, { "THP", wp::THP }
         };
 
         for( const auto& cmode : modes ) {
             if( !record.getItem( cmode.first ).defaultApplied( 0 ) )
                  p.addProductionControl( cmode.second );
         }
+
+        // There is always a BHP constraint, when not specified, will use the default value
+        p.addProductionControl( wp::BHP );
 
         if (addGroupProductionControl) {
             p.addProductionControl(WellProducer::GRUP);

--- a/opm/parser/share/keywords/000_Eclipse100/W/WCONPROD
+++ b/opm/parser/share/keywords/000_Eclipse100/W/WCONPROD
@@ -7,7 +7,7 @@
        {"name" : "GRAT"         , "value_type" : "DOUBLE" , "default" : 0.0 , "dimension" : "GasSurfaceVolume/Time"},
        {"name" : "LRAT"         , "value_type" : "DOUBLE" , "default" : 0.0 , "dimension" : "LiquidSurfaceVolume/Time"},
        {"name" : "RESV"         , "value_type" : "DOUBLE" , "default" : 0.0 , "dimension" : "LiquidSurfaceVolume/Time"},
-       {"name" : "BHP"          , "value_type" : "DOUBLE" , "default" : 0.0 , "dimension" : "Pressure"},
+       {"name" : "BHP"          , "value_type" : "DOUBLE" , "default" : 1.01325 , "dimension" : "Pressure"},
        {"name" : "THP"          , "value_type" : "DOUBLE" , "default" : 0.0 , "dimension" : "Pressure"},
        {"name" : "VFP_TABLE"    , "value_type" : "INT"    , "default" :   0 },
        {"name" : "ALQ"          , "value_type" : "DOUBLE" , "default" : 0.0 },


### PR DESCRIPTION
And always employing a BHP constraint there. 

Please suggest if this is the good way to do that.

The side effect is that the BHP constraint will always be the last one, potentially affects some situation that we switching well controls when some constraint is violated. I mean, for the situation that the order of the constraints in well_controls struct matter. 