### PR TITLE
Basic support for cylindrical grids

### DIFF
--- a/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -575,7 +575,7 @@ namespace Opm {
 
     void EclipseGrid::assertVectorSize(const std::vector<double>& vector , size_t expectedSize , const std::string& vectorName) {
         if (vector.size() != expectedSize)
-            throw std::invalid_argument("Wrong size for keyword: " + vectorName + ". Expected: " + boost::lexical_cast<std::string>(expectedSize) + " got: " + boost::lexical_cast<std::string>(vector.size()));
+            throw std::invalid_argument("Wrong size for keyword: " + vectorName + ". Expected: " + std::to_string(expectedSize) + " got: " + std::to_string(vector.size()));
     }
 
 

--- a/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -181,6 +181,9 @@ namespace Opm {
         }
     }
 
+    bool EclipseGrid::circle( ) const{
+        return this->m_circle;
+    }
 
     void EclipseGrid::initGrid( const std::array<int, 3>& dims, const Deck& deck) {
         if (hasCornerPointKeywords(deck)) {

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -95,6 +95,13 @@ namespace Opm {
         size_t getGlobalIndex(size_t active_index) const;
         size_t getGlobalIndex(size_t i, size_t j, size_t k) const;
 
+        /*
+          For RADIAL grids you can *optionally* use the keyword
+          'CIRCLE' to denote that period boundary conditions should be
+          applied in the 'THETA' direction; this will only apply if
+          the theta keywords entered sum up to exactly 360 degrees!
+        */
+        bool circle( ) const;
         bool isPinchActive( ) const;
         double getPinchThresholdThickness( ) const;
         PinchMode::ModeEnum getPinchOption( ) const;
@@ -178,6 +185,7 @@ namespace Opm {
         PinchMode::ModeEnum m_pinchoutMode;
         PinchMode::ModeEnum m_multzMode;
         mutable std::vector< int > activeMap;
+        bool m_circle = false;
 
         /*
           The internal class grid_ptr is a a std::unique_ptr with

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -78,6 +78,7 @@ namespace Opm {
         /// explicitly.  If a null pointer is passed, every cell is active.
         EclipseGrid(const Deck& deck, const int * actnum = nullptr);
 
+        static bool hasCylindricalKeywords(const Deck& deck);
         static bool hasCornerPointKeywords(const Deck&);
         static bool hasCartesianKeywords(const Deck&);
         size_t  getNumActive( ) const;
@@ -210,6 +211,7 @@ namespace Opm {
                                  const int * actnum,
                                  const double * mapaxes);
 
+        void initCylindricalGrid(       const std::array<int, 3>&, const Deck&);
         void initCartesianGrid(         const std::array<int, 3>&, const Deck&);
         void initCornerPointGrid(       const std::array<int, 3>&, const Deck&);
         void initDTOPSGrid(             const std::array<int, 3>&, const Deck&);
@@ -227,11 +229,31 @@ namespace Opm {
         static void scatterDim(const std::array<int, 3>& dims , size_t dim , const std::vector<double>& DV , std::vector<double>& D);
    };
 
+    class CoordMapper {
+    public:
+        CoordMapper(size_t nx, size_t ny);
+        size_t size() const;
+
+
+        /*
+          dim = 0,1,2 for x, y and z coordinate respectively.
+          layer = 0,1 for k=0 and k=nz layers respectively.
+        */
+
+        size_t index(size_t i, size_t j, size_t dim, size_t layer) const;
+    private:
+        size_t nx;
+        size_t ny;
+    };
+
+
+
     class ZcornMapper {
     public:
         ZcornMapper(size_t nx, size_t ny, size_t nz);
         size_t index(size_t i, size_t j, size_t k, int c) const;
         size_t index(size_t g, int c) const;
+        size_t size() const;
 
         /*
           The fixupZCORN method will take a zcorn vector as input and

--- a/lib/eclipse/share/keywords/000_Eclipse100/D/DR
+++ b/lib/eclipse/share/keywords/000_Eclipse100/D/DR
@@ -1,0 +1,2 @@
+{"name" : "DR", "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "dimension" : "Length"}}
+

--- a/lib/eclipse/share/keywords/000_Eclipse100/D/DRV
+++ b/lib/eclipse/share/keywords/000_Eclipse100/D/DRV
@@ -1,0 +1,2 @@
+{"name" : "DRV", "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "dimension" : "Length"}}
+

--- a/lib/eclipse/share/keywords/000_Eclipse100/D/DTHETA
+++ b/lib/eclipse/share/keywords/000_Eclipse100/D/DTHETA
@@ -1,0 +1,4 @@
+{"name" : "DTHETA", "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "dimension" : "1"},
+ "comment" : "The values are given in degrees - i.e. [0..360)"}
+ 
+

--- a/lib/eclipse/share/keywords/000_Eclipse100/D/DTHETAV
+++ b/lib/eclipse/share/keywords/000_Eclipse100/D/DTHETAV
@@ -1,0 +1,4 @@
+{"name" : "DTHETAV", "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "dimension" : "1"},
+ "comment" : "The values are given in degrees - i.e. [0..360)"}
+ 
+

--- a/lib/eclipse/share/keywords/000_Eclipse100/I/INRAD
+++ b/lib/eclipse/share/keywords/000_Eclipse100/I/INRAD
@@ -1,0 +1,2 @@
+{"name" : "INRAD", "sections" : ["GRID"] , "size" : 1 ,
+  "items" : [{"name" : "RADIUS" , "value_type" : "DOUBLE" , "dimension" : "Length"}]}

--- a/lib/eclipse/share/keywords/000_Eclipse100/O/OUTRAD
+++ b/lib/eclipse/share/keywords/000_Eclipse100/O/OUTRAD
@@ -1,0 +1,2 @@
+{"name" : "OUTRAD", "sections" : ["GRID"] , "size" : 1 ,
+  "items" : [{"name" : "RADIUS" , "value_type" : "DOUBLE" , "dimension" : "Length"}]}

--- a/lib/eclipse/share/keywords/000_Eclipse100/P/PERMR
+++ b/lib/eclipse/share/keywords/000_Eclipse100/P/PERMR
@@ -1,0 +1,1 @@
+{"name" : "PERMR" , "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "dimension" : "Permeability"}}

--- a/lib/eclipse/share/keywords/000_Eclipse100/R/RADIAL
+++ b/lib/eclipse/share/keywords/000_Eclipse100/R/RADIAL
@@ -1,0 +1,4 @@
+{
+  "name" : "RADIAL",
+  "sections" : ["GRID"]
+}

--- a/lib/eclipse/share/keywords/001_Eclipse300/C/CIRCLE
+++ b/lib/eclipse/share/keywords/001_Eclipse300/C/CIRCLE
@@ -1,0 +1,4 @@
+{
+  "name" : "CIRCLE",
+  "sections" : ["GRID"]
+}

--- a/lib/eclipse/tests/EclipseGridTests.cpp
+++ b/lib/eclipse/tests/EclipseGridTests.cpp
@@ -1098,3 +1098,290 @@ BOOST_AUTO_TEST_CASE(MoveTest) {
     BOOST_CHECK( !grid1.c_ptr() );               // We peek at some internal details ...
     BOOST_CHECK( !grid1.circle( ));
 }
+
+
+
+
+static Opm::Deck radial_missing_INRAD() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " 10 10 10 /\n"
+        "RADIAL\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+
+
+static Opm::Deck radial_keywords_OK() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " 10 6 10 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "10*1 /\n"
+        "DTHETAV\n"
+        "6*60 /\n"
+        "DZV\n"
+        "10*0.25 /\n"
+        "TOPS\n"
+        "60*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+static Opm::Deck radial_keywords_OK_CIRCLE() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        " 10 6 10 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "CIRCLE\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "10*1 /\n"
+        "DTHETAV\n"
+        "6*60 /\n"
+        "DZV\n"
+        "10*0.25 /\n"
+        "TOPS\n"
+        "60*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+
+
+BOOST_AUTO_TEST_CASE(RadialTest) {
+    Opm::Deck deck = radial_missing_INRAD();
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ deck }, std::invalid_argument);
+}
+
+
+BOOST_AUTO_TEST_CASE(RadialKeywordsOK) {
+    Opm::Deck deck = radial_keywords_OK();
+    Opm::EclipseGrid grid( deck );
+    BOOST_CHECK(!grid.circle());
+}
+
+BOOST_AUTO_TEST_CASE(RadialKeywordsOK_CIRCLE) {
+    Opm::Deck deck = radial_keywords_OK_CIRCLE();
+    Opm::EclipseGrid grid( deck );
+    BOOST_CHECK(grid.circle());
+}
+
+
+
+static Opm::Deck radial_keywords_DRV_size_mismatch() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        "10 6 12 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "9*1 /\n"
+        "DTHETAV\n"
+        "6*60 /\n"
+        "DZV\n"
+        "12*0.25 /\n"
+        "TOPS\n"
+        "60*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+
+static Opm::Deck radial_keywords_DZV_size_mismatch() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        "10 6 12 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "10*1 /\n"
+        "DTHETAV\n"
+        "6*60 /\n"
+        "DZV\n"
+        "11*0.25 /\n"
+        "TOPS\n"
+        "60*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+static Opm::Deck radial_keywords_DTHETAV_size_mismatch() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        "10 6 12 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "10*1 /\n"
+        "DTHETAV\n"
+        "5*60 /\n"
+        "DZV\n"
+        "12*0.25 /\n"
+        "TOPS\n"
+        "60*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+/*
+  This is stricter than the ECLIPSE implementation; we assume that
+  *only* the top layer is explicitly given.
+*/
+
+static Opm::Deck radial_keywords_TOPS_size_mismatch() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        "10 6 12 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "10*1 /\n"
+        "DTHETAV\n"
+        "6*60 /\n"
+        "DZV\n"
+        "12*0.25 /\n"
+        "TOPS\n"
+        "65*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+
+static Opm::Deck radial_keywords_ANGLE_OVERFLOW() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        "10 6 12 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "10*1 /\n"
+        "DTHETAV\n"
+        "6*70 /\n"
+        "DZV\n"
+        "12*0.25 /\n"
+        "TOPS\n"
+        "60*0.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(RadialKeywords_SIZE_ERROR) {
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ radial_keywords_DRV_size_mismatch() } , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ radial_keywords_DZV_size_mismatch() } , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ radial_keywords_TOPS_size_mismatch() } , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ radial_keywords_DTHETAV_size_mismatch() } , std::invalid_argument);
+    BOOST_CHECK_THROW( Opm::EclipseGrid{ radial_keywords_ANGLE_OVERFLOW() } , std::invalid_argument);
+}
+
+
+
+static Opm::Deck radial_details() {
+    const char* deckData =
+        "RUNSPEC\n"
+        "\n"
+        "DIMENS\n"
+        "1 5 2 /\n"
+        "RADIAL\n"
+        "GRID\n"
+        "INRAD\n"
+        "1 /\n"
+        "DRV\n"
+        "1 /\n"
+        "DTHETAV\n"
+        "3*90 60 30/\n"
+        "DZV\n"
+        "2*1 /\n"
+        "TOPS\n"
+        "5*1.0 /\n"
+        "\n";
+
+    Opm::Parser parser;
+    return parser.parseString( deckData, Opm::ParseContext());
+}
+
+
+
+BOOST_AUTO_TEST_CASE(RadialDetails) {
+    Opm::Deck deck = radial_details();
+    Opm::EclipseGrid grid( deck );
+
+    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 0 , 0 ) , 0.5*(2*2 - 1)*1, 0.0001);
+    BOOST_CHECK_CLOSE( grid.getCellVolume( 0 , 3 , 0 ) , sqrt(3.0)*0.25*( 4 - 1 ) , 0.0001);
+    auto pos0 = grid.getCellCenter(0,0,0);
+    auto pos2 = grid.getCellCenter(0,2,0);
+
+
+    BOOST_CHECK_CLOSE( std::get<0>(pos0) , 0.75 , 0.0001);
+    BOOST_CHECK_CLOSE( std::get<1>(pos0) , 0.75 , 0.0001);
+    BOOST_CHECK_CLOSE( std::get<2>(pos0) , 1.50 , 0.0001);
+
+    BOOST_CHECK_CLOSE( std::get<0>(pos2) , -0.75 , 0.0001);
+    BOOST_CHECK_CLOSE( std::get<1>(pos2) , -0.75 , 0.0001);
+    BOOST_CHECK_CLOSE( std::get<2>(pos2) , 1.50 , 0.0001);
+}
+
+
+BOOST_AUTO_TEST_CASE(CoordMapper) {
+    size_t nx = 10;
+    size_t ny = 7;
+    Opm::CoordMapper cmp = Opm::CoordMapper( nx , ny );
+    BOOST_CHECK_THROW( cmp.index(12,6,0,0), std::invalid_argument );
+    BOOST_CHECK_THROW( cmp.index(10,8,0,0), std::invalid_argument );
+    BOOST_CHECK_THROW( cmp.index(10,7,5,0), std::invalid_argument );
+    BOOST_CHECK_THROW( cmp.index(10,5,1,2), std::invalid_argument );
+
+    BOOST_CHECK_EQUAL( cmp.index(10,7,2,1) + 1 , cmp.size( ));
+}

--- a/lib/eclipse/tests/EclipseGridTests.cpp
+++ b/lib/eclipse/tests/EclipseGridTests.cpp
@@ -1096,4 +1096,5 @@ BOOST_AUTO_TEST_CASE(MoveTest) {
     Opm::EclipseGrid grid2( std::move( grid1 )); // grid2 should be move constructed from grid1
 
     BOOST_CHECK( !grid1.c_ptr() );               // We peek at some internal details ...
+    BOOST_CHECK( !grid1.circle( ));
 }


### PR DESCRIPTION
With this PR the EclipseGrid implementation has limited support for radial grids. The grid must be specified using the keywords `DRV, DTHETAV, DZV`and `TOPS`. When the radial grid is specified this way everything - including simulation and ouptut migth actually *Just Work*&trade;