### PR TITLE
Add plmixnum

### DIFF
--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -207,7 +207,8 @@ namespace Opm {
             GridProperties< int >::SupportedKeywordInfo( "OPERNUM", 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "PVTNUM" , 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "ROCKNUM", 1, "1" ),
-            GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" )
+            GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" ),
+            GridProperties< int >::SupportedKeywordInfo( "PLMIXNUM", 1, "1" )
         };
     }
 

--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -204,7 +204,7 @@ namespace Opm {
             GridProperties< int >::SupportedKeywordInfo( "IMBNUM" , 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "MISCNUM", 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "MULTNUM", 1, "1" ),
-            GridProperties< int >::SupportedKeywordInfo( "OPERNUM", 0, "1" ),//*
+            GridProperties< int >::SupportedKeywordInfo( "OPERNUM", 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "PVTNUM" , 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "ROCKNUM", 1, "1" ),
             GridProperties< int >::SupportedKeywordInfo( "SATNUM" , 1, "1" )

--- a/lib/eclipse/share/keywords/000_Eclipse100/P/PLMIXNUM
+++ b/lib/eclipse/share/keywords/000_Eclipse100/P/PLMIXNUM
@@ -1,0 +1,1 @@
+{"name" : "PLMIXNUM", "sections" : ["REGIONS"], "data" : {"value_type" : "INT" }}

--- a/lib/eclipse/share/keywords/keyword_list.cmake
+++ b/lib/eclipse/share/keywords/keyword_list.cmake
@@ -181,6 +181,7 @@ set( keywords
      000_Eclipse100/P/PIMTDIMS
      000_Eclipse100/P/PIMULTAB
      000_Eclipse100/P/PINCH
+     000_Eclipse100/P/PLMIXNUM
      000_Eclipse100/P/PLMIXPAR
      000_Eclipse100/P/PLYADS
      000_Eclipse100/P/PLYADSS


### PR DESCRIPTION
the first patch changes the default value for the OPERNUM grid property from 0 to 1 and removes a `//*` token (which should be considered to be a *really* bad way to distinguish between C and C++).

the second patch adds the PLMIXNUM keyword and the corresponding grid property. this property would be good to have for the new implementation of the polymer blackoil extension: https://github.com/OPM/ewoms/pull/195#discussion_r122908138