### PR TITLE
Scatter vector

### DIFF
--- a/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
+++ b/lib/eclipse/EclipseState/Grid/EclipseGrid.cpp
@@ -898,6 +898,7 @@ namespace Opm {
         return this->activeMap;
     }
 
+
     void EclipseGrid::resetACTNUM( const int * actnum) {
         ecl_grid_reset_actnum( m_grid.get() , actnum );
         /* re-build the active map cache */

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/EclipseGrid.hpp
@@ -144,6 +144,27 @@ namespace Opm {
             }
         }
 
+        template<typename T>
+        std::vector<T> scatterVector(const std::vector<T>& input_vector, T def = -1) const {
+            if (input_vector.size() == this->getCartesianSize())
+                return input_vector;
+
+            if (input_vector.size() != this->getNumActive())
+                throw std::invalid_argument("Input vector must have full or active size");
+
+            std::vector<T> scatter_vector( this->getCartesianSize() );
+
+            for (size_t i = 0; i < this->getCartesianSize(); i++) {
+                int active_index = ecl_grid_get_active_index1( m_grid.get() , i );
+                if (active_index < 0)
+                    scatter_vector[i] = def;
+                else
+                    scatter_vector[i] = input_vector[ active_index  ];
+            }
+
+            return scatter_vector;
+        }
+
 
         /// Will return a vector a length num_active; where the value
         /// of each element is the corresponding global index.

--- a/lib/eclipse/tests/EclipseGridTests.cpp
+++ b/lib/eclipse/tests/EclipseGridTests.cpp
@@ -39,8 +39,6 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
-#include <ert/util/test_util.hpp>
-
 
 BOOST_AUTO_TEST_CASE(CreateMissingDIMENS_throws) {
     Opm::Deck deck;
@@ -685,7 +683,7 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
         BOOST_CHECK_EQUAL( 1000U , grid.getCartesianSize());
 
         std::vector<double> v(7);
-        test_assert_throw( grid.scatterVector(v) , std::invalid_argument);
+        BOOST_CHECK_THROW( grid.scatterVector(v) , std::invalid_argument);
 
         std::vector<double> w(4);
         w[0] = 12;

--- a/lib/eclipse/tests/EclipseGridTests.cpp
+++ b/lib/eclipse/tests/EclipseGridTests.cpp
@@ -39,6 +39,8 @@
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 
+#include <ert/util/test_util.hpp>
+
 
 BOOST_AUTO_TEST_CASE(CreateMissingDIMENS_throws) {
     Opm::Deck deck;
@@ -677,6 +679,26 @@ BOOST_AUTO_TEST_CASE(ResetACTNUM) {
         BOOST_CHECK_EQUAL( compressed[1] , 2 );
         BOOST_CHECK_EQUAL( compressed[2] , 4 );
         BOOST_CHECK_EQUAL( compressed[3] , 6 );
+
+        std::vector<double> u(1000);
+        std::vector<double> u_scatter = grid.scatterVector(u);
+        BOOST_CHECK_EQUAL( 1000U , grid.getCartesianSize());
+
+        std::vector<double> v(7);
+        test_assert_throw( grid.scatterVector(v) , std::invalid_argument);
+
+        std::vector<double> w(4);
+        w[0] = 12;
+        w[1] = 13;
+        w[2] = 14;
+        w[3] = 15;
+        std::vector<double> scatter_w = grid.scatterVector(w);
+        BOOST_CHECK_EQUAL( scatter_w.size() , 1000U );
+        BOOST_CHECK_EQUAL( scatter_w[0] , 12 );
+        BOOST_CHECK_EQUAL( scatter_w[1] , -1 );
+        BOOST_CHECK_EQUAL( scatter_w[2] , 13 );
+        BOOST_CHECK_EQUAL( scatter_w[4] , 14 );
+        BOOST_CHECK_EQUAL( scatter_w[6] , 15 );
     }
     {
         const auto& activeMap = grid.getActiveMap( );


### PR DESCRIPTION
This pr suggets a scatterVector function in EclipseGrid:
```C++
template<typename T>
std::vector<T> scatterVector(const std::vector<T>& input_vector, T def = -1) const
```
Argument input_vector can have either size equal to the numbers of grid cells or the active number of grid cells, else an exception is thrown. For for former case,, the return value equals the input_vector. For the latter case: `output_entry[i] = input_vector[j]`, where `i` is the global index and `j` is the active index. For inactive cells, `output_entry[i] = def`.