### PR TITLE
changed: avoid use of targets for exports

### DIFF
--- a/lib/eclipse/CMakeLists.txt
+++ b/lib/eclipse/CMakeLists.txt
@@ -126,15 +126,13 @@ add_library(opmparser ${opmparser_SOURCES})
 
 target_link_libraries(opmparser PUBLIC opmjson
                                        ecl
-                                       ${boost_filesystem}
-                                       ${boost_system}
-                                       ${boost_regex}
-                                       ${boost_date_time})
+                                       ${Boost_LIBRARIES})
 target_compile_definitions(opmparser PRIVATE -DOPM_PARSER_DECK_API=1)
 target_include_directories(opmparser
     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/include>
             $<INSTALL_INTERFACE:include>
+            ${Boost_INCLUDE_DIRS}
     PRIVATE ${CMAKE_CURRENT_BINARY_DIR}/include
 )
 

--- a/lib/json/CMakeLists.txt
+++ b/lib/json/CMakeLists.txt
@@ -1,7 +1,7 @@
 project(opm-json CXX)
 
 add_library(opmjson JsonObject.cpp $<TARGET_OBJECTS:cjson>)
-target_link_libraries(opmjson PUBLIC ${boost_filesystem})
+target_link_libraries(opmjson PUBLIC ${Boost_FILESYSTEM_LIBRARY})
 
 if (CJSON_LIBRARY)
     target_link_libraries(opmjson PUBLIC cjson)
@@ -14,6 +14,7 @@ add_static_analysis_tests(JSON_SOURCES JSON_INCLUDES)
 target_include_directories(opmjson
     PUBLIC  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
             $<INSTALL_INTERFACE:include>
+            ${Boost_INCLUDE_DIRS}
     PRIVATE $<TARGET_PROPERTY:cjson,INTERFACE_INCLUDE_DIRECTORIES>
 )
 set_target_properties(opmjson PROPERTIES


### PR DESCRIPTION
the exported file refers to imported targets through their
name with the expectation that these are defined whenever
the target file is included.

the use of custom imported targets for boost thus becomes
problematic in downstreams, since they are forced to define
these targets prior to opm-parser inclusion.

as the targets are named the same as their library
counterparts it appears to work per murphy's law.
cmake will simply fall back to interpreting the target names as
library names, e.g. it will do -lboost_filesystem.

there are two ways to fix this: either through manually
writing a opm-parser-config.cmake file which defines the boost targets,
then includes the target file, or by forgoing the use of targets for
the linking. 

i have here done the latter.