### PR TITLE
Summary rpr

### DIFF
--- a/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.cpp
@@ -22,6 +22,7 @@
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
+#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
@@ -36,13 +37,14 @@ namespace Opm {
 
     EclipseConfig::EclipseConfig(const Deck& deck,
                                  const Eclipse3DProperties& eclipse3DProperties,
+                                 const TableManager& tables,
                                  const GridDims& inputGrid,
                                  const Schedule& schedule,
                                  const ParseContext& parseContext) :
             m_ioConfig(        deck),
             m_initConfig(      deck),
             m_simulationConfig(deck, eclipse3DProperties),
-            m_summaryConfig(   deck, schedule, eclipse3DProperties, parseContext , inputGrid.getNXYZ()),
+            m_summaryConfig(   deck, schedule, tables, parseContext , inputGrid.getNXYZ()),
             m_restartConfig(   deck )
     {
         this->m_ioConfig.initFirstRFTOutput(schedule);

--- a/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -35,12 +35,14 @@ namespace Opm {
     class Eclipse3DProperties;
     class IOConfig;
     class ParseContext;
+    class TableManager;
 
     class EclipseConfig
     {
     public:
         EclipseConfig(const Deck& deck,
                       const Eclipse3DProperties& eclipse3DProperties,
+                      const TableManager& tables,
                       const GridDims& gridDims,
                       const Schedule& schedule,
                       const ParseContext& parseContext);

--- a/opm/parser/eclipse/EclipseState/EclipseState.cpp
+++ b/opm/parser/eclipse/EclipseState/EclipseState.cpp
@@ -58,7 +58,7 @@ namespace Opm {
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
-        m_eclipseConfig(     deck, m_eclipseProperties, m_gridDims, m_schedule, parseContext ),
+        m_eclipseConfig(     deck, m_eclipseProperties, m_tables, m_gridDims, m_schedule, parseContext ),
         m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
                              m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) ),
         m_inputNnc(          deck, m_gridDims ),

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -29,7 +29,7 @@
 namespace Opm {
 
     class Deck;
-    class Eclipse3DProperties;
+    class TableManager;
     class EclipseState;
     class ParserKeyword;
     class Schedule;
@@ -41,9 +41,9 @@ namespace Opm {
 
             SummaryConfig( const Deck&, const EclipseState& , const ParseContext&  );
             SummaryConfig( const Deck&, const Schedule&,
-                           const Eclipse3DProperties&, const ParseContext&, std::array< int, 3 > );
+                           const TableManager&, const ParseContext&, std::array< int, 3 > );
             SummaryConfig( const Deck&, const Schedule&,
-                           const Eclipse3DProperties&, const ParseContext&, int, int, int );
+                           const TableManager&, const ParseContext&, int, int, int );
 
             const_iterator begin() const;
             const_iterator end() const;
@@ -60,6 +60,11 @@ namespace Opm {
             bool hasKeyword( const std::string& keyword ) const;
 
             /*
+               The hasSummaryKey() method will look for fully
+               qualified keys like 'RPR:3' and 'BPR:10,15,20.
+            */
+            bool hasSummaryKey(const std::string& keyword ) const;
+            /*
               Can be used to query if a certain 3D field, e.g. PRESSURE,
               is required to calculate the summary variables.
             */
@@ -74,6 +79,7 @@ namespace Opm {
             */
             std::vector< ERT::smspec_node > keywords;
             std::set<std::string> short_keywords;
+            std::set<std::string> summary_keywords;
     };
 
 } //namespace Opm

--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -38,6 +38,8 @@ static Deck createDeck( const std::string& summary ) {
             "\n"
             "DIMENS\n"
             " 10 10 10 /\n"
+            "REGDIMS\n"
+            "  3/\n"
             "GRID\n"
             "DXV \n 10*400 /\n"
             "DYV \n 10*400 /\n"
@@ -523,6 +525,7 @@ BOOST_AUTO_TEST_CASE( summary_require3DField ) {
 
         const auto summary = createSummary( input );
         BOOST_CHECK( summary.require3DField( "SGAS"));
+        BOOST_CHECK( summary.hasSummaryKey( "BSGAS:3,3,6" ) );
     }
 
 
@@ -531,7 +534,18 @@ BOOST_AUTO_TEST_CASE( summary_require3DField ) {
         const auto summary = createSummary( input );
         BOOST_CHECK( summary.require3DField( "PRESSURE"));
         BOOST_CHECK( summary.requireFIPNUM( ));
+        BOOST_CHECK( summary.hasKeyword( "RPR" ) );
+        BOOST_CHECK( summary.hasSummaryKey( "RPR:1" ) );
+        BOOST_CHECK( summary.hasSummaryKey( "RPR:3" ) );
+        BOOST_CHECK( !summary.hasSummaryKey( "RPR:4" ) );
     }
+
+
+    {
+        const auto input = "RPR\n 10 /\n";
+        BOOST_CHECK_THROW( createSummary( input ) , std::invalid_argument );
+    }
+
 
 
     {
@@ -540,5 +554,5 @@ BOOST_AUTO_TEST_CASE( summary_require3DField ) {
         BOOST_CHECK( summary.require3DField( "GIPL"));
         BOOST_CHECK( summary.requireFIPNUM( ));
     }
-
 }
+

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.cpp
@@ -516,6 +516,14 @@ namespace Opm {
         }
     }
 
+    size_t TableManager::numFIPRegions() const {
+        size_t ntfip = m_tabdims.getNumFIPRegions();
+        if (m_regdims->getNTFIP( ) > ntfip)
+            return m_regdims->getNTFIP( );
+        else
+            return ntfip;
+    }
+
     const Tabdims& TableManager::getTabdims() const {
         return m_tabdims;
     }

--- a/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -63,6 +63,11 @@ namespace Opm {
         const Tabdims& getTabdims() const;
         const Eqldims& getEqldims() const;
 
+        /*
+          WIll return max{ Tabdims::NTFIP , Regdims::NTFIP }.
+        */
+        size_t numFIPRegions() const;
+
         const TableContainer& getSwofTables() const;
         const TableContainer& getSgwfnTables() const;
         const TableContainer& getSof2Tables() const;

--- a/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
+++ b/opm/parser/eclipse/EclipseState/Tables/tests/TableManagerTests.cpp
@@ -1233,7 +1233,7 @@ BOOST_AUTO_TEST_CASE( TestParseDENSITY ) {
 BOOST_AUTO_TEST_CASE( TestParseROCK ) {
     const std::string data = R"(
       TABDIMS
-        1* 2 /
+        1* 2 * * 8/
 
       ROCK
         1.1 1.2 /
@@ -1251,12 +1251,16 @@ BOOST_AUTO_TEST_CASE( TestParseROCK ) {
     BOOST_CHECK_EQUAL( 2.2 * 1e-5, rock[1].compressibility );
 
     BOOST_CHECK_THROW( rock.at( 2 ), std::out_of_range );
+    BOOST_CHECK_EQUAL( 8 , tables.numFIPRegions( ));
 }
 
 BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
     const std::string data = R"(
       TABDIMS
         1* 1 /
+
+      REGDIMS
+        25 /
 
       PVCDO
         3600 1.12 1.6e-5 0.88 0.0 /
@@ -1274,7 +1278,7 @@ BOOST_AUTO_TEST_CASE( TestParsePVCDO ) {
     BOOST_CHECK_CLOSE( 0.0,     pvcdo[ 0 ].viscosibility * 1e5, 1e-5 );
 
     BOOST_CHECK_THROW( pvcdo.at( 1 ), std::out_of_range );
-
+    BOOST_CHECK_EQUAL( 25 , tables.numFIPRegions( ));
 
     const std::string malformed = R"(
       TABDIMS

--- a/opm/parser/share/keywords/000_Eclipse100/R/REGION_PROBE
+++ b/opm/parser/share/keywords/000_Eclipse100/R/REGION_PROBE
@@ -107,11 +107,5 @@
  ],
  "comment":"Tracer keywords where the 2nd letter is a 'T' should be compounded with the tracer name",
  "deck_name_regex": "R[OGW]?[IP][PRT]_.+|RU.+|RTIPF.+|RTIPS.+|RTFTF.+|RTFTS.+|RTFTT.+|RTIPT.+|RTIPF.+|RTIPS.+|RTIP[1-9][0-9]*.+|RTFTT.+|RTFTF.+|RTFTS.+|RTFT[1-9][0-9]*.+|RTADS.+|RTDCY.+",
-
- "size" : 1,
- "items" : [{
-  "name" : "REGIONS",
-  "value_type" : "INT",
-  "size_type" : "ALL"
- }]
+ "data" : {"value_type" : "INT"}
 }


### PR DESCRIPTION
The SUMMARY section keywords like `RPR` is used to ask for per region results. If the `Rxxx`keywords are given without region numbers the results should be reported *for all regions*:

```txt
RPR
/
```
currently the opm code interprets *all regions* as all FIPNUM values which are present in the grid, that could for instance result in the following set of summary keys: `{RPR:4, RPR:3, RPR:7}`. The Eclipse interpretation of *all regions* is the set `{"RPR:1, RPR:2, RPR:3, .... RPR:NTFIP}` - where `NTFIP`is the maximum number of fluid in place regions from either the `TABDIMS` or `REGDIMS` keyword. Observe that set of summary keys generated by Eclipse does not consider which regions are actually present in the deck, so we can get many summary variables which only get value zero.

I encourage @alfbr to merge this - if he agrees with the slight change of policy induced in this PR.
