### PR TITLE
Add SPOLY and make SSOL a grid property

### DIFF
--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -370,6 +370,7 @@ namespace Opm {
         supportedDoubleKeywords.emplace_back( "PRESSURE", 0.0 , "Pressure" );
         supportedDoubleKeywords.emplace_back( "SWAT", 0.0 , "1" );
         supportedDoubleKeywords.emplace_back( "SGAS", 0.0 , "1" );
+        supportedDoubleKeywords.emplace_back( "SSOL", 0.0 , "1" );
         supportedDoubleKeywords.emplace_back( "SPOLY", 0.0 , "Density" );
         supportedDoubleKeywords.emplace_back( "RS",  0.0, "1" );
         supportedDoubleKeywords.emplace_back( "RV",  0.0, "1" );

--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -370,6 +370,7 @@ namespace Opm {
         supportedDoubleKeywords.emplace_back( "PRESSURE", 0.0 , "Pressure" );
         supportedDoubleKeywords.emplace_back( "SWAT", 0.0 , "1" );
         supportedDoubleKeywords.emplace_back( "SGAS", 0.0 , "1" );
+        supportedDoubleKeywords.emplace_back( "SPOLY", 0.0 , "Density" );
         supportedDoubleKeywords.emplace_back( "RS",  0.0, "1" );
         supportedDoubleKeywords.emplace_back( "RV",  0.0, "1" );
 

--- a/lib/eclipse/share/keywords/000_Eclipse100/S/SPOLY
+++ b/lib/eclipse/share/keywords/000_Eclipse100/S/SPOLY
@@ -1,0 +1,8 @@
+{
+  "name" : "SPOLY" ,
+  "sections" : ["SOLUTION", "SPECIAL"],
+  "data" : {
+    "value_type" : "DOUBLE",
+    "dimension" : "Density"
+  }
+}


### PR DESCRIPTION
this adds a JSON definition plus grid property for the SPOLY keyword and it also adds the already existing SSOL keyword to the list of grid properties. with this PR it should be possible to access all properties required for polymer and solvent enabled simulators without resorting to the deck object.