### PR TITLE
Added Deck copy constructor

### DIFF
--- a/lib/eclipse/Deck/Deck.cpp
+++ b/lib/eclipse/Deck/Deck.cpp
@@ -117,6 +117,17 @@ namespace Opm {
             this->keywordMap[ kw.name() ].push_back( index++ );
     }
 
+    void DeckView::reinit( const_iterator first_arg, const_iterator last_arg ) {
+        this->first = first_arg;
+        this->last = last_arg;
+
+        this->keywordMap.clear();
+
+        size_t index = 0;
+        for( const auto& kw : *this )
+            this->keywordMap[ kw.name() ].push_back( index++ );
+    }
+
     DeckView::DeckView( std::pair< const_iterator, const_iterator > limits ) :
         DeckView( limits.first, limits.second )
     {}
@@ -150,6 +161,17 @@ namespace Opm {
     Deck::Deck( std::initializer_list< std::string > ilist ) :
         Deck( std::vector< DeckKeyword >( ilist.begin(), ilist.end() ) )
     {}
+
+    Deck::Deck( const Deck& d ) :
+        DeckView( d.begin(), d.begin() ),
+        keywordList( d.keywordList ),
+        m_messageContainer( d.m_messageContainer ),
+        defaultUnits( d.defaultUnits ),
+        activeUnits( d.activeUnits ),
+        m_dataFile( d.m_dataFile ) {
+
+        this->reinit(this->keywordList.begin(), this->keywordList.end());
+    }
 
     void Deck::addKeyword( DeckKeyword&& keyword ) {
         this->keywordList.push_back( std::move( keyword ) );

--- a/lib/eclipse/include/opm/parser/eclipse/Deck/Deck.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Deck/Deck.hpp
@@ -102,6 +102,8 @@ namespace Opm {
             DeckView( const_iterator first, const_iterator last );
             explicit DeckView( std::pair< const_iterator, const_iterator > );
 
+            void reinit( const_iterator, const_iterator );
+
         private:
             const_iterator first;
             const_iterator last;
@@ -127,6 +129,9 @@ namespace Opm {
             Deck( std::initializer_list< DeckKeyword > );
             // cppcheck-suppress noExplicitConstructor
             Deck( std::initializer_list< std::string > );
+
+            Deck( const Deck& );
+
             void addKeyword( DeckKeyword&& keyword );
             void addKeyword( const DeckKeyword& keyword );
 
@@ -157,4 +162,3 @@ namespace Opm {
     };
 }
 #endif  /* DECK_HPP */
-


### PR DESCRIPTION
Copying Decks caused the first and last iterators in DeckView to point
to invalid memory.