### PR TITLE
Added missing include in Equil.hpp

### DIFF
--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/InitConfig/Equil.hpp
@@ -1,6 +1,8 @@
 #ifndef OPM_EQUIL_HPP
 #define OPM_EQUIL_HPP
 
+#include <vector>
+
 namespace Opm {
 
     class DeckKeyword;


### PR DESCRIPTION
When running test in opm-parser, this never showed up as a problem since
Equil.hpp seems to be always included after <vector> is included (either
directly or by including other files). However, this can become a
problem when using opm-parser in other projects (eg, sunbeam)

If possible, this should backported to 2017.10/final. Alternatively, a workaround is to include <vector> before Equil.hpp whenever necessary