### PR TITLE
implement proper support for constant initial reservoir temperature

### DIFF
--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -214,7 +214,8 @@ namespace Opm {
 
 
     static std::vector< GridProperties< double >::SupportedKeywordInfo >
-    makeSupportedDoubleKeywords(const TableManager*        tableManager,
+    makeSupportedDoubleKeywords(const Deck& deck,
+                                const TableManager*        tableManager,
                                 const EclipseGrid*         eclipseGrid,
                                 GridProperties<int>* intGridProperties)
     {
@@ -256,7 +257,7 @@ namespace Opm {
         const auto KRGRLookup   = std::bind( KRGREndpoint,   _1, tableManager, eclipseGrid, intGridProperties );
         const auto IKRGRLookup  = std::bind( IKRGREndpoint,  _1, tableManager, eclipseGrid, intGridProperties );
 
-        const auto tempLookup = std::bind( temperature_lookup, _1, tableManager, eclipseGrid, intGridProperties );
+        const auto tempLookup = std::bind( temperatureLookup, _1, &deck, tableManager, eclipseGrid, intGridProperties );
 
         const auto distributeTopLayer = std::bind( &distTopLayer, _1, eclipseGrid );
 
@@ -429,7 +430,7 @@ namespace Opm {
           // register the grid properties
           m_intGridProperties(eclipseGrid, makeSupportedIntKeywords()),
           m_doubleGridProperties(eclipseGrid, &m_deckUnitSystem,
-                                 makeSupportedDoubleKeywords(&tableManager, &eclipseGrid, &m_intGridProperties))
+                                 makeSupportedDoubleKeywords(deck, &tableManager, &eclipseGrid, &m_intGridProperties))
     {
         /*
          * The EQUALREG, MULTREG, COPYREG, ... keywords are used to manipulate

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp
@@ -32,6 +32,7 @@
 namespace Opm {
 
     class Box;
+    class Deck;
     class DeckItem;
     class DeckKeyword;
     class EclipseGrid;
@@ -188,10 +189,11 @@ private:
 
 // initialize the TEMPI grid property using the temperature vs depth
 // table (stemming from the TEMPVD or the RTEMPVD keyword)
-std::vector< double > temperature_lookup( size_t,
-                                          const TableManager*,
-                                          const EclipseGrid*,
-                                          const GridProperties<int>* );
+std::vector< double > temperatureLookup( size_t,
+                                         const Deck*,
+                                         const TableManager*,
+                                         const EclipseGrid*,
+                                         const GridProperties<int>* );
 }
 
 #endif

--- a/lib/eclipse/share/keywords/000_Eclipse100/R/RTEMP
+++ b/lib/eclipse/share/keywords/000_Eclipse100/R/RTEMP
@@ -1,0 +1,11 @@
+{
+        "name" : "RTEMP",
+        "sections" : ["PROPS", "SOLUTION"],
+        "size" : 1,
+        "items" : [{
+                "name" : "TEMPERATURE",
+                "value_type" : "DOUBLE",
+                "default": 15.55555555,
+                "dimension" : "Temperature"
+        }]
+}

--- a/lib/eclipse/share/keywords/000_Eclipse100/R/RTEMPA
+++ b/lib/eclipse/share/keywords/000_Eclipse100/R/RTEMPA
@@ -1,0 +1,11 @@
+{
+        "name" : "RTEMPA",
+        "sections" : ["PROPS", "SOLUTION"],
+        "size" : 1,
+        "items" : [{
+                "name" : "TEMPERATURE",
+                "value_type" : "DOUBLE",
+                "default": 15.55555555,
+                "dimension" : "Temperature"
+        }]
+}

--- a/lib/eclipse/share/keywords/keyword_list.cmake
+++ b/lib/eclipse/share/keywords/keyword_list.cmake
@@ -230,6 +230,8 @@ set( keywords
      000_Eclipse100/R/RPTSOL
      000_Eclipse100/R/RS
      000_Eclipse100/R/RSVD
+     000_Eclipse100/R/RTEMP
+     000_Eclipse100/R/RTEMPA
      000_Eclipse100/R/RTEMPVD
      000_Eclipse100/R/RUNSPEC
      000_Eclipse100/R/RUNSUM


### PR DESCRIPTION
This involves adding the RTEMP and RTEMPA keywords and using them in the grid property initializer of TEMPI if no temperature-vs-depth table is specified.

on my machine, this fixes OPM/opm-simulators#1231