### PR TITLE
EclipseState: refactor constructor

### DIFF
--- a/lib/eclipse/EclipseState/EclipseConfig.cpp
+++ b/lib/eclipse/EclipseState/EclipseConfig.cpp
@@ -20,31 +20,19 @@
 #include <memory>
 
 #include <opm/parser/eclipse/Deck/Deck.hpp>
-#include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Deck/Section.hpp>
-#include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
-#include <opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp>
 #include <opm/parser/eclipse/EclipseState/EclipseConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
-#include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
 
 namespace Opm {
 
-    EclipseConfig::EclipseConfig(const Deck& deck,
-                                 const Eclipse3DProperties& eclipse3DProperties,
-                                 const TableManager& tables,
-                                 const GridDims& inputGrid,
-                                 const Schedule& schedule,
-                                 const ParseContext& parseContext) :
+    EclipseConfig::EclipseConfig(const Deck& deck) :
             m_ioConfig(        deck),
             m_initConfig(      deck),
             m_restartConfig(   deck )
     {
-        this->m_ioConfig.initFirstRFTOutput(schedule);
     }
 
 

--- a/lib/eclipse/EclipseState/EclipseConfig.cpp
+++ b/lib/eclipse/EclipseState/EclipseConfig.cpp
@@ -31,7 +31,6 @@
 #include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/TimeMap.hpp>
-#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 
 namespace Opm {
 
@@ -43,7 +42,6 @@ namespace Opm {
                                  const ParseContext& parseContext) :
             m_ioConfig(        deck),
             m_initConfig(      deck),
-            m_simulationConfig(deck, eclipse3DProperties),
             m_summaryConfig(   deck, schedule, tables, parseContext , inputGrid.getNXYZ()),
             m_restartConfig(   deck )
     {
@@ -61,10 +59,6 @@ namespace Opm {
 
     IOConfig& EclipseConfig::io() {
         return m_ioConfig;
-    }
-
-    const SimulationConfig& EclipseConfig::simulation() const {
-        return m_simulationConfig;
     }
 
     const SummaryConfig& EclipseConfig::summary() const {
@@ -90,8 +84,4 @@ namespace Opm {
         return init();
     }
 
-    // [[deprecated]] --- use simulation()
-    const SimulationConfig& EclipseConfig::getSimulationConfig() const {
-        return simulation();
-    }
 }

--- a/lib/eclipse/EclipseState/EclipseConfig.cpp
+++ b/lib/eclipse/EclipseState/EclipseConfig.cpp
@@ -42,7 +42,6 @@ namespace Opm {
                                  const ParseContext& parseContext) :
             m_ioConfig(        deck),
             m_initConfig(      deck),
-            m_summaryConfig(   deck, schedule, tables, parseContext , inputGrid.getNXYZ()),
             m_restartConfig(   deck )
     {
         this->m_ioConfig.initFirstRFTOutput(schedule);
@@ -61,17 +60,8 @@ namespace Opm {
         return m_ioConfig;
     }
 
-    const SummaryConfig& EclipseConfig::summary() const {
-        return m_summaryConfig;
-    }
-
     const RestartConfig& EclipseConfig::restart() const {
         return this->m_restartConfig;
-    }
-
-    // [[deprecated]] --- use summary()
-    const SummaryConfig& EclipseConfig::getSummaryConfig() const {
-        return summary();
     }
 
     // [[deprecated]] --- use restart()

--- a/lib/eclipse/EclipseState/EclipseState.cpp
+++ b/lib/eclipse/EclipseState/EclipseState.cpp
@@ -57,8 +57,9 @@ namespace Opm {
         m_gridDims(          deck ),
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
-        m_simulationConfig( deck, m_eclipseProperties ),
+        m_simulationConfig(  deck, m_eclipseProperties ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
+        m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext , m_inputGrid.getNXYZ()),
         m_eclipseConfig(     deck, m_eclipseProperties, m_tables, m_gridDims, m_schedule, parseContext ),
         m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
                              m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) ),
@@ -100,7 +101,7 @@ namespace Opm {
     }
 
     const SummaryConfig& EclipseState::getSummaryConfig() const {
-        return m_eclipseConfig.getSummaryConfig();
+        return m_summaryConfig;
     }
 
     const RestartConfig& EclipseState::getRestartConfig() const {

--- a/lib/eclipse/EclipseState/EclipseState.cpp
+++ b/lib/eclipse/EclipseState/EclipseState.cpp
@@ -57,6 +57,7 @@ namespace Opm {
         m_gridDims(          deck ),
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
+        m_simulationConfig( deck, m_eclipseProperties ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
         m_eclipseConfig(     deck, m_eclipseProperties, m_tables, m_gridDims, m_schedule, parseContext ),
         m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
@@ -104,6 +105,10 @@ namespace Opm {
 
     const RestartConfig& EclipseState::getRestartConfig() const {
         return m_eclipseConfig.getRestartConfig();
+    }
+
+    const SimulationConfig& EclipseState::getSimulationConfig() const {
+        return m_simulationConfig;
     }
 
     RestartConfig& EclipseState::getRestartConfig() {
@@ -162,11 +167,6 @@ namespace Opm {
 
     const Runspec& EclipseState::runspec() const {
         return this->m_runspec;
-    }
-
-    /// [[deprecated]] --- use cfg().simulation()
-    const SimulationConfig& EclipseState::getSimulationConfig() const {
-        return m_eclipseConfig.getSimulationConfig();
     }
 
     const FaultCollection& EclipseState::getFaults() const {

--- a/lib/eclipse/EclipseState/EclipseState.cpp
+++ b/lib/eclipse/EclipseState/EclipseState.cpp
@@ -59,10 +59,9 @@ namespace Opm {
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
         m_simulationConfig(  deck, m_eclipseProperties ),
+        m_transMult(         GridDims(deck), deck, m_eclipseProperties ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
-        m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext , m_inputGrid.getNXYZ()),
-        m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
-                             m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) )
+        m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext , m_inputGrid.getNXYZ())
     {
         m_inputGrid.resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
         m_eclipseConfig.io().initFirstRFTOutput(m_schedule);

--- a/lib/eclipse/EclipseState/EclipseState.cpp
+++ b/lib/eclipse/EclipseState/EclipseState.cpp
@@ -30,7 +30,6 @@
 #include <opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/Fault.hpp>
-#include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/SatfuncPropertyInitializers.hpp>
@@ -54,17 +53,16 @@ namespace Opm {
         m_parseContext(      parseContext ),
         m_tables(            deck ),
         m_runspec(           deck ),
-        m_gridDims(          deck ),
         m_eclipseConfig(     deck ),
+        m_deckUnitSystem(    deck.getActiveUnitSystem() ),
+        m_inputNnc(          deck ),
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
         m_simulationConfig(  deck, m_eclipseProperties ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
         m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext , m_inputGrid.getNXYZ()),
         m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
-                             m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) ),
-        m_inputNnc(          deck, m_gridDims ),
-        m_deckUnitSystem(    deck.getActiveUnitSystem() )
+                             m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) )
     {
         m_inputGrid.resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
         m_eclipseConfig.io().initFirstRFTOutput(m_schedule);

--- a/lib/eclipse/EclipseState/EclipseState.cpp
+++ b/lib/eclipse/EclipseState/EclipseState.cpp
@@ -61,7 +61,7 @@ namespace Opm {
         m_simulationConfig(  deck, m_eclipseProperties ),
         m_transMult(         GridDims(deck), deck, m_eclipseProperties ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
-        m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext , m_inputGrid.getNXYZ())
+        m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext)
     {
         m_inputGrid.resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
         m_eclipseConfig.io().initFirstRFTOutput(m_schedule);

--- a/lib/eclipse/EclipseState/EclipseState.cpp
+++ b/lib/eclipse/EclipseState/EclipseState.cpp
@@ -55,18 +55,19 @@ namespace Opm {
         m_tables(            deck ),
         m_runspec(           deck ),
         m_gridDims(          deck ),
+        m_eclipseConfig(     deck ),
         m_inputGrid(         deck, nullptr ),
         m_eclipseProperties( deck, m_tables, m_inputGrid ),
         m_simulationConfig(  deck, m_eclipseProperties ),
         m_schedule(          m_parseContext, m_inputGrid, m_eclipseProperties, deck, m_runspec.phases() ),
         m_summaryConfig(     deck, m_schedule, m_tables, m_parseContext , m_inputGrid.getNXYZ()),
-        m_eclipseConfig(     deck, m_eclipseProperties, m_tables, m_gridDims, m_schedule, parseContext ),
         m_transMult(         m_inputGrid.getNX(), m_inputGrid.getNY(), m_inputGrid.getNZ(),
                              m_eclipseProperties, deck.getKeywordList( "MULTREGT" ) ),
         m_inputNnc(          deck, m_gridDims ),
         m_deckUnitSystem(    deck.getActiveUnitSystem() )
     {
         m_inputGrid.resetACTNUM(m_eclipseProperties.getIntGridProperty("ACTNUM").getData().data());
+        m_eclipseConfig.io().initFirstRFTOutput(m_schedule);
 
         if( this->runspec().phases().size() < 3 )
             m_messageContainer.info("Only " + std::to_string( this->runspec().phases().size() )

--- a/lib/eclipse/EclipseState/Grid/NNC.cpp
+++ b/lib/eclipse/EclipseState/Grid/NNC.cpp
@@ -30,7 +30,8 @@
 
 namespace Opm
 {
-    NNC::NNC(const Deck& deck, const GridDims& gridDims) {
+    NNC::NNC(const Deck& deck) {
+        GridDims gridDims(deck);
         const auto& nncs = deck.getKeywordList<ParserKeywords::NNC>();
         for (size_t idx_nnc = 0; idx_nnc<nncs.size(); ++idx_nnc) {
             const auto& nnc = *nncs[idx_nnc];

--- a/lib/eclipse/EclipseState/Grid/TransMult.cpp
+++ b/lib/eclipse/EclipseState/Grid/TransMult.cpp
@@ -26,25 +26,25 @@
 #include <opm/parser/eclipse/EclipseState/Grid/FaultCollection.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/MULTREGTScanner.hpp>
 
 
 namespace Opm {
 
-    TransMult::TransMult(size_t nx , size_t ny , size_t nz,
-                         const Eclipse3DProperties& props,
-                         const std::vector< const DeckKeyword* >& keywords ) :
-        m_nx(nx),
-        m_ny(ny),
-        m_nz(nz),
+    TransMult::TransMult(const GridDims& dims, const Deck& deck, const Eclipse3DProperties& props) :
         m_names( { { FaceDir::XPlus,  "MULTX"  },
                    { FaceDir::YPlus,  "MULTY"  },
                    { FaceDir::ZPlus,  "MULTZ"  },
                    { FaceDir::XMinus, "MULTX-" },
                    { FaceDir::YMinus, "MULTY-" },
-                   { FaceDir::ZMinus, "MULTZ-" }, } ),
-        m_multregtScanner( props, keywords )
-    {}
+                   { FaceDir::ZMinus, "MULTZ-" }}),
+        m_nx( dims.getNX()),
+        m_ny( dims.getNY()),
+        m_nz( dims.getNZ()),
+        m_multregtScanner( props, deck.getKeywordList( "MULTREGT" ))
+    {
+    }
 
     void TransMult::assertIJK(size_t i , size_t j , size_t k) const {
         if ((i >= m_nx) || (j >= m_ny) || (k >= m_nz))
@@ -133,4 +133,4 @@ namespace Opm {
             applyMULTFLT(fault);
         }
     }
-}
+    }

--- a/lib/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/lib/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -377,13 +377,6 @@ inline void uniq( std::vector< ERT::smspec_node >& vec ) {
 
 }
 
-SummaryConfig::SummaryConfig( const Deck& deck, const EclipseState& es , const ParseContext& parseContext)
-    : SummaryConfig( deck,
-                     es.getSchedule(),
-                     es.getTableManager(),
-                     parseContext,
-                     dimensions( es.getInputGrid() ) )
-{}
 
 SummaryConfig::SummaryConfig( const Deck& deck,
                               const Schedule& schedule,

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -22,7 +22,6 @@
 
 #include <memory>
 
-#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
@@ -49,17 +48,13 @@ namespace Opm {
         const InitConfig& init() const;
         const IOConfig& io() const;
         IOConfig& io();
-        const SummaryConfig& summary() const;
         const RestartConfig& restart() const;
-
         const InitConfig& getInitConfig() const;
-        const SummaryConfig& getSummaryConfig() const;
         const RestartConfig& getRestartConfig() const;
 
     private:
         IOConfig m_ioConfig;
         const InitConfig m_initConfig;
-        SummaryConfig m_summaryConfig;
         RestartConfig m_restartConfig;
     };
 }

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -24,7 +24,6 @@
 
 #include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/InitConfig/InitConfig.hpp>
-#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/IOConfig.hpp>
 #include <opm/parser/eclipse/EclipseState/IOConfig/RestartConfig.hpp>
 
@@ -50,19 +49,16 @@ namespace Opm {
         const InitConfig& init() const;
         const IOConfig& io() const;
         IOConfig& io();
-        const SimulationConfig & simulation() const;
         const SummaryConfig& summary() const;
         const RestartConfig& restart() const;
 
         const InitConfig& getInitConfig() const;
-        const SimulationConfig & getSimulationConfig() const;
         const SummaryConfig& getSummaryConfig() const;
         const RestartConfig& getRestartConfig() const;
 
     private:
         IOConfig m_ioConfig;
         const InitConfig m_initConfig;
-        const SimulationConfig m_simulationConfig;
         SummaryConfig m_summaryConfig;
         RestartConfig m_restartConfig;
     };

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseConfig.hpp
@@ -29,21 +29,11 @@
 namespace Opm {
 
     class Deck;
-    class GridDims;
-    class Eclipse3DProperties;
-    class IOConfig;
-    class ParseContext;
-    class TableManager;
 
     class EclipseConfig
     {
     public:
-        EclipseConfig(const Deck& deck,
-                      const Eclipse3DProperties& eclipse3DProperties,
-                      const TableManager& tables,
-                      const GridDims& gridDims,
-                      const Schedule& schedule,
-                      const ParseContext& parseContext);
+        EclipseConfig(const Deck& deck);
 
         const InitConfig& init() const;
         const IOConfig& io() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -124,16 +124,15 @@ namespace Opm {
         ParseContext m_parseContext;
         const TableManager m_tables;
         Runspec m_runspec;
-        const GridDims m_gridDims;
         EclipseConfig m_eclipseConfig;
+        UnitSystem m_deckUnitSystem;
+        NNC m_inputNnc;
         EclipseGrid m_inputGrid;
         Eclipse3DProperties m_eclipseProperties;
         const SimulationConfig m_simulationConfig;
         Schedule m_schedule;
         const SummaryConfig m_summaryConfig;
         TransMult m_transMult;
-        NNC m_inputNnc;
-        UnitSystem m_deckUnitSystem;
 
         FaultCollection m_faults;
         std::string m_title;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -34,6 +34,7 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
+#include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
 
 namespace Opm {
 
@@ -90,7 +91,6 @@ namespace Opm {
         bool hasInputNNC() const;
 
         const Eclipse3DProperties& get3DProperties() const;
-
         const TableManager& getTableManager() const;
         const EclipseConfig& getEclipseConfig() const;
         const EclipseConfig& cfg() const;
@@ -121,6 +121,7 @@ namespace Opm {
                                            const std::string& keywordName);
 
         ParseContext m_parseContext;
+        const SimulationConfig m_simulationConfig;
         const TableManager m_tables;
         Runspec m_runspec;
         const GridDims m_gridDims;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -125,12 +125,12 @@ namespace Opm {
         const TableManager m_tables;
         Runspec m_runspec;
         const GridDims m_gridDims;
+        EclipseConfig m_eclipseConfig;
         EclipseGrid m_inputGrid;
         Eclipse3DProperties m_eclipseProperties;
         const SimulationConfig m_simulationConfig;
         Schedule m_schedule;
         const SummaryConfig m_summaryConfig;
-        EclipseConfig m_eclipseConfig;
         TransMult m_transMult;
         NNC m_inputNnc;
         UnitSystem m_deckUnitSystem;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -130,9 +130,9 @@ namespace Opm {
         EclipseGrid m_inputGrid;
         Eclipse3DProperties m_eclipseProperties;
         const SimulationConfig m_simulationConfig;
+        TransMult m_transMult;
         Schedule m_schedule;
         const SummaryConfig m_summaryConfig;
-        TransMult m_transMult;
 
         FaultCollection m_faults;
         std::string m_title;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/EclipseState.hpp
@@ -35,6 +35,7 @@
 #include <opm/parser/eclipse/Parser/MessageContainer.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/EclipseState/SimulationConfig/SimulationConfig.hpp>
+#include <opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp>
 
 namespace Opm {
 
@@ -121,13 +122,14 @@ namespace Opm {
                                            const std::string& keywordName);
 
         ParseContext m_parseContext;
-        const SimulationConfig m_simulationConfig;
         const TableManager m_tables;
         Runspec m_runspec;
         const GridDims m_gridDims;
         EclipseGrid m_inputGrid;
         Eclipse3DProperties m_eclipseProperties;
+        const SimulationConfig m_simulationConfig;
         Schedule m_schedule;
+        const SummaryConfig m_summaryConfig;
         EclipseConfig m_eclipseConfig;
         TransMult m_transMult;
         NNC m_inputNnc;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/NNC.hpp
@@ -34,7 +34,6 @@ struct NNCdata {
 };
 
 class Deck;
-class GridDims;
 
 /// Represents non-neighboring connections (non-standard adjacencies).
 /// This class is essentially a directed weighted graph.
@@ -44,7 +43,7 @@ public:
     NNC() = default;
 
     /// Construct from input deck.
-    NNC(const Deck& deck, const GridDims& gridDims);
+    explicit NNC(const Deck& deck);
     void addNNC(const size_t cell1, const size_t cell2, const double trans);
     const std::vector<NNCdata>& nncdata() const { return m_nnc; }
     size_t numNNC() const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/TransMult.hpp
@@ -47,9 +47,7 @@ namespace Opm {
     class TransMult {
 
     public:
-        TransMult(size_t nx , size_t ny , size_t nz,
-                  const Eclipse3DProperties&,
-                  const std::vector< const DeckKeyword* >& );
+        TransMult(const GridDims& dims, const Deck& deck, const Eclipse3DProperties& props);
         double getMultiplier(size_t globalIndex, FaceDir::DirEnum faceDir) const;
         double getMultiplier(size_t i , size_t j , size_t k, FaceDir::DirEnum faceDir) const;
         double getRegionMultiplier( size_t globalCellIndex1, size_t globalCellIndex2, FaceDir::DirEnum faceDir) const;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -39,7 +39,6 @@ namespace Opm {
         public:
             typedef std::vector< ERT::smspec_node >::const_iterator const_iterator;
 
-            SummaryConfig( const Deck&, const EclipseState& , const ParseContext&  );
             SummaryConfig( const Deck&, const Schedule&,
                            const TableManager&, const ParseContext&, std::array< int, 3 > );
             SummaryConfig( const Deck&, const Schedule&,

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/SummaryConfig/SummaryConfig.hpp
@@ -34,15 +34,14 @@ namespace Opm {
     class ParserKeyword;
     class Schedule;
     class ParseContext;
+    class GridDims;
 
     class SummaryConfig {
         public:
             typedef std::vector< ERT::smspec_node >::const_iterator const_iterator;
 
             SummaryConfig( const Deck&, const Schedule&,
-                           const TableManager&, const ParseContext&, std::array< int, 3 > );
-            SummaryConfig( const Deck&, const Schedule&,
-                           const TableManager&, const ParseContext&, int, int, int );
+                           const TableManager&, const ParseContext&);
 
             const_iterator begin() const;
             const_iterator end() const;
@@ -70,6 +69,11 @@ namespace Opm {
             bool require3DField( const std::string& keyword) const;
             bool requireFIPNUM( ) const;
         private:
+            SummaryConfig( const Deck& deck,
+                           const Schedule& schedule,
+                           const TableManager& tables,
+                           const ParseContext& parseContext,
+                           const GridDims& dims);
 
             /*
               The short_keywords set contains only the pure keyword

--- a/lib/eclipse/tests/SummaryConfigTests.cpp
+++ b/lib/eclipse/tests/SummaryConfigTests.cpp
@@ -101,7 +101,7 @@ static std::vector< std::string > sorted_key_names( const SummaryConfig& summary
 static SummaryConfig createSummary( std::string input , const ParseContext& parseContext = ParseContext()) {
     auto deck = createDeck( input );
     EclipseState state( deck, parseContext );
-    return state.getEclipseConfig().getSummaryConfig();
+    return state.getSummaryConfig();
 }
 
 BOOST_AUTO_TEST_CASE(wells_all) {

--- a/lib/eclipse/tests/TransMultTests.cpp
+++ b/lib/eclipse/tests/TransMultTests.cpp
@@ -29,10 +29,11 @@
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/TransMult.hpp>
 #include <opm/parser/eclipse/EclipseState/Grid/GridProperty.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/GridDims.hpp>
 
 BOOST_AUTO_TEST_CASE(Empty) {
     Opm::Eclipse3DProperties props;
-    Opm::TransMult transMult(10,10,10, props, {} );
+    Opm::TransMult transMult(Opm::GridDims(10,10,10) ,{} , props);
 
     BOOST_CHECK_THROW( transMult.getMultiplier(12,10,10 , Opm::FaceDir::XPlus) , std::invalid_argument );
     BOOST_CHECK_THROW( transMult.getMultiplier(1000 , Opm::FaceDir::XPlus) , std::invalid_argument );


### PR DESCRIPTION
Minor refactoring of EclipseState constructor. To prepare for external Schedule.

Depends on: 
https://github.com/OPM/opm-output/pull/204
https://github.com/OPM/opm-core/pull/1176