### PR TITLE
Fix errors / warnings from static analyzers 

### DIFF
--- a/lib/eclipse/Deck/DeckKeyword.cpp
+++ b/lib/eclipse/Deck/DeckKeyword.cpp
@@ -23,20 +23,16 @@
 
 namespace Opm {
 
-    DeckKeyword::DeckKeyword(const std::string& keywordName) {
-        m_knownKeyword = true;
-        m_keywordName = keywordName;
-        m_isDataKeyword = false;
-        m_fileName = "";
-        m_lineNumber = -1;
+    DeckKeyword::DeckKeyword(const std::string& keywordName) :
+        m_keywordName(keywordName), m_lineNumber(-1),
+        m_knownKeyword(true), m_isDataKeyword(false)
+    {
     }
 
-    DeckKeyword::DeckKeyword(const std::string& keywordName, bool knownKeyword) {
-        m_knownKeyword = knownKeyword;
-        m_keywordName = keywordName;
-        m_isDataKeyword = false;
-        m_fileName = "";
-        m_lineNumber = -1;
+    DeckKeyword::DeckKeyword(const std::string& keywordName, bool knownKeyword) :
+        m_keywordName(keywordName), m_lineNumber(-1),
+        m_knownKeyword(knownKeyword), m_isDataKeyword(false)
+    {
     }
 
     void DeckKeyword::setLocation(const std::string& fileName, int lineNumber) {

--- a/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -345,16 +345,16 @@ namespace Opm {
         const std::vector<double>& dzv     = deck.getKeyword<ParserKeywords::DZV>().getSIDoubleData();
         const std::vector<double>& tops    = deck.getKeyword<ParserKeywords::TOPS>().getSIDoubleData();
 
-        if (drv.size() != dims[0])
+        if (drv.size() != static_cast<size_t>(dims[0]))
             throw std::invalid_argument("DRV keyword should have exactly " + std::to_string( dims[0] ) + " elements");
 
-        if (dthetav.size() != dims[1])
+        if (dthetav.size() != static_cast<size_t>(dims[1]))
             throw std::invalid_argument("DTHETAV keyword should have exactly " + std::to_string( dims[1] ) + " elements");
 
-        if (dzv.size() != dims[2])
+        if (dzv.size() != static_cast<size_t>(dims[2]))
             throw std::invalid_argument("DZV keyword should have exactly " + std::to_string( dims[2] ) + " elements");
 
-        if (tops.size() != dims[0] * dims[1])
+        if (tops.size() != static_cast<size_t>(dims[0] * dims[1]))
             throw std::invalid_argument("TOPS keyword should have exactly " + std::to_string( dims[0] * dims[1] ) + " elements");
 
         {
@@ -382,12 +382,12 @@ namespace Opm {
             {
                 std::vector<double> zk(dims[2]);
                 zk[0] = 0;
-                for (size_t k = 1; k < dims[2]; k++)
+                for (int k = 1; k < dims[2]; k++)
                     zk[k] = zk[k - 1] + dzv[k - 1];
 
-                for (size_t k=  0; k < dims[2]; k++) {
-                    for (size_t j=0; j < dims[1]; j++) {
-                        for (size_t i = 0; i < dims[0]; i++) {
+                for (int k = 0; k < dims[2]; k++) {
+                    for (int j = 0; j < dims[1]; j++) {
+                        for (int i = 0; i < dims[0]; i++) {
                             size_t tops_value = tops[ i + dims[0] * j];
                             for (size_t c=0; c < 4; c++) {
                                 zcorn[ zm.index(i,j,k,c) ]     = zk[k] + tops_value;
@@ -403,22 +403,22 @@ namespace Opm {
                 double z1 = *std::min_element( zcorn.begin() , zcorn.end());
                 double z2 = *std::max_element( zcorn.begin() , zcorn.end());
                 ri[0] = deck.getKeyword<ParserKeywords::INRAD>().getRecord(0).getItem(0).getSIDouble( 0 );
-                for (size_t i = 1; i <= dims[0]; i++)
+                for (int i = 1; i <= dims[0]; i++)
                     ri[i] = ri[i - 1] + drv[i - 1];
 
                 tj[0] = 0;
-                for (size_t j = 1; j <= dims[1]; j++)
+                for (int j = 1; j <= dims[1]; j++)
                     tj[j] = tj[j - 1] + dthetav[j - 1];
 
 
-                for (size_t j = 0; j <= dims[1]; j++) {
+                for (int j = 0; j <= dims[1]; j++) {
                     /*
                       The theta value is supposed to go counterclockwise, starting at 'twelve o clock'.
                     */
                     double t = M_PI * (90 - tj[j]) / 180;
                     double c = cos( t );
                     double s = sin( t );
-                    for (size_t i=0; i <= dims[0]; i++) {
+                    for (int i = 0; i <= dims[0]; i++) {
                         double r = ri[i];
                         double x = r*c;
                         double y = r*s;

--- a/lib/eclipse/EclipseState/IOConfig/RestartConfig.cpp
+++ b/lib/eclipse/EclipseState/IOConfig/RestartConfig.cpp
@@ -366,10 +366,10 @@ RPTSCHED( const DeckKeyword& keyword ) {
     auto mnemonics = RPT( keyword, is_RPTSCHED_mnemonic, RPTSCHED_integer );
 
     if( mnemonics.count( "NOTHING" ) )
-        return { std::move( mnemonics ), { 0 } };
+        return { std::move( mnemonics ), { RestartSchedule(0) } };
 
     if( mnemonics.count( "RESTART" ) )
-        return { std::move( mnemonics ), size_t( mnemonics.at( "RESTART" ) ) };
+        return { std::move( mnemonics ), RestartSchedule( size_t( mnemonics.at( "RESTART" )) ) };
 
     return { std::move( mnemonics ), {} };
 }

--- a/lib/eclipse/EclipseState/Schedule/Tuning.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Tuning.cpp
@@ -123,7 +123,7 @@ namespace Opm {
         }
     }
 
-    void Tuning::setTuningInitialValue(const std::string tuningItem, double value, bool resetVector) {
+    void Tuning::setTuningInitialValue(const std::string& tuningItem, double value, bool resetVector) {
         /*The following code diverges from coding standard to improve readabillity*/
         if        ("TSINIT" == tuningItem)  {  m_TSINIT.updateInitial(value); }  //RECORD 1
         else if   ("TSMAXZ" == tuningItem)  {  m_TSMAXZ.updateInitial(value); }
@@ -162,7 +162,7 @@ namespace Opm {
         }
     }
 
-    void Tuning::setTuningInitialValue(const std::string tuningItem, int value, bool resetVector) {
+    void Tuning::setTuningInitialValue(const std::string& tuningItem, int value, bool resetVector) {
         /*The following code diverges from coding standard to improve readabillity*/
         if        ("TRWGHT" == tuningItem)  { m_TRWGHT.updateInitial(value); }  //RECORD 2
 

--- a/lib/eclipse/EclipseState/Schedule/Well.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Well.cpp
@@ -132,7 +132,7 @@ namespace Opm {
         return i.surfaceInjectionRate;
     }
 
-    bool Well::setProductionProperties(size_t timeStep , const WellProductionProperties newProperties) {
+    bool Well::setProductionProperties(size_t timeStep , const WellProductionProperties& newProperties) {
         if (isInjector(timeStep))
             switchToProducer( timeStep );
 
@@ -152,7 +152,7 @@ namespace Opm {
         return m_productionProperties.at(timeStep);
     }
 
-    bool Well::setInjectionProperties(size_t timeStep , const WellInjectionProperties newProperties) {
+    bool Well::setInjectionProperties(size_t timeStep , const WellInjectionProperties& newProperties) {
         if (isProducer(timeStep))
             switchToInjector( timeStep );
 
@@ -172,7 +172,7 @@ namespace Opm {
         return m_injectionProperties.at(timeStep);
     }
 
-    bool Well::setPolymerProperties(size_t timeStep , const WellPolymerProperties newProperties) {
+    bool Well::setPolymerProperties(size_t timeStep , const WellPolymerProperties& newProperties) {
         m_isProducer.update(timeStep , false);
         bool update = m_polymerProperties.update(timeStep, newProperties);
         if (update)

--- a/lib/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/lib/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -275,7 +275,7 @@ inline void keywordR( std::vector< ERT::smspec_node >& list,
     }
 
     for( const int region : regions ) {
-        if (region >= 1 && region <= numfip)
+        if (region >= 1 && region <= static_cast<int>(numfip))
             list.emplace_back( keyword.name(), dims.data(), region );
         else
             throw std::invalid_argument("Illegal region value: " + std::to_string( region ));

--- a/lib/eclipse/EclipseState/Tables/ColumnSchema.cpp
+++ b/lib/eclipse/EclipseState/Tables/ColumnSchema.cpp
@@ -26,7 +26,8 @@ namespace Opm {
     ColumnSchema::ColumnSchema(const std::string& nm, Table::ColumnOrderEnum order, Table::DefaultAction defaultAction) :
         m_name( nm ),
         m_order( order ),
-        m_defaultAction( defaultAction )
+        m_defaultAction( defaultAction ),
+        m_defaultValue ( 0.0 )
     {
 
     }

--- a/lib/eclipse/Parser/ParseContext.cpp
+++ b/lib/eclipse/Parser/ParseContext.cpp
@@ -46,7 +46,7 @@ namespace Opm {
       after the hawrdwired settings.
     */
 
-    ParseContext::ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial) {
+    ParseContext::ParseContext(const std::vector<std::pair<std::string , InputError::Action>>& initial) {
         initDefault();
 
         for (const auto& pair : initial)

--- a/lib/eclipse/Utility/Functional.cpp
+++ b/lib/eclipse/Utility/Functional.cpp
@@ -30,11 +30,11 @@ namespace fun {
     }
 
     iota::const_iterator iota::begin() const {
-        return { first };
+        return const_iterator{ first };
     }
 
     iota::const_iterator iota::end() const {
-        return { last };
+        return const_iterator{ last };
     }
 
     int iota::const_iterator::operator*() const {

--- a/lib/eclipse/include/opm/parser/eclipse/Deck/Deck.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Deck/Deck.hpp
@@ -97,7 +97,7 @@ namespace Opm {
             const std::vector< size_t >& offsets( const std::string& ) const;
 
             DeckView( const_iterator first, const_iterator last );
-            DeckView( std::pair< const_iterator, const_iterator > );
+            explicit DeckView( std::pair< const_iterator, const_iterator > );
 
         private:
             const_iterator first;

--- a/lib/eclipse/include/opm/parser/eclipse/Deck/Deck.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Deck/Deck.hpp
@@ -120,7 +120,9 @@ namespace Opm {
             using iterator = std::vector< DeckKeyword >::iterator;
 
             Deck();
+            // cppcheck-suppress noExplicitConstructor
             Deck( std::initializer_list< DeckKeyword > );
+            // cppcheck-suppress noExplicitConstructor
             Deck( std::initializer_list< std::string > );
             void addKeyword( DeckKeyword&& keyword );
             void addKeyword( const DeckKeyword& keyword );

--- a/lib/eclipse/include/opm/parser/eclipse/Deck/DeckItem.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Deck/DeckItem.hpp
@@ -32,7 +32,7 @@ namespace Opm {
     class DeckItem {
     public:
         DeckItem() = default;
-        DeckItem( const std::string& );
+        explicit DeckItem( const std::string& );
 
         DeckItem( const std::string&, int, size_t size_hint = 8 );
         DeckItem( const std::string&, double, size_t size_hint = 8 );

--- a/lib/eclipse/include/opm/parser/eclipse/Deck/DeckKeyword.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Deck/DeckKeyword.hpp
@@ -33,7 +33,7 @@ namespace Opm {
     public:
         typedef std::vector< DeckRecord >::const_iterator const_iterator;
 
-        DeckKeyword(const std::string& keywordName);
+        explicit DeckKeyword(const std::string& keywordName);
         DeckKeyword(const std::string& keywordName, bool knownKeyword);
 
         const std::string& name() const;

--- a/lib/eclipse/include/opm/parser/eclipse/Deck/Section.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Deck/Section.hpp
@@ -61,49 +61,49 @@ class Section : public DeckView {
     class RUNSPECSection : public Section {
     public:
         using Section::const_iterator;
-        RUNSPECSection(const Deck& deck) : Section(deck, "RUNSPEC") {}
+        explicit RUNSPECSection(const Deck& deck) : Section(deck, "RUNSPEC") {}
     };
 
     class GRIDSection : public Section {
     public:
         using Section::const_iterator;
-        GRIDSection(const Deck& deck) : Section(deck, "GRID") {}
+        explicit GRIDSection(const Deck& deck) : Section(deck, "GRID") {}
     };
 
     class EDITSection : public Section {
     public:
         using Section::const_iterator;
-        EDITSection(const Deck& deck) : Section(deck, "EDIT") {}
+        explicit EDITSection(const Deck& deck) : Section(deck, "EDIT") {}
     };
 
     class PROPSSection : public Section {
     public:
         using Section::const_iterator;
-        PROPSSection(const Deck& deck) : Section(deck, "PROPS") {}
+        explicit PROPSSection(const Deck& deck) : Section(deck, "PROPS") {}
     };
 
     class REGIONSSection : public Section {
     public:
         using Section::const_iterator;
-        REGIONSSection(const Deck& deck) : Section(deck, "REGIONS") {}
+        explicit REGIONSSection(const Deck& deck) : Section(deck, "REGIONS") {}
     };
 
     class SOLUTIONSection : public Section {
     public:
         using Section::const_iterator;
-        SOLUTIONSection(const Deck& deck) : Section(deck, "SOLUTION") {}
+        explicit SOLUTIONSection(const Deck& deck) : Section(deck, "SOLUTION") {}
     };
 
     class SUMMARYSection : public Section {
     public:
         using Section::const_iterator;
-        SUMMARYSection(const Deck& deck) : Section(deck, "SUMMARY") {}
+        explicit SUMMARYSection(const Deck& deck) : Section(deck, "SUMMARY") {}
     };
 
     class SCHEDULESection : public Section {
     public:
         using Section::const_iterator;
-        SCHEDULESection(const Deck& deck) : Section(deck, "SCHEDULE") {}
+        explicit SCHEDULESection(const Deck& deck) : Section(deck, "SCHEDULE") {}
     };
 }
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/Fault.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/Fault.hpp
@@ -32,7 +32,7 @@ namespace Opm {
 
 class Fault {
 public:
-    Fault(const std::string& faultName);
+    explicit Fault(const std::string& faultName);
 
     const  std::string& getName() const;
     void   setTransMult(double transMult);

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/GridDims.hpp
@@ -32,11 +32,11 @@ namespace Opm {
     {
     public:
 
-        GridDims(std::array<int, 3> xyz);
+        explicit GridDims(std::array<int, 3> xyz);
 
         GridDims(size_t nx, size_t ny, size_t nz);
 
-        GridDims(const Deck& deck);
+        explicit GridDims(const Deck& deck);
 
         size_t getNX() const;
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/GridProperties.hpp
@@ -72,7 +72,7 @@ namespace Opm {
                        const UnitSystem*  deckUnitSystem,
                        std::vector< SupportedKeywordInfo >&& supportedKeywords);
 
-        GridProperties(const EclipseGrid& eclipseGrid,
+        explicit GridProperties(const EclipseGrid& eclipseGrid,
                        std::vector< SupportedKeywordInfo >&& supportedKeywords);
 
         T convertInputValue(  const GridProperty<T>& property , double doubleValue) const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -295,7 +295,7 @@ namespace Opm {
         public:
 
             RestartSchedule() = default;
-            RestartSchedule( size_t sched_restart);
+            explicit RestartSchedule( size_t sched_restart);
             RestartSchedule( size_t step, size_t b, size_t freq);
             bool writeRestartFile( size_t timestep , const TimeMap& timemap) const;
             bool operator!=(const RestartSchedule& rhs) const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     class InitConfig {
 
     public:
-        InitConfig(const Deck& deck);
+        explicit InitConfig(const Deck& deck);
 
         void setRestart( const std::string& root, int step);
         bool restartRequested() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp
@@ -28,6 +28,7 @@ namespace Opm {
     class CompletionSet {
     public:
         CompletionSet() = default;
+        // cppcheck-suppress noExplicitConstructor
         CompletionSet( std::initializer_list< Completion > );
 
         using const_iterator = std::vector< Completion >::const_iterator;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Events.hpp
@@ -105,7 +105,7 @@ namespace Opm
 
     class Events {
     public:
-        Events(const TimeMap& timeMap);
+        explicit Events(const TimeMap& timeMap);
         void addEvent(ScheduleEvents::Events event, size_t reportStep);
         bool hasEvent(uint64_t eventMask, size_t reportStep) const;
     private:

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Group.hpp
@@ -37,7 +37,7 @@ namespace Opm {
 
     namespace GroupInjection {
         struct InjectionData {
-            InjectionData( const TimeMap& );
+            explicit InjectionData( const TimeMap& );
 
             DynamicState< Phase > phase;
             DynamicState< GroupInjection::ControlEnum > controlMode;
@@ -52,7 +52,7 @@ namespace Opm {
 
     namespace GroupProduction {
         struct ProductionData {
-            ProductionData( const TimeMap& );
+            explicit ProductionData( const TimeMap& );
 
             DynamicState< GroupProduction::ControlEnum > controlMode;
             DynamicState< GroupProductionExceedLimit::ActionEnum > exceedAction;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/MessageLimits.hpp
@@ -73,7 +73,7 @@ namespace Opm {
            set in the record are modified.
         */
 
-        MessageLimits( const TimeMap& );
+        explicit MessageLimits( const TimeMap& );
 
         ///Get all the value from MESSAGES keyword.
         int getMessagePrintLimit(size_t timestep) const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/OilVaporizationProperties.hpp
@@ -34,6 +34,7 @@ namespace Opm
      */
     class OilVaporizationProperties {
     public:
+        OilVaporizationProperties() = default;
         static OilVaporizationProperties createDRSDT(double maxDRSDT, std::string option);
         static OilVaporizationProperties createDRVDT(double maxDRVDT);
         static OilVaporizationProperties createVAPPARS(double vap1, double vap2);

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
@@ -44,7 +44,7 @@ namespace Opm {
     */
 
     public:
-        Tuning(const TimeMap& timemap);
+        explicit Tuning(const TimeMap& timemap);
 
         void setTuningInitialValue(const std::string tuningItem, double value,bool resetVector);
         void setTuningInitialValue(const std::string tuningItem, int value, bool resetVector);

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Tuning.hpp
@@ -46,8 +46,8 @@ namespace Opm {
     public:
         explicit Tuning(const TimeMap& timemap);
 
-        void setTuningInitialValue(const std::string tuningItem, double value,bool resetVector);
-        void setTuningInitialValue(const std::string tuningItem, int value, bool resetVector);
+        void setTuningInitialValue(const std::string& tuningItem, double value,bool resetVector);
+        void setTuningInitialValue(const std::string& tuningItem, int value, bool resetVector);
         
         void getTuningItemValue(const std::string& tuningItem, size_t timestep, double& value);
         void getTuningItemValue(const std::string& tuningItem, size_t timestep, int& value);

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Well.hpp
@@ -109,15 +109,15 @@ namespace Opm {
         bool operator==(const Well&) const;
         bool operator!=(const Well&) const;
 
-        bool                            setProductionProperties(size_t timeStep , const WellProductionProperties properties);
+        bool                            setProductionProperties(size_t timeStep , const WellProductionProperties& properties);
         WellProductionProperties        getProductionPropertiesCopy(size_t timeStep) const;
         const WellProductionProperties& getProductionProperties(size_t timeStep)  const;
 
-        bool                           setInjectionProperties(size_t timeStep , const WellInjectionProperties properties);
+        bool                           setInjectionProperties(size_t timeStep , const WellInjectionProperties& properties);
         WellInjectionProperties        getInjectionPropertiesCopy(size_t timeStep) const;
         const WellInjectionProperties& getInjectionProperties(size_t timeStep) const;
 
-        bool                           setPolymerProperties(size_t timeStep , const WellPolymerProperties properties);
+        bool                           setPolymerProperties(size_t timeStep , const WellPolymerProperties& properties);
         WellPolymerProperties          getPolymerPropertiesCopy(size_t timeStep) const;
         const WellPolymerProperties&   getPolymerProperties(size_t timeStep) const;
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellEconProductionLimits.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellEconProductionLimits.hpp
@@ -30,7 +30,7 @@ namespace Opm {
 
     class WellEconProductionLimits{
     public:
-        WellEconProductionLimits(const DeckRecord& record);
+        explicit WellEconProductionLimits(const DeckRecord& record);
         WellEconProductionLimits();
 
         // TODO: not handling things related to m_secondary_max_water_cut

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/JFunc.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/JFunc.hpp
@@ -32,7 +32,7 @@ public:
     enum class Flag { BOTH, WATER, GAS };
     enum class Direction { XY, X, Y, Z };
 
-    JFunc(const Deck& deck);
+    explicit JFunc(const Deck& deck);
     double alphaFactor() const;
     double betaFactor() const;
     double goSurfaceTension() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/MiscTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/MiscTable.hpp
@@ -28,7 +28,7 @@ namespace Opm {
 
     class MiscTable : public SimpleTable {
     public:
-        MiscTable( const DeckItem& item );
+        explicit MiscTable( const DeckItem& item );
 
         const TableColumn& getSolventFractionColumn() const;
         const TableColumn& getMiscibilityColumn() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/MsfnTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/MsfnTable.hpp
@@ -28,7 +28,7 @@ namespace Opm {
 
     class MsfnTable : public SimpleTable {
     public:
-        MsfnTable( const DeckItem& item );
+        explicit MsfnTable( const DeckItem& item );
 
         const TableColumn& getGasPhaseFractionColumn() const;
         const TableColumn& getGasSolventRelpermMultiplierColumn() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/PmiscTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/PmiscTable.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     class PmiscTable : public SimpleTable {
     public:
 
-        PmiscTable( const DeckItem& item );
+        explicit PmiscTable( const DeckItem& item );
 
         const TableColumn& getOilPhasePressureColumn() const;
         const TableColumn& getMiscibilityColumn() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/PvtxTable.hpp
@@ -112,7 +112,7 @@ The first row actually corresponds to saturated values.
         static size_t numTables( const DeckKeyword& keyword);
         static std::vector<std::pair<size_t , size_t> > recordRanges( const DeckKeyword& keyword);
 
-        PvtxTable(const std::string& columnName);
+        explicit PvtxTable(const std::string& columnName);
         const SimpleTable& getUnderSaturatedTable(size_t tableNumber) const;
         void init(const DeckKeyword& keyword, size_t tableIdx);
         size_t size() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SgcwmisTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SgcwmisTable.hpp
@@ -28,7 +28,7 @@ namespace Opm {
 
     class SgcwmisTable : public SimpleTable {
     public:
-        SgcwmisTable( const DeckItem& item );
+        explicit SgcwmisTable( const DeckItem& item );
 
         const TableColumn& getWaterSaturationColumn() const;
         const TableColumn& getMiscibleResidualGasColumn() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SorwmisTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SorwmisTable.hpp
@@ -29,7 +29,7 @@ namespace Opm {
     class SorwmisTable : public SimpleTable {
     public:
 
-        SorwmisTable( const DeckItem& item );
+        explicit SorwmisTable( const DeckItem& item );
 
         const TableColumn& getWaterSaturationColumn() const;
         const TableColumn& getMiscibleResidualOilColumn() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/Tabdims.hpp
@@ -49,7 +49,7 @@ namespace Opm {
         { }
 
 
-        Tabdims(const Deck& deck) :
+        explicit Tabdims(const Deck& deck) :
             Tabdims()
         {
             if (deck.hasKeyword("TABDIMS")) {

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/TableManager.hpp
@@ -54,7 +54,7 @@ namespace Opm {
 
     class TableManager {
     public:
-        TableManager( const Deck& deck );
+        explicit TableManager( const Deck& deck );
 
         const TableContainer& getTables( const std::string& tableName ) const;
         const TableContainer& operator[](const std::string& tableName) const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Util/Value.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Util/Value.hpp
@@ -46,7 +46,7 @@ private:
 
 public:
 
-    Value(const std::string& name) :
+    explicit Value(const std::string& name) :
         m_name( name ),
         m_initialized( false )
     { }

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -79,7 +79,7 @@ namespace Opm {
     class ParseContext {
     public:
         ParseContext();
-        explicit ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
+        explicit ParseContext(const std::vector<std::pair<std::string , InputError::Action>>& initial);
         Message::type handleError( const std::string& errorKey, MessageContainer& msgContainer, const std::string& msg ) const;
         bool hasKey(const std::string& key) const;
         ParseContext  withKey(const std::string& key, InputError::Action action = InputError::WARN) const;

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -79,7 +79,7 @@ namespace Opm {
     class ParseContext {
     public:
         ParseContext();
-        ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
+        explicit ParseContext(const std::vector<std::pair<std::string , InputError::Action>> initial);
         Message::type handleError( const std::string& errorKey, MessageContainer& msgContainer, const std::string& msg ) const;
         bool hasKey(const std::string& key) const;
         ParseContext  withKey(const std::string& key, InputError::Action action = InputError::WARN) const;

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/Parser.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/Parser.hpp
@@ -47,7 +47,7 @@ namespace Opm {
 
     class Parser {
     public:
-        Parser(bool addDefault = true);
+        explicit Parser(bool addDefault = true);
 
         static std::string stripComments(const std::string& inputString);
 

--- a/lib/eclipse/include/opm/parser/eclipse/Utility/Functional.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Utility/Functional.hpp
@@ -195,7 +195,7 @@ namespace fun {
      */
     class iota {
         public:
-            iota( int end );
+            explicit iota( int end );
             iota( int begin, int end );
 
             class const_iterator {
@@ -217,7 +217,7 @@ namespace fun {
                     bool operator!=( const const_iterator& rhs ) const;
 
                 private:
-                    const_iterator( int );
+                    explicit const_iterator( int );
                     int value;
 
                     friend class iota;

--- a/lib/eclipse/include/opm/parser/eclipse/Utility/Stringview.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Utility/Stringview.hpp
@@ -52,8 +52,10 @@ namespace Opm {
             inline string_view() = default;
             inline string_view( const_iterator, const_iterator );
             inline string_view( const_iterator, size_t );
+            //cppcheck-suppress noExplicitConstructor
             inline string_view( const std::string& );
             inline string_view( const std::string&, size_t );
+            //cppcheck-suppress noExplicitConstructor
             inline string_view( const char* );
 
             inline const_iterator begin() const;

--- a/lib/eclipse/tests/SectionTests.cpp
+++ b/lib/eclipse/tests/SectionTests.cpp
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(SCHEDULESection_NotTerminated) {
 
 BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
 
-    ParseContext mode = { { { ParseContext::PARSE_UNKNOWN_KEYWORD, InputError::IGNORE } } };
+    ParseContext mode { { { ParseContext::PARSE_UNKNOWN_KEYWORD, InputError::IGNORE } } };
     Parser parser;
 
     const std::string minimal = "RUNSPEC\n"
@@ -246,7 +246,7 @@ BOOST_AUTO_TEST_CASE(Section_ValidDecks) {
 BOOST_AUTO_TEST_CASE(Section_InvalidDecks) {
 
     Parser parser;
-    ParseContext mode = { { { ParseContext::PARSE_UNKNOWN_KEYWORD, InputError::IGNORE } } };
+    ParseContext mode { { { ParseContext::PARSE_UNKNOWN_KEYWORD, InputError::IGNORE } } };
 
     const std::string keyword_before_RUNSPEC =
                                 "WWCT \n /\n"


### PR DESCRIPTION
These are the errors report from static analyzers in this module.

As the string_view is designed around implicit casts, it does not make sense to make those constructors explicit so I chose the suppression route there. 

Just as a FYI: should you not like the suppression tags, we can use a regular expression in the wrapper script instead.