### PR TITLE
Change time map api

### DIFF
--- a/lib/eclipse/EclipseState/IOConfig/IOConfig.cpp
+++ b/lib/eclipse/EclipseState/IOConfig/IOConfig.cpp
@@ -58,13 +58,11 @@ namespace Opm {
     IOConfig::IOConfig( const Deck& deck ) :
         IOConfig( GRIDSection( deck ),
                   RUNSPECSection( deck ),
-                  TimeMap( deck ),
                   deck.hasKeyword("NOSIM"),
                   deck.getDataFile() )
     {}
 
     IOConfig::IOConfig( const std::string& input_path ) :
-        m_timemap( TimeMap{ Deck{} } ),
         m_deck_filename( input_path ),
         m_output_dir( outputdir( input_path ) ),
         m_base_name( basename( input_path ) )
@@ -97,10 +95,8 @@ namespace Opm {
 
     IOConfig::IOConfig( const GRIDSection& grid,
                         const RUNSPECSection& runspec,
-                        TimeMap timemap,
                         bool nosim,
                         const std::string& input_path ) :
-        m_timemap( std::move( timemap ) ),
         m_write_INIT_file( grid.hasKeyword( "INIT" ) ),
         m_write_EGRID_file( write_egrid_file( grid ) ),
         m_UNIFIN( runspec.hasKeyword( "UNIFIN" ) ),
@@ -165,13 +161,6 @@ namespace Opm {
 
     bool IOConfig::getFMTOUT() const {
         return m_FMTOUT;
-    }
-
-
-
-    boost::gregorian::date IOConfig::getTimestepDate(size_t reportStep) const {
-        const auto& time = m_timemap[reportStep];
-        return time.date();
     }
 
 

--- a/lib/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -56,15 +56,6 @@
 
 namespace Opm {
 
-    namespace {
-
-        time_t posixTime( const boost::posix_time::ptime& t) {
-            boost::posix_time::ptime epoch( boost::gregorian::date( 1970, 1, 1 ) );
-            return time_t( ( t - epoch ).total_seconds() );
-        }
-
-    }
-
     Schedule::Schedule( const ParseContext& parseContext,
                         const EclipseGrid& grid,
                         const Eclipse3DProperties& eclipseProperties,
@@ -101,16 +92,16 @@ namespace Opm {
         }
     }
 
-    boost::posix_time::ptime Schedule::getStartTime() const {
-        return m_timeMap.getStartTime(/*timeStepIdx=*/0);
+    std::time_t Schedule::getStartTime() const {
+        return this->posixStartTime( );
     }
 
     time_t Schedule::posixStartTime() const {
-        return posixTime(this->getStartTime());
+        return m_timeMap.getStartTime( 0 );
     }
 
     time_t Schedule::posixEndTime() const {
-        return posixTime( this->m_timeMap.getEndTime() );
+        return this->m_timeMap.getEndTime();
     }
 
     void Schedule::iterateScheduleSection(const ParseContext& parseContext , const SCHEDULESection& section , const EclipseGrid& grid,

--- a/lib/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/lib/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -18,6 +18,9 @@
 */
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <ctime>
+
+#include <ert/util/util.h>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
@@ -320,11 +323,33 @@ namespace Opm {
     }
 
 
-    const boost::posix_time::ptime& TimeMap::operator[] (size_t index) const {
-        if (index < m_timeList.size())
-            return m_timeList[index];
-        else
+    std::time_t TimeMap::operator[] (size_t index) const {
+        if (index < m_timeList.size()) {
+            boost::posix_time::ptime boost_time = m_timeList[index];
+            boost::posix_time::ptime epoch(boost::gregorian::date(1970,1,1));
+            boost::posix_time::time_duration::sec_type duration = (boost_time - epoch).total_seconds();
+
+            return std::time_t( duration );
+        } else
             throw std::invalid_argument("Index out of range");
+    }
+
+
+
+    std::time_t TimeMap::mkdate(int in_year, int in_month, int in_day) {
+        std::time_t t = util_make_date_utc( in_day , in_month , in_year );
+        {
+            /*
+               The underlying mktime( ) function will happily wrap
+               around dates like January 33, this function will check
+               that no such wrap-around has taken place.
+            */
+            int out_year, out_day, out_month;
+            util_set_date_values_utc( t, &out_day , &out_month, &out_year);
+            if ((in_day != out_day) || (in_month != out_month) || (in_year != out_year))
+                throw std::invalid_argument("Invalid input arguments for date.");
+        }
+        return t;
     }
 
 

--- a/lib/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/lib/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -76,12 +76,12 @@ namespace Opm {
     }
 
 
-    boost::posix_time::ptime TimeMap::getStartTime(size_t tStepIdx) const {
-        return m_timeList[tStepIdx];
+    std::time_t TimeMap::getStartTime(size_t tStepIdx) const {
+        return this->operator[]( tStepIdx );
     }
 
-    boost::posix_time::ptime TimeMap::getEndTime() const {
-        return m_timeList.back();
+    std::time_t TimeMap::getEndTime() const {
+        return this->operator[]( this->size( ) - 1);
     }
 
     double TimeMap::getTotalTime() const

--- a/lib/eclipse/EclipseState/Schedule/TimeMap.cpp
+++ b/lib/eclipse/EclipseState/Schedule/TimeMap.cpp
@@ -353,6 +353,15 @@ namespace Opm {
     }
 
 
+    std::time_t TimeMap::forward(std::time_t t, long seconds) {
+        return t + seconds;
+    }
+
+    std::time_t TimeMap::forward(std::time_t t, int hours, int minutes, long seconds) {
+        return t + seconds + minutes * 60 + hours * 3600;
+    }
+
+
 }
 
 

--- a/lib/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/lib/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -49,8 +49,12 @@ inline void verifyRestartConfig( const TimeMap& tm, const RestartConfig& rst, st
 
         BOOST_CHECK_EQUAL( save, rst.getWriteRestartFile( report_step ) );
         if (save) {
-            boost::posix_time::ptime ptime = tm[report_step];
-            BOOST_CHECK_EQUAL( report_date, ptime.date() );
+            std::time_t t = tm[report_step];
+            boost::posix_time::ptime epoch(boost::gregorian::date(1970,1,1));
+            boost::posix_time::ptime report_date_ptime(report_date);
+            boost::posix_time::time_duration::sec_type duration = (report_date_ptime - epoch).total_seconds();
+
+            BOOST_CHECK_EQUAL( duration , t );
         }
     }
 }

--- a/lib/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
+++ b/lib/eclipse/IntegrationTests/IOConfigIntegrationTest.cpp
@@ -40,7 +40,7 @@ inline std::string prefix() {
     return boost::unit_test::framework::master_test_suite().argv[1];
 }
 
-inline void verifyRestartConfig( const RestartConfig& rst, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
+inline void verifyRestartConfig( const TimeMap& tm, const RestartConfig& rst, std::vector<std::tuple<int , bool, boost::gregorian::date>>& rptConfig) {
 
     for (auto rptrst : rptConfig) {
         int report_step                    = std::get<0>(rptrst);
@@ -49,7 +49,8 @@ inline void verifyRestartConfig( const RestartConfig& rst, std::vector<std::tupl
 
         BOOST_CHECK_EQUAL( save, rst.getWriteRestartFile( report_step ) );
         if (save) {
-            BOOST_CHECK_EQUAL( report_date, rst.getTimestepDate( report_step ));
+            boost::posix_time::ptime ptime = tm[report_step];
+            BOOST_CHECK_EQUAL( report_date, ptime.date() );
         }
     }
 }
@@ -301,7 +302,7 @@ BOOST_AUTO_TEST_CASE( NorneRestartConfig ) {
 
 
     auto state = Parser::parse(prefix() + "IOConfig/RPTRST_DECK.DATA");
-    verifyRestartConfig(state.cfg().restart(), rptConfig);
+    verifyRestartConfig(state.getSchedule().getTimeMap(), state.cfg().restart(), rptConfig);
 }
 
 
@@ -344,7 +345,7 @@ BOOST_AUTO_TEST_CASE( RestartConfig2 ) {
     auto deck = parser.parseFile(prefix() + "IOConfig/RPT_TEST2.DATA", parseContext);
     EclipseState state( deck , parseContext );
     const auto& rstConfig = state.cfg().restart();
-    verifyRestartConfig( rstConfig, rptConfig );
+    verifyRestartConfig(state.getSchedule().getTimeMap(), state.cfg().restart(), rptConfig);
 
     BOOST_CHECK_EQUAL( rstConfig.getFirstRestartStep() , 0 );
 }

--- a/lib/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/IntegrationTests/ScheduleCreateFromDeck.cpp
@@ -29,6 +29,7 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Well.hpp>
@@ -54,7 +55,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Schedule sched(parseContext , grid , eclipseProperties, deck, Phases(true, true, true) );
     const auto& timeMap = sched.getTimeMap();
-    BOOST_CHECK_EQUAL(boost::posix_time::ptime(boost::gregorian::date(2007, boost::gregorian::May, 10)), sched.getStartTime());
+    BOOST_CHECK_EQUAL(TimeMap::mkdate(2007 , 5 , 10), sched.getStartTime());
     BOOST_CHECK_EQUAL(9U, timeMap.size());
     BOOST_CHECK( deck.hasKeyword("NETBALAN") );
 }
@@ -70,7 +71,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule_Comments_After_Keywords) {
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Schedule sched(parseContext , grid , eclipseProperties, deck, Phases(true, true, true) );
     const auto& timeMap = sched.getTimeMap();
-    BOOST_CHECK_EQUAL(boost::posix_time::ptime(boost::gregorian::date(2007, boost::gregorian::May, 10)), sched.getStartTime());
+    BOOST_CHECK_EQUAL(TimeMap::mkdate(2007, 5 , 10) , sched.getStartTime());
     BOOST_CHECK_EQUAL(9U, timeMap.size());
 }
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp
@@ -22,8 +22,6 @@
 
 #include <boost/date_time/gregorian/gregorian_types.hpp>
 
-#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
-
 namespace Opm {
 
     class Deck;
@@ -133,9 +131,6 @@ namespace Opm {
         void overrideNOSIM(bool nosim);
 
 
-
-        boost::gregorian::date getTimestepDate(size_t timestep) const;
-
         std::string getRestartFileName(const std::string& restart_base, int report_step, bool output) const;
 
         bool getOutputEnabled() const;
@@ -161,7 +156,6 @@ namespace Opm {
         void setWriteInitialRestartFile(bool writeInitialRestartFile);
 
     private:
-        TimeMap m_timemap;
         bool            m_write_INIT_file = false;
         bool            m_write_EGRID_file = true;
         bool            m_UNIFIN = false;
@@ -178,7 +172,6 @@ namespace Opm {
 
         IOConfig( const GRIDSection&,
                   const RUNSPECSection&,
-                  TimeMap,
                   bool nosim,
                   const std::string& input_path );
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp
@@ -332,11 +332,6 @@ namespace Opm {
         void handleSolutionSection(const SOLUTIONSection& solutionSection);
         void setWriteInitialRestartFile(bool writeInitialRestartFile);
 
-        boost::gregorian::date getTimestepDate(size_t reportStep) const {
-            const auto& time = this->m_timemap[reportStep];
-            return time.date();
-        }
-
         RestartSchedule getNode( size_t timestep ) const;
         static std::string getRestartFileName(const std::string& restart_base, int report_step, bool unified, bool fmt_file);
     private:

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -60,7 +60,7 @@ namespace Opm
          * If the input deck does not specify a start time, Eclipse's 1. Jan
          * 1983 is defaulted
          */
-        boost::posix_time::ptime getStartTime() const;
+        time_t getStartTime() const;
         time_t posixStartTime() const;
         time_t posixEndTime() const;
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -49,8 +49,8 @@ namespace Opm {
         //boost::posix_time::ptime operator[] (size_t index) const;
         std::time_t operator[] (size_t index) const;
         /// Return the date and time where a given time step starts.
-        boost::posix_time::ptime getStartTime(size_t tStepIdx) const;
-        boost::posix_time::ptime getEndTime() const;
+        std::time_t getStartTime(size_t tStepIdx) const;
+        std::time_t getEndTime() const;
         /// Return the period of time in seconds which passed between the start of the simulation and a given point in time.
         double getTimePassedUntil(size_t tLevelIdx) const;
         /// Return the length of a given time step in seconds.

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -22,6 +22,7 @@
 #define TIMEMAP_HPP_
 
 #include <vector>
+#include <ctime>
 
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
@@ -44,7 +45,9 @@ namespace Opm {
         size_t last() const;
         size_t numTimesteps() const;
         double getTotalTime() const;
-        const boost::posix_time::ptime& operator[] (size_t index) const;
+
+        //boost::posix_time::ptime operator[] (size_t index) const;
+        std::time_t operator[] (size_t index) const;
         /// Return the date and time where a given time step starts.
         boost::posix_time::ptime getStartTime(size_t tStepIdx) const;
         boost::posix_time::ptime getEndTime() const;
@@ -61,6 +64,7 @@ namespace Opm {
         static boost::posix_time::ptime timeFromEclipse( const DeckRecord& dateRecord);
         static boost::posix_time::ptime timeFromEclipse(int day , const std::string& month, int year, const std::string& eclipseTimeString = "00:00:00.000");
         static boost::posix_time::time_duration dayTimeFromEclipse(const std::string& eclipseTimeString);
+        static std::time_t mkdate(int year, int month, int day);
     private:
         static const std::map<std::string , boost::gregorian::greg_month>& eclipseMonthNames();
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp
@@ -64,6 +64,9 @@ namespace Opm {
         static boost::posix_time::ptime timeFromEclipse( const DeckRecord& dateRecord);
         static boost::posix_time::ptime timeFromEclipse(int day , const std::string& month, int year, const std::string& eclipseTimeString = "00:00:00.000");
         static boost::posix_time::time_duration dayTimeFromEclipse(const std::string& eclipseTimeString);
+
+        static std::time_t forward(std::time_t t0, int hours, int minutes, long seconds);
+        static std::time_t forward(std::time_t t0, long seconds);
         static std::time_t mkdate(int year, int month, int day);
     private:
         static const std::map<std::string , boost::gregorian::greg_month>& eclipseMonthNames();

--- a/lib/eclipse/tests/EclipseStateTests.cpp
+++ b/lib/eclipse/tests/EclipseStateTests.cpp
@@ -26,6 +26,7 @@ along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/ThresholdPressure.hpp>
@@ -201,7 +202,7 @@ BOOST_AUTO_TEST_CASE(CreateSchedule) {
     EclipseState state(deck, ParseContext());
     const auto& schedule = state.getSchedule();
 
-    BOOST_CHECK_EQUAL(schedule.getStartTime(), boost::posix_time::ptime(boost::gregorian::date(1998, 3, 8)));
+    BOOST_CHECK_EQUAL(schedule.getStartTime(), TimeMap::mkdate( 1998 , 3 , 8));
 }
 
 

--- a/lib/eclipse/tests/ScheduleTests.cpp
+++ b/lib/eclipse/tests/ScheduleTests.cpp
@@ -28,6 +28,7 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
+#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Group.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/GroupTree.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/CompletionSet.hpp>
@@ -201,7 +202,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckMissingReturnsDefaults) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Schedule schedule(ParseContext() , grid , eclipseProperties, deck, Phases(true, true, true) );
-    BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1983  , boost::gregorian::Jan , 1)));
+    BOOST_CHECK_EQUAL( schedule.getStartTime() , TimeMap::mkdate(1983, 1 , 1));
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWellsOrdered) {
@@ -223,7 +224,7 @@ BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithStart) {
     TableManager table ( deck );
     Eclipse3DProperties eclipseProperties ( deck , table, grid);
     Schedule schedule(ParseContext() , grid , eclipseProperties, deck, Phases(true, true, true) );
-    BOOST_CHECK_EQUAL( schedule.getStartTime() , boost::posix_time::ptime(boost::gregorian::date( 1998  , boost::gregorian::Mar , 8)));
+    BOOST_CHECK_EQUAL( schedule.getStartTime() , TimeMap::mkdate(1998, 3  , 8 ));
 }
 
 BOOST_AUTO_TEST_CASE(CreateScheduleDeckWithSCHEDULENoThrow) {

--- a/lib/eclipse/tests/TimeMapTest.cpp
+++ b/lib/eclipse/tests/TimeMapTest.cpp
@@ -96,8 +96,8 @@ BOOST_AUTO_TEST_CASE(AddStepSizeCorrect) {
     BOOST_CHECK_EQUAL( 3U , timeMap.size());
 
     BOOST_CHECK_THROW( timeMap[3] , std::invalid_argument );
-    BOOST_CHECK_EQUAL( timeMap[0] , boost::posix_time::ptime(boost::posix_time::ptime(startDate)));
-    BOOST_CHECK_EQUAL( timeMap[2] , boost::posix_time::ptime(boost::posix_time::ptime( boost::gregorian::date( 2010 , boost::gregorian::Jan , 2 ))));
+    BOOST_CHECK_EQUAL( timeMap[0] , Opm::TimeMap::mkdate(2010, 1, 1 ));
+    BOOST_CHECK_EQUAL( timeMap[2] , Opm::TimeMap::mkdate(2010, 1, 2 ));
 }
 
 
@@ -342,5 +342,10 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
             BOOST_CHECK_EQUAL(false, tmap.isTimestepInFirstOfMonthsYearsSequence(timestep, true, false));
         }
     }
+}
+
+
+BOOST_AUTO_TEST_CASE(mkdate) {
+    BOOST_CHECK_THROW( Opm::TimeMap::mkdate( 2010 , 0 , 0  ) , std::invalid_argument);
 }
 

--- a/lib/eclipse/tests/TimeMapTest.cpp
+++ b/lib/eclipse/tests/TimeMapTest.cpp
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_CASE(GetStartDate) {
     boost::gregorian::date startDate( 2010 , boost::gregorian::Jan , 1);
     boost::posix_time::ptime startTime(startDate);
     Opm::TimeMap timeMap(startTime);
-    BOOST_CHECK_EQUAL( startTime , timeMap.getStartTime(/*timeStepIdx=*/0));
+    BOOST_CHECK_EQUAL( Opm::TimeMap::mkdate(2010, 1, 1) , timeMap.getStartTime(/*timeStepIdx=*/0));
 }
 
 
@@ -214,68 +214,70 @@ BOOST_AUTO_TEST_CASE( addTSTEPFromWrongKeywordThrows ) {
     BOOST_CHECK_THROW( timeMap.addFromTSTEPKeyword( deckKeyword ) , std::invalid_argument );
 }
 
-BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
-    const char *deckData =
-        "START\n"
-        " 21 MAY 1981 /\n"
-        "\n"
-        "TSTEP\n"
-        " 1 2 3 4 5 /\n"
-        "\n"
-        "DATES\n"
-        " 1 JAN 1982 /\n"
-        " 1 JAN 1982 13:55:44 /\n"
-        " 3 JAN 1982 14:56:45.123 /\n"
-        "/\n"
-        "\n"
-        "TSTEP\n"
-        " 6 7 /\n";
-
-    Opm::Parser parser( true );
-    auto deck = parser.parseString(deckData, Opm::ParseContext());
-    Opm::TimeMap tmap(deck);
-
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/0),
-                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21)));
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/0), 1*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/1), 1.0*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/1),
-                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-                                               boost::posix_time::time_duration(1*24, 0, 0)));
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/1), 2*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/2), (1.0 + 2.0)*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/2),
-                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-                                               boost::posix_time::time_duration((1 + 2)*24, 0, 0)));
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/2), 3*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/3), (1.0 + 2.0 + 3.0)*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/3),
-                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-                                               boost::posix_time::time_duration((1 + 2 + 3)*24, 0, 0)));
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/3), 4*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/4), (1.0 + 2.0 + 3.0 + 4.0)*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/4),
-                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-                                               boost::posix_time::time_duration((1 + 2 + 3 + 4)*24, 0, 0)));
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/4), 5*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/5), (1.0 + 2.0 + 3.0 + 4.0 + 5.0)*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/5),
-                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-                                               boost::posix_time::time_duration((1 + 2 + 3 + 4 + 5)*24, 0, 0)));
-    // timestep 5 is the period between the last step specified using
-    // of the TIMES keyword and the first record of DATES
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/6),
-                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 1)));
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/7),
-                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 1),
-                                               boost::posix_time::time_duration(13, 55, 44)));
-    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/8),
-                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 3),
-                                               boost::posix_time::time_duration(14, 56, 45) +
-                                               boost::posix_time::milliseconds(123)));
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/8), 6*24*60*60);
-    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/9), 7*24*60*60);
-}
+//BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
+//    const char *deckData =
+//        "START\n"
+//        " 21 MAY 1981 /\n"
+//        "\n"
+//        "TSTEP\n"
+//        " 1 2 3 4 5 /\n"
+//        "\n"
+//        "DATES\n"
+//        " 1 JAN 1982 /\n"
+//        " 1 JAN 1982 13:55:44 /\n"
+//        " 3 JAN 1982 14:56:45.123 /\n"
+//        "/\n"
+//        "\n"
+//        "TSTEP\n"
+//        " 6 7 /\n";
+//
+//    Opm::Parser parser( true );
+//    auto deck = parser.parseString(deckData, Opm::ParseContext());
+//    Opm::TimeMap tmap(deck);
+//
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/0),
+//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21)));
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/0), 1*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/1), 1.0*24*60*60);
+//
+//
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/1),
+//                      TimeMap::mkdate( 1981 , 5 , 21 ) + boost::posix_time::time_duration(1*24, 0, 0));
+//
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/1), 2*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/2), (1.0 + 2.0)*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/2),
+//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
+//                                               boost::posix_time::time_duration((1 + 2)*24, 0, 0)));
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/2), 3*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/3), (1.0 + 2.0 + 3.0)*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/3),
+//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
+//                                               boost::posix_time::time_duration((1 + 2 + 3)*24, 0, 0)));
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/3), 4*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/4), (1.0 + 2.0 + 3.0 + 4.0)*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/4),
+//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
+//                                               boost::posix_time::time_duration((1 + 2 + 3 + 4)*24, 0, 0)));
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/4), 5*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/5), (1.0 + 2.0 + 3.0 + 4.0 + 5.0)*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/5),
+//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
+//                                               boost::posix_time::time_duration((1 + 2 + 3 + 4 + 5)*24, 0, 0)));
+//    // timestep 5 is the period between the last step specified using
+//    // of the TIMES keyword and the first record of DATES
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/6),
+//                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 1)));
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/7),
+//                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 1),
+//                                               boost::posix_time::time_duration(13, 55, 44)));
+//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/8),
+//                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 3),
+//                                               boost::posix_time::time_duration(14, 56, 45) +
+//                                               boost::posix_time::milliseconds(123)));
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/8), 6*24*60*60);
+//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/9), 7*24*60*60);
+//}
 
 
 BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {

--- a/lib/eclipse/tests/TimeMapTest.cpp
+++ b/lib/eclipse/tests/TimeMapTest.cpp
@@ -214,70 +214,69 @@ BOOST_AUTO_TEST_CASE( addTSTEPFromWrongKeywordThrows ) {
     BOOST_CHECK_THROW( timeMap.addFromTSTEPKeyword( deckKeyword ) , std::invalid_argument );
 }
 
-//BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
-//    const char *deckData =
-//        "START\n"
-//        " 21 MAY 1981 /\n"
-//        "\n"
-//        "TSTEP\n"
-//        " 1 2 3 4 5 /\n"
-//        "\n"
-//        "DATES\n"
-//        " 1 JAN 1982 /\n"
-//        " 1 JAN 1982 13:55:44 /\n"
-//        " 3 JAN 1982 14:56:45.123 /\n"
-//        "/\n"
-//        "\n"
-//        "TSTEP\n"
-//        " 6 7 /\n";
-//
-//    Opm::Parser parser( true );
-//    auto deck = parser.parseString(deckData, Opm::ParseContext());
-//    Opm::TimeMap tmap(deck);
-//
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/0),
-//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21)));
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/0), 1*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/1), 1.0*24*60*60);
-//
-//
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/1),
-//                      TimeMap::mkdate( 1981 , 5 , 21 ) + boost::posix_time::time_duration(1*24, 0, 0));
-//
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/1), 2*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/2), (1.0 + 2.0)*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/2),
-//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-//                                               boost::posix_time::time_duration((1 + 2)*24, 0, 0)));
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/2), 3*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/3), (1.0 + 2.0 + 3.0)*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/3),
-//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-//                                               boost::posix_time::time_duration((1 + 2 + 3)*24, 0, 0)));
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/3), 4*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/4), (1.0 + 2.0 + 3.0 + 4.0)*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/4),
-//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-//                                               boost::posix_time::time_duration((1 + 2 + 3 + 4)*24, 0, 0)));
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/4), 5*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(/*timeLevelIdx=*/5), (1.0 + 2.0 + 3.0 + 4.0 + 5.0)*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIdx=*/5),
-//                      boost::posix_time::ptime(boost::gregorian::date(1981, 5, 21),
-//                                               boost::posix_time::time_duration((1 + 2 + 3 + 4 + 5)*24, 0, 0)));
-//    // timestep 5 is the period between the last step specified using
-//    // of the TIMES keyword and the first record of DATES
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/6),
-//                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 1)));
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/7),
-//                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 1),
-//                                               boost::posix_time::time_duration(13, 55, 44)));
-//    BOOST_CHECK_EQUAL(tmap.getStartTime(/*timeLevelIndex=*/8),
-//                      boost::posix_time::ptime(boost::gregorian::date(1982, 1, 3),
-//                                               boost::posix_time::time_duration(14, 56, 45) +
-//                                               boost::posix_time::milliseconds(123)));
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/8), 6*24*60*60);
-//    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(/*index=*/9), 7*24*60*60);
-//}
+BOOST_AUTO_TEST_CASE(TimeStepsCorrect) {
+    const char *deckData =
+        "START\n"
+        " 21 MAY 1981 /\n"
+        "\n"
+        "TSTEP\n"
+        " 1 2 3 4 5 /\n"
+        "\n"
+        "DATES\n"
+        " 1 JAN 1982 /\n"
+        " 1 JAN 1982 13:55:44 /\n"
+        " 3 JAN 1982 14:56:45.123 /\n"
+        "/\n"
+        "\n"
+        "TSTEP\n"
+        " 6 7 /\n";
+
+    Opm::Parser parser( true );
+    auto deck = parser.parseString(deckData, Opm::ParseContext());
+    Opm::TimeMap tmap(deck);
+
+    BOOST_CHECK_EQUAL(tmap.getStartTime(0),Opm::TimeMap::mkdate( 1981 , 5 , 21 ));
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(0), 1*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(1), 1.0*24*60*60);
+
+
+    BOOST_CHECK_EQUAL(tmap.getStartTime(1),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1981 , 5 , 21 ) , 3600*24));
+
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(1), 2*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(2), (1.0 + 2.0)*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getStartTime(2),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1981 , 5 , 21 ) , 3*24*3600));
+
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(2), 3*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(3), (1.0 + 2.0 + 3.0)*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getStartTime(3),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1981 , 5 , 21 ) , 6*3600*24));
+
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(3), 4*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(4), (1.0 + 2.0 + 3.0 + 4.0)*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getStartTime(4),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1981 , 5 , 21 ) , 10*3600*24));
+
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(4), 5*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getTimePassedUntil(5), (1.0 + 2.0 + 3.0 + 4.0 + 5.0)*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getStartTime(5),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1981 , 5 , 21 ) , 15*3600*24));
+
+    // timestep 5 is the period between the last step specified using
+    // of the TIMES keyword and the first record of DATES
+    BOOST_CHECK_EQUAL(tmap.getStartTime(6),
+                      Opm::TimeMap::mkdate( 1982 , 1 , 1 ));
+
+    BOOST_CHECK_EQUAL(tmap.getStartTime(7),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1982 , 1 , 1 ) , 13,55,44 ));
+
+    BOOST_CHECK_EQUAL(tmap.getStartTime(8),
+                      Opm::TimeMap::forward( Opm::TimeMap::mkdate( 1982 , 1 , 3 ) , 14,56,45));
+
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(8), 6*24*60*60);
+    BOOST_CHECK_EQUAL(tmap.getTimeStepLength(9), 7*24*60*60);
+}
 
 
 BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
@@ -349,5 +348,28 @@ BOOST_AUTO_TEST_CASE(initTimestepsYearsAndMonths) {
 
 BOOST_AUTO_TEST_CASE(mkdate) {
     BOOST_CHECK_THROW( Opm::TimeMap::mkdate( 2010 , 0 , 0  ) , std::invalid_argument);
+    std::time_t t0 = Opm::TimeMap::mkdate( 2010 , 1, 1);
+    std::time_t t1 = Opm::TimeMap::forward( t0 , 24*3600);
+
+    int year, day, month;
+
+    util_set_date_values_utc( t1, &day , &month, &year);
+    BOOST_CHECK_EQUAL( year , 2010 );
+    BOOST_CHECK_EQUAL( month , 1 );
+    BOOST_CHECK_EQUAL( day , 2 );
+
+    t1 = Opm::TimeMap::forward( t1 , -24*3600);
+    util_set_date_values_utc( t1, &day , &month, &year);
+    BOOST_CHECK_EQUAL( year , 2010 );
+    BOOST_CHECK_EQUAL( month , 1 );
+    BOOST_CHECK_EQUAL( day , 1 );
+
+
+    t1 = Opm::TimeMap::forward( t0 , 23, 55 , 300);
+    util_set_date_values_utc( t1, &day , &month, &year);
+    BOOST_CHECK_EQUAL( year , 2010 );
+    BOOST_CHECK_EQUAL( month , 1 );
+    BOOST_CHECK_EQUAL( day , 2 );
+
 }
 


### PR DESCRIPTION
Boost datetime internally uses a 32 bit integer type to represent time, and has a 2038 problem. 

In the opm-parser code the class `TimeMap` uses boost datetime internally, we intend to change that to `std::time_t` - which is a 64 bit integral type on any 64 bit linux, and also on any reasonably new 32bit linux.

The current PR will just change the `TimeMap::operator[]`to return `std::time_t` instead of boost datetime. The code still uses boost datetime internally.

Downstream:

ewoms: https://github.com/OPM/ewoms/pull/198
simulators: https://github.com/OPM/opm-simulators/pull/1222