### PR TITLE
[WIP] Minor fix for test program.

### DIFF
--- a/lib/eclipse/tests/SummaryConfigTests.cpp
+++ b/lib/eclipse/tests/SummaryConfigTests.cpp
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE(completions) {
                        "/\n"
                        "CGIR\n" // all defaulted
                        " '*' /\n"
-                       "/\n";
+                       "/\n"
                        "CPRL\n" // all defaulted
                        " '*' /\n"
                        "/\n";


### PR DESCRIPTION
A compiler warning indicated a real, minor bug in SummaryConfigTests.cpp. However, the obvious fix leads to test failure.

I think you are better suited than me to decide what the correct test should be!