### PR TITLE
Add unit test for field oil efficiency (aka FOE)

### DIFF
--- a/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
+++ b/opm/parser/eclipse/EclipseState/SummaryConfig/tests/SummaryConfigTests.cpp
@@ -156,6 +156,13 @@ BOOST_AUTO_TEST_CASE(fields) {
             names.begin(), names.end() );
 }
 
+BOOST_AUTO_TEST_CASE(field_oil_efficiency) {
+    const auto input = "FOE\n";
+    const auto summary = createSummary( input );
+
+    BOOST_CHECK_EQUAL( true , summary.hasKeyword( "FOE"));
+}
+
 BOOST_AUTO_TEST_CASE(blocks) {
     const auto input = "BPR\n"
                        "3 3 6 /\n"


### PR DESCRIPTION
A unit test for the precense of "FOE" in summary config was created in SummaryConfigTests.cpp.