### PR TITLE
make the travis CI scripts independent of opm-common

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,11 +13,6 @@ addons:
       - libboost1.55-all-dev
       - gcc-4.8
       - g++-4.8
-      - gfortran-4.8
-      - liblapack-dev
-      - libgmp3-dev
-      - libsuitesparse-dev
-      - libeigen3-dev
       - bc
       - cmake
       - cmake-data
@@ -30,11 +25,7 @@ env:
 before_script:
     - export CXX="g++-4.8" CC="gcc-4.8" FC="gfortran-4.8"
     - cd ..
-    - git clone https://github.com/OPM/opm-common.git
-    - opm-common/travis/clone-opm.sh opm-parser
-    - opm-common/travis/build-prereqs.sh
+    - opm-parser/travis/build-prereqs.sh
 
 
-script: opm-common/travis/build-and-test.sh opm-parser
-
-
+script: opm-parser/travis/build-and-test.sh opm-parser

--- a/travis/build-and-test.sh
+++ b/travis/build-and-test.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+set -e
+
+build_order=opm-parser
+
+function upstream_build {
+    project=${1}
+    echo "Building: ${project}"
+    mkdir -p ${project}/build
+    pushd ${project}/build > /dev/null
+    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=OFF
+    make 
+    popd > /dev/null
+}
+
+
+function downstream_build_and_test {
+    project=${1}
+    echo "Building and testing: ${project}"
+    mkdir -p ${project}/build
+    pushd ${project}/build > /dev/null
+    # The build commands cmake, make and ctest must be given as
+    # separate commands and not chained with &&. If chaining with &&
+    # is used the 'set -e' does not exit on first error.
+    cmake ../ -DENABLE_PYTHON=ON -DBUILD_TESTING=ON
+    make
+    ctest --output-on-failure
+
+    popd > /dev/null
+}
+
+#-----------------------------------------------------------------
+
+export CONDA_HOME="$HOME/miniconda"
+export PATH="$CONDA_HOME/bin:$PATH"
+
+
+for i in "${!build_order[@]}"; do
+   if [[ "${build_order[$i]}" = "$1" ]]; then
+       project_index=$i
+   fi
+done
+
+if [[ -z ${project_index} ]]; then
+   echo "${0}: Project: ${1} not recognized."
+   exit 1
+fi
+
+
+
+build_index=0
+
+
+while [ $build_index -lt ${project_index} ];
+do
+    project=${build_order[$build_index]}
+    upstream_build ${project}
+    build_index=$((build_index + 1)) 
+done
+
+
+
+while [ $build_index -lt ${#build_order[@]} ]
+do
+    project=${build_order[$build_index]}
+    downstream_build_and_test ${project}
+    build_index=$((build_index + 1)) 
+done
+      

--- a/travis/build-prereqs.sh
+++ b/travis/build-prereqs.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -e
+
+# This script should build all the opm-parser dependencies which are installed from source.
+
+function install_python_deps {
+    export TRAVIS_PYTHON_VERSION="2.7"
+    wget https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
+
+    bash miniconda.sh -b -p $HOME/miniconda
+    export CONDA_HOME="$HOME/miniconda"
+    export PATH="$CONDA_HOME/bin:$PATH"
+    hash -r
+    conda config --set always_yes yes --set changeps1 no
+    conda update -q conda
+
+    conda install numpy
+}
+
+
+function build_libecl {
+    install_python_deps
+    git clone https://github.com/Statoil/libecl.git
+    mkdir -p libecl/build
+    pushd libecl/build > /dev/null
+    cmake .. && make
+    popd > /dev/null
+}
+
+
+#################################################################
+build_libecl


### PR DESCRIPTION
the reason is that everything in opm-parser is now independent of opm-common, so why should the travis support scripts still rely on it?

besides this, the downstreams are not build and tested by travis anymore because travis recently aquired the habit of timing out if this is enabled, so the downstream builder is more of a distraction than a help. also, the OPM downstream modules nowadays ought to use the OPM Jenkins rig ( http://ci.opm-project.org ) as their primary CI system anyway.