### PR TITLE
Create boost targets names dynamically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,32 +76,80 @@ else ()
 endif ()
 
 find_package(Boost 1.44.0
-             COMPONENTS filesystem date_time system unit_test_framework regex
+             COMPONENTS filesystem
+                        date_time
+                        system
+                        unit_test_framework
+                        regex
              REQUIRED)
 
+# boost libraries are often named with -mt, -d, -g etc. when they're configured
+# in a particular way, and should be linked to precisely these libraries.
+# create a target name from a found boost lib, possibly adjusted to the build
+# type.
+function(boost_target target component)
+    function(libname var lib)
+        get_filename_component(name "${lib}" NAME_WE)
+        string(SUBSTRING ${name} 3 -1 name)
+        set(${var} ${name} PARENT_SCOPE)
+    endfunction()
+
+    unset(lib_name)
+    list(LENGTH ARGN library_list_length)
+    # list only contains one element (the library itself) - strip the lib
+    # prefix and return
+    if (library_list_length EQUAL 1)
+        libname(lib_name ${ARGN})
+        set(${target} ${lib_name} PARENT_SCOPE)
+        return()
+    endif()
+
+    # Build type is one of the standard (debug, release, relwithdebinfo,
+    # minsizerel and we choose build/release accordingly
+    string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type)
+    set(lib_name ${Boost_${component}_LIBRARY})
+
+    if ("${_build_type}" STREQUAL "DEBUG")
+        if (Boost_${component}_LIBRARY_DEBUG)
+            set(lib_name ${Boost_${component}_LIBRARY_DEBUG})
+        endif()
+
+        libname(lib_name ${lib_name})
+        set(${target} ${lib_name} PARENT_SCOPE)
+        return ()
+    endif()
+
+    if ("${_build_type}" MATCHES "(RELEASE)|(RELWITHDEBINFO)|(MINSIZEREL)")
+        if (Boost_${component}_LIBRARY_RELEASE)
+            set(lib_name ${Boost_${component}_LIBRARY_RELEASE})
+        endif()
+
+        libname(lib_name ${lib_name})
+        set(${target} ${lib_name} PARENT_SCOPE)
+        return ()
+    endif()
+
+    # check if it is some custom build type that's also a debug type
+    # if not, assume linking to optimized is what we want
+    list(FIND DEBUG_CONFIGURATIONS "${CMAKE_BUILD_TYPE}" _is_debug)
+    if (NOT _is_debug EQUAL -1)
+        set(key debug)
+    else()
+        set(key optimized)
+    endif ()
+
+    list(FIND ARGN ${key} _index)
+    math(EXPR _index "${_index} + 1")
+    list(GET ARGN ${_index} lib_name)
+
+    libname(lib_name ${lib_name})
+    set(${target} ${lib_name} PARENT_SCOPE)
+endfunction()
+
 # make targets for boost
-add_library(boost_filesystem UNKNOWN IMPORTED)
-set_target_properties(boost_filesystem PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
-    INTERFACE_COMPILE_DEFINITIONS BOOST_FILESYSTEM_VERSION=3
-    INTERFACE_LINK_LIBRARIES  "boost_system"
-    IMPORTED_LOCATION         "${Boost_FILESYSTEM_LIBRARY}"
-    IMPORTED_LOCATION_DEBUG   "${Boost_FILESYSTEM_LIBRARY_DEBUG}"
-    IMPORTED_LOCATION_RELEASE "${Boost_FILESYSTEM_LIBRARY_RELEASE}"
-)
-
-add_library(boost_date_time UNKNOWN IMPORTED)
-set_target_properties(boost_date_time PROPERTIES
-    INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
-    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
-    IMPORTED_LOCATION       "${Boost_DATE_TIME_LIBRARY}"
-    IMPORTED_LOCATION_DEBUG "${Boost_DATE_TIME_LIBRARY_DEBUG}"
-    IMPORTED_LOCATION_RELEASE "${Boost_DATE_TIME_LIBRARY_RELEASE}"
-)
-
-add_library(boost_system UNKNOWN IMPORTED)
-set_target_properties(boost_system PROPERTIES
+boost_target(boost_system SYSTEM ${Boost_SYSTEM_LIBRARY})
+add_library(${boost_system} UNKNOWN IMPORTED)
+set_target_properties(${boost_system} PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
     IMPORTED_LOCATION         "${Boost_SYSTEM_LIBRARY}"
@@ -109,10 +157,35 @@ set_target_properties(boost_system PROPERTIES
     IMPORTED_LOCATION_RELEASE "${Boost_SYSTEM_LIBRARY_RELEASE}"
 )
 
-add_library(boost_regex UNKNOWN IMPORTED)
-set_target_properties(boost_regex PROPERTIES
+boost_target( boost_filesystem FILESYSTEM ${Boost_FILESYSTEM_LIBRARY} )
+add_library(${boost_filesystem} UNKNOWN IMPORTED)
+set_target_properties(${boost_filesystem} PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+    INTERFACE_COMPILE_DEFINITIONS BOOST_FILESYSTEM_VERSION=3
+    INTERFACE_LINK_LIBRARIES  "${boost_system}"
+    IMPORTED_LOCATION         "${Boost_FILESYSTEM_LIBRARY}"
+    IMPORTED_LOCATION_DEBUG   "${Boost_FILESYSTEM_LIBRARY_DEBUG}"
+    IMPORTED_LOCATION_RELEASE "${Boost_FILESYSTEM_LIBRARY_RELEASE}"
+)
+
+boost_target( boost_date_time DATE_TIME ${Boost_DATE_TIME_LIBRARY} )
+add_library(${boost_date_time} UNKNOWN IMPORTED)
+set_target_properties(${boost_date_time} PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+    IMPORTED_LOCATION         "${Boost_DATE_TIME_LIBRARY}"
+    IMPORTED_LOCATION_DEBUG   "${Boost_DATE_TIME_LIBRARY_DEBUG}"
+    IMPORTED_LOCATION_RELEASE "${Boost_DATE_TIME_LIBRARY_RELEASE}"
+)
+
+
+boost_target( boost_regex REGEX ${Boost_REGEX_LIBRARY} )
+add_library(${boost_regex} UNKNOWN IMPORTED)
+set_target_properties(${boost_regex} PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+    INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
+    INTERFACE_LINK_LIBRARIES  "${boost_system}"
     IMPORTED_LOCATION         "${Boost_REGEX_LIBRARY}"
     IMPORTED_LOCATION_DEBUG   "${Boost_REGEX_LIBRARY_DEBUG}"
     IMPORTED_LOCATION_RELEASE "${Boost_REGEX_LIBRARY_RELEASE}"
@@ -122,7 +195,7 @@ add_library(boost_test UNKNOWN IMPORTED)
 set_target_properties(boost_test PROPERTIES
     INTERFACE_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
     INTERFACE_SYSTEM_INCLUDE_DIRECTORIES "${Boost_INCLUDE_DIRS}"
-    INTERFACE_LINK_LIBRARIES  "boost_system"
+    INTERFACE_LINK_LIBRARIES  "${boost_system}"
     IMPORTED_LOCATION         "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}"
     IMPORTED_LOCATION_DEBUG   "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY_DEBUG}"
     IMPORTED_LOCATION_RELEASE "${Boost_UNIT_TEST_FRAMEWORK_LIBRARY_RELEASE}"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,12 +31,12 @@ build_script:
     - git clone https://github.com/statoil/libecl
     - ps: mkdir -p libecl/build
     - ps: pushd libecl/build
-    - cmake C:\projects\opm-parser\libecl -G"%GEN%" -DCMAKE_BUILD_TYPE=%configuration% -DERT_BUILD_CXX=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_PYTHON=OFF
+    - cmake .. -G"%GEN%" -DCMAKE_BUILD_TYPE=%configuration% -DERT_BUILD_CXX=ON -DBUILD_SHARED_LIBS=OFF -DBUILD_PYTHON=OFF
     - cmake --build . --config %configuration%
     - ps: popd
     - mkdir build
     - ps: pushd build
-    - cmake C:\projects\opm-parser -G"%GEN%" %BOOST_OPTIONS% -DOPM_DATA_ROOT=%DATA_ROOT% -DCMAKE_BUILD_TYPE=%configuration%
+    - cmake .. -G"%GEN%" %BOOST_OPTIONS% -DOPM_DATA_ROOT=%DATA_ROOT% -DCMAKE_BUILD_TYPE=%configuration%
     - cmake --build . --config %configuration%
     - ctest -C %configuration% --output-on-failure
     - ps: popd

--- a/lib/eclipse/CMakeLists.txt
+++ b/lib/eclipse/CMakeLists.txt
@@ -22,7 +22,7 @@ set(genkw_SOURCES Parser/createDefaultKeywordList.cpp
 )
 add_executable(genkw ${genkw_SOURCES})
 
-target_link_libraries(genkw opmjson ecl boost_regex)
+target_link_libraries(genkw opmjson ecl ${boost_regex})
 target_include_directories(genkw PRIVATE include)
 
 file(GLOB_RECURSE keyword_templates share/keywords/*)
@@ -128,10 +128,10 @@ add_library(opmparser ${opmparser_SOURCES})
 
 target_link_libraries(opmparser PUBLIC opmjson
                                        ecl
-                                       boost_filesystem
-                                       boost_system
-                                       boost_regex
-                                       boost_date_time)
+                                       ${boost_filesystem}
+                                       ${boost_system}
+                                       ${boost_regex}
+                                       ${boost_date_time})
 target_compile_definitions(opmparser PRIVATE -DOPM_PARSER_DECK_API=1)
 target_include_directories(opmparser
     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/lib/json/CMakeLists.txt
+++ b/lib/json/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(opm-json CXX)
 
 add_library(opmjson JsonObject.cpp $<TARGET_OBJECTS:cjson>)
-target_link_libraries(opmjson PUBLIC boost_filesystem)
+target_link_libraries(opmjson PUBLIC ${boost_filesystem})
 
 if (CJSON_LIBRARY)
     target_link_libraries(opmjson PUBLIC cjson)


### PR DESCRIPTION
On some systems, in particular Windows or custom boosts, plenty
information about configuration is embedded into the library name.
However, opm-parser's boost names were hard coded to the vanilla library
names, which leads to libraries not being found.

Generate the target names dynamically (and address them as variables) so
that the target names match the name of the library actually being
linked to - a name which is also then later exported to the
opm-parser-config.cmake file.

Supersedes https://github.com/OPM/opm-parser/pull/1088