### PR TITLE
First try to find ecl with deactivated package registry.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ endif()
 
 # Give us a chance to find ecl installed to CMAKE_INSTALL_PREFIX.
 # We need to deactivate the package registry for this.
-find_package(ecl NO_CMAKE_SYSTEM_PACKAGE_REGISTRY)
+find_package(ecl NO_CMAKE_SYSTEM_PACKAGE_REGISTRY NO_CMAKE_PACKAGE_REGISTRY)
 # If everything else failed fall back to the registry
 find_package(ecl REQUIRED)
 message(STATUS "Found ecl library: ${ecl_DIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ if(ecl_DIR AND NOT IS_DIRECTORY ${ecl_DIR})
     " ecl_DIR is not a directory")
 endif()
 
+# Give us a chance to find ecl installed to CMAKE_INSTALL_PREFIX.
+# We need to deactivate the package registry for this.
+find_package(ecl NO_CMAKE_SYSTEM_PACKAGE_REGISTRY)
+# If everything else failed fall back to the registry
 find_package(ecl REQUIRED)
 message(STATUS "Found ecl library: ${ecl_DIR}")
 find_library(CJSON_LIBRARY NAMES cjson)


### PR DESCRIPTION
This allows to configure with-DCMAKE_INSTALL_PREFIX and find the installed version and not the build tree of ecl (that was used the last time).

I just did an installation test with `-DSIBLING_SEARCH=Off -DCMAKE_INSTALL_PREFIX=/path/to/install` and had a hard time figuring out why opm-parser still found the sibling build of ecl and not the installed version. Well there is still the package registry lying around as ecl is using it...

This is for discussion. One can also either explicitly set ecl_DIR (not tested) or set CMAKE_PREFIX_PATH (tested) to the installed version. But this seems more complicated than needed for users/admins.