### PR TITLE
Fix search path of libecl for installed opm-parser.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -260,6 +260,7 @@ set(OPM_PARSER_MODULE_PATH "${OPM_PARSER_PREFIX}/share/dune/cmake/modules")
 set(OPM_PARSER_INCLUDEDIRS "${OPM_PARSER_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}")
 set(OPM_PARSER_LIBDIRS "${OPM_PARSER_PREFIX}/${CMAKE_INSTALL_LIBDIR}")
 set(OPM_PARSER_INSTALLED ON)
+set(ECL_DIR "${OPM_PARSER_PREFIX}/share/cmake/ecl")
 configure_file(opm-parser-config.cmake.in
   "${PROJECT_BINARY_DIR}/install/opm-parser-config.cmake" @ONLY)
 
@@ -268,6 +269,7 @@ set(OPM_PARSER_INCLUDEDIRS "${OPM_PARSER_PREFIX}/lib/eclipse/include;${OPM_PARSE
 set(OPM_PARSER_MODULE_PATH "${OPM_PARSER_PREFIX}/cmake/modules")
 set(OPM_PARSER_LIBDIRS "${CMAKE_BINARY_DIR}/lib/eclipse;${CMAKE_BINARY_DIR}/lib/json")
 set(OPM_PARSER_INSTALLED OFF)
+set(ECL_DIR "${ecl_DIR}")
 configure_file(opm-parser-config.cmake.in
   "${PROJECT_BINARY_DIR}/opm-parser-config.cmake" @ONLY)
 

--- a/opm-parser-config.cmake.in
+++ b/opm-parser-config.cmake.in
@@ -1,7 +1,13 @@
 if(NOT opm-parser_FOUND)
   #import the target
-  set(ecl_DIR @ecl_DIR@)
+  if(NOT ecl_DIR)
+      set(ecl_DIR @ECL_DIR@)
+  endif()
+  # Find without registry
+  find_package(ecl NO_CMAKE_PACKAGE_REGISTRY NO_CMAKE_SYSTEM_PACKAGE_REGISTRY)
+  # Fall back to registry
   find_package(ecl REQUIRED)
+
   get_filename_component(_dir "${CMAKE_CURRENT_LIST_FILE}" PATH)
   include("${_dir}/opm-parser-targets.cmake")
 


### PR DESCRIPTION
Previously, ecl_DIR was always set to the build directory used even
for the installed cmake configuration file. This patch at least allows
to overwrite that location and for the installed version tries to guess
the correct location. The guess is that libecl and opm-parser are installed
under the same prefix. As a fallback we use the package registry.