### PR TITLE
Policy change: Missing xxxDIMS keyword - go directly to default.

### DIFF
--- a/lib/eclipse/Parser/ParseContext.cpp
+++ b/lib/eclipse/Parser/ParseContext.cpp
@@ -60,7 +60,6 @@ namespace Opm {
         addKey(PARSE_UNKNOWN_KEYWORD);
         addKey(PARSE_RANDOM_TEXT);
         addKey(PARSE_RANDOM_SLASH);
-        addKey(PARSE_MISSING_DIMS_KEYWORD);
         addKey(PARSE_EXTRA_DATA);
         addKey(PARSE_MISSING_INCLUDE);
 
@@ -235,7 +234,6 @@ namespace Opm {
     const std::string ParseContext::PARSE_UNKNOWN_KEYWORD = "PARSE_UNKNOWN_KEYWORD";
     const std::string ParseContext::PARSE_RANDOM_TEXT = "PARSE_RANDOM_TEXT";
     const std::string ParseContext::PARSE_RANDOM_SLASH = "PARSE_RANDOM_SLASH";
-    const std::string ParseContext::PARSE_MISSING_DIMS_KEYWORD = "PARSE_MISSING_DIMS_KEYWORD";
     const std::string ParseContext::PARSE_EXTRA_DATA = "PARSE_EXTRA_DATA";
     const std::string ParseContext::PARSE_MISSING_INCLUDE = "PARSE_MISSING_INCLUDE";
 

--- a/lib/eclipse/Parser/Parser.cpp
+++ b/lib/eclipse/Parser/Parser.cpp
@@ -435,33 +435,26 @@ std::shared_ptr< RawKeyword > createRawKeyword( const string_view& kw, ParserSta
 
     const auto& sizeKeyword = parserKeyword->getSizeDefinitionPair();
     const auto& deck = parserState.deck;
+    size_t targetSize;
 
     if( deck.hasKeyword(sizeKeyword.first ) ) {
         const auto& sizeDefinitionKeyword = deck.getKeyword(sizeKeyword.first);
         const auto& record = sizeDefinitionKeyword.getRecord(0);
-        const auto targetSize = record.getItem( sizeKeyword.second ).get< int >( 0 );
-        return std::make_shared< RawKeyword >( keywordString,
-                                                parserState.current_path().string(),
-                                                parserState.line(),
-                                                targetSize,
-                                                parserKeyword->isTableCollection() );
+
+        targetSize = record.getItem( sizeKeyword.second ).get< int >( 0 );
+    } else {
+        const auto* keyword = parser.getKeyword( sizeKeyword.first );
+        const auto& record = keyword->getRecord(0);
+        const auto& int_item = record.get( sizeKeyword.second );
+
+        targetSize = int_item.getDefault< int >( );
     }
 
-    std::string msg = "Expected the kewyord: " + sizeKeyword.first
-                    + " to infer the number of records in: " + keywordString;
-    auto& msgContainer = parserState.deck.getMessageContainer();
-    parserState.parseContext.handleError(ParseContext::PARSE_MISSING_DIMS_KEYWORD , msgContainer, msg );
-
-    const auto* keyword = parser.getKeyword( sizeKeyword.first );
-    const auto& record = keyword->getRecord(0);
-    const auto& int_item = record.get( sizeKeyword.second );
-
-    const auto targetSize = int_item.getDefault< int >( );
     return std::make_shared< RawKeyword >( keywordString,
-                                            parserState.current_path().string(),
-                                            parserState.line(),
-                                            targetSize,
-                                            parserKeyword->isTableCollection() );
+                                           parserState.current_path().string(),
+                                           parserState.line(),
+                                           targetSize,
+                                           parserKeyword->isTableCollection() );
 }
 
 bool tryParseKeyword( ParserState& parserState, const Parser& parser ) {

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -137,20 +137,6 @@ namespace Opm {
 
 
         /*
-          For some keywords the number of records (i.e. size) is given
-          as an item in another keyword. A typical example is the
-          EQUIL keyword where the number of records is given by the
-          NTEQUL item of the EQLDIMS keyword. If the size defining
-          XXXDIMS keyword is not in the deck, we can use the default
-          values of the XXXDIMS keyword; this is regulated by the
-          'missingDIMskeyword' field.
-
-          Observe that a fully defaulted XXXDIMS keyword does not
-          trigger this behavior.
-        */
-        const static std::string PARSE_MISSING_DIMS_KEYWORD;
-
-        /*
           If the number of elements in the input record exceeds the
           number of items in the keyword configuration this error
           situation will be triggered. Many keywords end with several

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -173,27 +173,6 @@ BOOST_AUTO_TEST_CASE(TEST_UNKNOWN_OPERATE) {
 
 
 
-BOOST_AUTO_TEST_CASE( CheckMissingSizeKeyword) {
-    const char * deck =
-        "SOLUTION\n"
-        "EQUIL\n"
-        "  10 10 10 10 / \n"
-        "\n";
-
-
-    ParseContext parseContext;
-    Parser parser(false);
-
-    parser.addKeyword<ParserKeywords::EQUIL>();
-    parser.addKeyword<ParserKeywords::EQLDIMS>();
-    parser.addKeyword<ParserKeywords::SOLUTION>();
-
-    parseContext.update( ParseContext::PARSE_MISSING_DIMS_KEYWORD , InputError::THROW_EXCEPTION );
-    BOOST_CHECK_THROW( parser.parseString( deck , parseContext ) , std::invalid_argument);
-
-    parseContext.update( ParseContext::PARSE_MISSING_DIMS_KEYWORD , InputError::IGNORE );
-    BOOST_CHECK_NO_THROW( parser.parseString( deck , parseContext ) );
-}
 
 
 BOOST_AUTO_TEST_CASE( CheckUnsupportedInSCHEDULE ) {

--- a/lib/eclipse/tests/integration/ParseKEYWORD.cpp
+++ b/lib/eclipse/tests/integration/ParseKEYWORD.cpp
@@ -109,23 +109,6 @@ BOOST_AUTO_TEST_CASE( ENDINC ) {
     BOOST_CHECK_EQUAL(false, deck.hasKeyword("ENDINC"));
 }
 
-BOOST_AUTO_TEST_CASE( EQUIL_MISSING_DIMS ) {
-    Parser parser;
-    ParseContext parseContext;
-    parseContext.update(ParseContext::PARSE_MISSING_DIMS_KEYWORD, InputError::IGNORE);
-    const std::string equil = "EQUIL\n"
-        "2469   382.4   1705.0  0.0    500    0.0     1     1      20 /";
-    auto deck = parser.parseString(equil, parseContext);
-    const auto& kw1 = deck.getKeyword("EQUIL" , 0);
-    BOOST_CHECK_EQUAL( 1U , kw1.size() );
-
-    const auto& rec1 = kw1.getRecord(0);
-    const auto& item1       = rec1.getItem("OWC");
-    const auto& item1_index = rec1.getItem(2);
-
-    BOOST_CHECK_EQUAL( &item1  , &item1_index );
-    BOOST_CHECK( fabs(item1.getSIDouble(0) - 1705) < 0.001);
-}
 
 
 BOOST_AUTO_TEST_CASE( EQUIL ) {


### PR DESCRIPTION
For some keywords - like e.g. `EQUIL` the number of records are given as an item of another keyword, `EQLDIMS` in the case of `EQUIL`. The `EQLDIMS` keyword has defaults specified, so strictly speaking it is not necessary to require that keyword.

Currently the code will see it as an error situation if `EQLDIMS` is not there when `EQUIL`is parsed, however it can be handled with the ParseContext system. With this PR the situation of a missing `xxxDIMS` keyword is just plain silently ignored.

This is a change of policy - we can no longer enforce that all required `xxxDIMS` keywords are present, but there should be no change in end functionality. I suggest we merge this - but I am open to other opinions.