### PR TITLE
Support radial properties

### DIFF
--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -387,7 +387,7 @@ namespace Opm {
         supportedDoubleKeywords.emplace_back( "MULTPV", 1.0, "1" );
 
         // the permeability keywords
-        for( const auto& kw : { "PERMX", "PERMY", "PERMZ" } )
+        for( const auto& kw : { "PERMR", "PERMTHT", "PERMX", "PERMY", "PERMZ", } )
             supportedDoubleKeywords.emplace_back( kw, nan, distributeTopLayer, "Permeability" );
 
         /* E300 only */

--- a/lib/eclipse/share/keywords/000_Eclipse100/P/PERMTHT
+++ b/lib/eclipse/share/keywords/000_Eclipse100/P/PERMTHT
@@ -1,0 +1,1 @@
+{"name" : "PERMTHT" , "sections" : ["GRID"], "data" : {"value_type" : "DOUBLE" , "dimension" : "Permeability"}}

--- a/lib/eclipse/share/keywords/000_Eclipse100/R/RADIAL
+++ b/lib/eclipse/share/keywords/000_Eclipse100/R/RADIAL
@@ -1,4 +1,4 @@
 {
   "name" : "RADIAL",
-  "sections" : ["GRID"]
+  "sections" : ["RUNSPEC"]
 }

--- a/lib/eclipse/share/keywords/keyword_list.cmake
+++ b/lib/eclipse/share/keywords/keyword_list.cmake
@@ -172,6 +172,7 @@ set( keywords
      000_Eclipse100/P/PCG
      000_Eclipse100/P/PERFORMANCE_PROBE
      000_Eclipse100/P/PERMR
+     000_Eclipse100/P/PERMTHT
      000_Eclipse100/P/PERMX
      000_Eclipse100/P/PERMXY
      000_Eclipse100/P/PERMY


### PR DESCRIPTION
This change-set adds support for internalising the `PERMR` and `PERMTHT` keywords.  The former was already known to the parser, but was not recognised as a 3D grid property.  The latter is new as of this change-set.

We also relocate the `RADIAL` keyword to the `RUNSPEC` section as per the official specification.