### PR TITLE
Make Release the default build type rather than Debug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,8 +19,8 @@ include(GNUInstallDirs)
 include(TestCXXAcceptsFlag)
 
 if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    message(STATUS "No build type specified - defaulting to 'Debug'.")
-    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose build type." FORCE)
+    message(STATUS "No build type specified - defaulting to 'Release'.")
+    set(CMAKE_BUILD_TYPE "Release" CACHE STRING "Choose build type." FORCE)
     set_property(CACHE CMAKE_BUILD_TYPE PROPERTY
                  STRINGS "Release" "Debug" "RelWithDebInfo" "MinSizeRel")
 endif()


### PR DESCRIPTION
This brings default build options of opm-parser in line with the other opm-modules.