### PR TITLE
changed: use the common functionality for optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,14 +90,11 @@ else()
   # overriden via -DCMAKE_FLAGS from the command line or ccmake
   SET( CMAKE_CXX_FLAGS "-pipe  ${CMAKE_CXX_FLAGS}")
   SET( CMAKE_CXX_FLAGS_DEBUG   "-pedantic -Wall -Wextra -Wformat-nonliteral -Wcast-align -Wpointer-arith -Wmissing-declarations -Wcast-qual -Wshadow -Wwrite-strings -Wchar-subscripts -Wredundant-decls ${CMAKE_CXX_FLAGS_DEBUG}")
-  SET( CMAKE_CXX_FLAGS_DEBUG   "-O0 -DDEBUG  -ggdb3        ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_DEBUG}  ")
-  SET( CMAKE_CXX_FLAGS_RELEASE "-O3 -DNDEBUG -mtune=native ${CMAKE_CXX_FLAGS} ${CMAKE_CXX_FLAGS_RELEASE}")
 endif(MSVC)
 
 SET( CMAKE_C_FLAGS "-pipe -Wall -Wno-unknown-pragmas -std=c99 ${CMAKE_C_FLAGS}")
-SET( CMAKE_C_FLAGS_DEBUG   "-O0 -DDEBUG -ggdb3         ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}  ")
-SET( CMAKE_C_FLAGS_RELEASE "-O3 -DNDEBUG -mtune=native ${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_RELEASE}")
 
+include(UseOptimization)
 
 if (BOOST_ROOT AND NOT DEFINED Boost_NO_SYSTEM_PATHS)
    set (Boost_NO_SYSTEM_PATHS TRUE)


### PR DESCRIPTION
while packaging 2017.04, i realized opm builds with -mtune=native by default. this is not a good idea in generic binaries, as you end up tuning to whatever hardware happens to be available on the build slave.

in general, the option is attached to a cmake option (which defaults to true). that means i could disable it.
in opm-parser build optimization flags are more rigid, so the release is built with native tuning.

this enables the generic opm-common hosted rule to allow proper builds in the future. it should not alter anything by default (maybe order and such but the actual flags being enabled should be the same). please help me verify the last point - it's the same on my box but that's no proof.