### PR TITLE
Added include on cmath to restore build on Debian.

### DIFF
--- a/lib/eclipse/Deck/DeckItem.cpp
+++ b/lib/eclipse/Deck/DeckItem.cpp
@@ -25,6 +25,7 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <cmath>
 
 namespace Opm {
 


### PR DESCRIPTION
Build broke on latest Debian stable with introduction of std::fabs in https://github.com/OPM/opm-parser/pull/1120 This restores build.