### PR TITLE
Make debug build work again by not using DEBUG as a test name.

### DIFF
--- a/lib/eclipse/IntegrationTests/ParseKEYWORD.cpp
+++ b/lib/eclipse/IntegrationTests/ParseKEYWORD.cpp
@@ -35,7 +35,7 @@ inline std::string pathprefix() {
     return boost::unit_test::framework::master_test_suite().argv[1];
 }
 
-BOOST_AUTO_TEST_CASE( DEBUG ) {
+BOOST_AUTO_TEST_CASE( DebugDebugData ) {
     Parser().parseFile( pathprefix() + "DEBUG/DEBUG.DATA" );
 }
 


### PR DESCRIPTION
That name is already reserved for OPM compile flags. Resorting
to less generic Name using CamelCase.

Closes #1076 