### PR TITLE
make the build system compatible with Dune's cmake build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,7 +230,32 @@ add_subdirectory(lib/json)
 add_subdirectory(lib/eclipse)
 add_subdirectory(applications)
 
-install(FILES dune.module DESTINATION lib/dunecontrol/opm-parser)
-install(EXPORT opm-parser-config DESTINATION share/cmake/opm-parser)
-export(TARGETS opmjson opmparser FILE opm-parserConfig.cmake)
+file(COPY "cmake/modules/OpmParserMacros.cmake" DESTINATION "${CMAKE_CURRENT_BINARY_DIR}/cmake/modules")
+
+set(OPM_PARSER_PREFIX "${CMAKE_INSTALL_PREFIX}")
+set(OPM_PARSER_MODULE_PATH "${OPM_PARSER_PREFIX}/share/dune/cmake/modules")
+set(OPM_PARSER_INCLUDEDIRS "${OPM_PARSER_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
+set(OPM_PARSER_LIBDIRS "${OPM_PARSER_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
+set(OPM_PARSER_INSTALLED ON)
+configure_file(opm-parser-config.cmake.in
+  "${PROJECT_BINARY_DIR}/install/opm-parser-config.cmake" @ONLY)
+
+set(OPM_PARSER_PREFIX "${CMAKE_SOURCE_DIR}")
+set(OPM_PARSER_INCLUDEDIRS "${OPM_PARSER_PREFIX}/lib/eclipse/include;${OPM_PARSER_PREFIX}/lib/json/include")
+set(OPM_PARSER_MODULE_PATH "${OPM_PARSER_PREFIX}/cmake/modules")
+set(OPM_PARSER_LIBDIRS "${CMAKE_BINARY_DIR}/lib/eclipse;${CMAKE_BINARY_DIR}/lib/json")
+set(OPM_PARSER_INSTALLED OFF)
+configure_file(opm-parser-config.cmake.in
+  "${PROJECT_BINARY_DIR}/opm-parser-config.cmake" @ONLY)
+
+configure_file(opm-parser.pc.in
+  "${PROJECT_BINARY_DIR}/opm-parser.pc" @ONLY)
+
+install(FILES "cmake/modules/OpmParserMacros.cmake" DESTINATION "share/dune/cmake/modules")
+install(FILES "dune.module" DESTINATION "lib/dunecontrol/opm-parser")
+install(FILES  "config.h.cmake" DESTINATION "share/opm-parser")
+install(FILES  "${CMAKE_CURRENT_BINARY_DIR}/opm-parser.pc" DESTINATION "lib/pkgconfig")
+install(FILES  "${CMAKE_CURRENT_BINARY_DIR}/install/opm-parser-config.cmake" DESTINATION "lib/cmake/opm-parser")
+export(TARGETS opmjson opmparser FILE opm-parser-targets.cmake)
+install(EXPORT opm-parser-targets DESTINATION "lib/cmake/opm-parser")
 export(PACKAGE opm-parser)

--- a/cmake/modules/OpmParserMacros.cmake
+++ b/cmake/modules/OpmParserMacros.cmake
@@ -1,0 +1,16 @@
+# .. cmake_module::
+#
+# This module's content is executed whenever a Dune module requires or
+# suggests opm-parser!
+#
+
+find_package(ecl REQUIRED)
+
+if (ecl_FOUND)
+  set(HAVE_ERT "1")
+  set(HAVE_LIBECL "1")
+endif()
+
+find_package(Boost
+  COMPONENTS regex filesystem system date_time
+  REQUIRED)

--- a/config.h.cmake
+++ b/config.h.cmake
@@ -1,0 +1,50 @@
+/* begin opm-parser
+   put the definitions for config.h specific to
+   your project here. Everything above will be
+   overwritten
+*/
+/* begin private */
+/* Name of package */
+#define PACKAGE "@DUNE_MOD_NAME@"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "@DUNE_MAINTAINER@"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "@DUNE_MOD_NAME@"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "@DUNE_MOD_NAME@ @DUNE_MOD_VERSION@"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "@DUNE_MOD_NAME@"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL "@DUNE_MOD_URL@"
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "@DUNE_MOD_VERSION@"
+
+/* end private */
+
+/* Define to the version of opm-parser */
+#define OPM_PARSER_VERSION "${OPM_PARSER_VERSION}"
+
+/* Define to the major version of opm-parser */
+#define OPM_PARSER_VERSION_MAJOR ${OPM_PARSER_VERSION_MAJOR}
+
+/* Define to the minor version of opm-parser */
+#define OPM_PARSER_VERSION_MINOR ${OPM_PARSER_VERSION_MINOR}
+
+/* Define to the revision of opm-parser */
+#define OPM_PARSER_VERSION_REVISION ${OPM_PARSER_VERSION_REVISION}
+
+/* Specify whether ERT/libecl is available or not */
+#cmakedefine HAVE_ERT 1
+#cmakedefine HAVE_LIBECL 1
+
+/* begin bottom */
+
+/* end bottom */
+
+/* end opm-parser */

--- a/lib/eclipse/CMakeLists.txt
+++ b/lib/eclipse/CMakeLists.txt
@@ -152,7 +152,7 @@ endforeach()
 add_static_analysis_tests(opmparser_SRC opmparser_INCLUDES)
 
 install(TARGETS opmparser
-        EXPORT  opm-parser-config
+        EXPORT  opm-parser-targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/lib/json/CMakeLists.txt
+++ b/lib/json/CMakeLists.txt
@@ -24,7 +24,7 @@ set_target_properties(opmjson PROPERTIES
 
 install(DIRECTORY include/ DESTINATION include)
 install(TARGETS opmjson
-        EXPORT  opm-parser-config
+        EXPORT  opm-parser-targets
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/opm-parser-config.cmake.in
+++ b/opm-parser-config.cmake.in
@@ -1,0 +1,18 @@
+if(NOT opm-parser_FOUND)
+  #import the target
+  get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
+  include("${_dir}/opm-parser-targets.cmake")
+
+  #report other information
+  set(opm-parser_INSTALLED "@OPM_PARSER_INSTALLED@")
+  set(opm-parser_PREFIX "@OPM_PARSER_PREFIX@")
+  set(opm-parser_INCLUDE_DIRS "@OPM_PARSER_INCLUDEDIRS@")
+  set(opm-parser_LIBRARY_DIRS "@OPM_PARSER_LIBDIRS@")
+  set(opm-parser_CXX_FLAGS "@CMAKE_CXX_FLAGS@")
+  set(opm-parser_CXX_FLAGS_DEBUG "@CMAKE_CXX_FLAGS_DEBUG@")
+  set(opm-parser_CXX_FLAGS_MINSIZEREL "@CMAKE_CXX_FLAGS_MINSIZEREL@")
+  set(opm-parser_CXX_FLAGS_RELEASE "@CMAKE_CXX_FLAGS_RELEASE@")
+  set(opm-parser_CXX_FLAGS_RELWITHDEBINFO "@CMAKE_CXX_FLAGS_RELWITHDEBINFO@")
+  set(opm-parser_LIBRARIES "opmparser")
+  set(opm-parser_MODULE_PATH "@OPM_PARSER_MODULE_PATH@")
+endif(NOT opm-parser_FOUND)

--- a/opm-parser.pc.in
+++ b/opm-parser.pc.in
@@ -1,0 +1,15 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${prefix}/lib
+includedir=${prefix}/include
+CXX=@CMAKE_CXX_COMPILER@
+CC=@CMAKE_C_COMPILER@
+DEPENDENCIES=
+
+Name: opm-parser
+Version: @VERSION@
+Description: The opm-parser module
+URL: http://www.opm-project.org/
+Requires: ${DEPENDENCIES}
+Libs: -L${libdir} -lopmparser
+Cflags: -I${includedir}


### PR DESCRIPTION
before this, dune modules that are not using the OPM build system needed to treat opm-parser as an external library, which is IMHO quite sub-optimal cf. #1105 . With this patch, opm-parser can be build as part of duncontrol build chains, i.e., the pkg-config support is fixed, the `opm-parser-config.cmake` provides everything which is expected by dune's cmake based build system and all required files are installed to the right places (hopefully). This means that with this other Dune modules just need to specify a dependency on opm-parser in their dune.module file and opm-parser's libraries and headers should be picked up just fine.

Things like generating opm-parser-config.cmake should quite likely be done in a better way, but I'm not really a cmake expert and the solution proposed by this patch seems to get things done regardless of whether opm-parser is system-installed or not. Comprehensive solutions are highly appreciated. @jokva: it would be nice if you had a look.