### PR TITLE
Fix shut well logic when WELOPEN and COMPDAT is combined

### DIFF
--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/Schedule.hpp
@@ -159,6 +159,7 @@ namespace Opm
         void handleMESSAGES(const DeckKeyword& keyword, size_t currentStep);
 
         void checkUnhandledKeywords( const SCHEDULESection& ) const;
+        void checkIfAllConnectionsIsShut(size_t currentStep);
 
         static double convertInjectionRateToSI(double rawRate, WellInjector::TypeEnum wellType, const Opm::UnitSystem &unitSystem);
         static double convertInjectionRateToSI(double rawRate, Phase wellPhase, const Opm::UnitSystem &unitSystem);

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -910,7 +910,7 @@ BOOST_AUTO_TEST_CASE(TestWellEvents) {
     BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 1 ));
     BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 3 ));
     BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 4 ));
-    BOOST_CHECK( w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 5 ));
+    BOOST_CHECK( !w1->hasEvent( ScheduleEvents::WELL_STATUS_CHANGE , 5 ));
 
     BOOST_CHECK( w1->hasEvent( ScheduleEvents::COMPLETION_CHANGE , 0 ));
     BOOST_CHECK( w1->hasEvent( ScheduleEvents::COMPLETION_CHANGE , 5 ));


### PR DESCRIPTION
Do not shut well if all completions are shut using WELOPEN, but new
completions are opened using COMPDAT