### PR TITLE
Fixing history mode

### DIFF
--- a/lib/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -452,8 +452,7 @@ namespace Opm {
                     properties = WellProductionProperties::prediction( record, addGrupProductionControl );
                 } else {
                     const WellProductionProperties& prev_properties = well->getProductionProperties(currentStep);
-                    double BHPLimit = prev_properties.BHPLimit;
-                    properties = WellProductionProperties::history( BHPLimit , record, m_phases);
+                    properties = WellProductionProperties::history(prev_properties, record);
                 }
 
                 if (status != WellCommon::SHUT) {
@@ -969,13 +968,7 @@ namespace Opm {
                     }
                     else if (cMode == "BHP"){
                         prop.BHPLimit = newValue * siFactorP;
-                        /* For wells controlled by WCONHIST the BHP value given by the
-                           WCHONHIST keyword can not be used to control the well - i.e BHP
-                           control is not natively available - however when BHP has been
-                           specified with WELTARG we can enable BHP control.
-                        */
-                        if (prop.predictionMode == false)
-                            prop.addProductionControl(WellProducer::BHP);
+                        prop.BHPLimitFromWelltag = true;
                     }
                     else if (cMode == "THP"){
                         prop.THPLimit = newValue * siFactorP;

--- a/lib/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -743,12 +743,12 @@ namespace Opm {
             properties.surfaceInjectionRate = injectionRate;
 
             const std::string& cmodeString = record.getItem("CMODE").getTrimmedString(0);
-            const WellInjector::ControlModeEnum controlMode = WellInjector::ControlModeFromString( cmodeString );
+            const WellInjector::ControlModeEnum controlModeInput = WellInjector::ControlModeFromString( cmodeString );
 
-            properties.controlMode = controlMode;
+            properties.controlMode = controlModeInput;
 
-            if (controlMode == WellInjector::RATE)
-                properties.addInjectionControl(controlMode);
+            if (controlModeInput == WellInjector::RATE)
+                properties.addInjectionControl(controlModeInput);
 
             // It is recommended that a large BHP limit (without specific value) is used when swtiching to historical mode and
             // not under `BHP` control mode. Currently, we set one big value based on the numeric limits, which means it should
@@ -768,7 +768,7 @@ namespace Opm {
 
             // when switching from prediction mode to historical mode
             if ( prev_properties.predictionMode ) {
-                if ( controlMode != WellInjector::BHP )
+                if ( controlModeInput != WellInjector::BHP )
                     properties.BHPLimit = large_default_bhp;
                 else
                     properties.BHPLimit = BHPLimit_from_deck;
@@ -779,7 +779,7 @@ namespace Opm {
                 // WCONINJH keyword
                 properties.BHPLimit = BHPLimit_from_prev;
                 properties.BHPLimitFromWelltag = true;
-            } else if (controlMode == WellInjector::BHP ) {
+            } else if (controlModeInput == WellInjector::BHP ) {
                 properties.BHPLimit = BHPLimit_from_deck;
                 properties.BHPLimitFromWelltag = false;
             } else {
@@ -787,7 +787,7 @@ namespace Opm {
                 properties.BHPLimitFromWelltag = false;
             }
 
-            if ( !(controlMode == WellInjector::RATE || controlMode == WellInjector::BHP) ) {
+            if ( !(controlModeInput == WellInjector::RATE || controlModeInput == WellInjector::BHP) ) {
                 const std::string msg = "unsupported control mode " + cmodeString + " for WCONINJH of Well " + wellName;
                 throw std::invalid_argument(msg);
             }

--- a/lib/eclipse/EclipseState/Schedule/Well.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Well.cpp
@@ -75,19 +75,13 @@ namespace Opm {
 
 
     void Well::switchToProducer( size_t timeStep) {
-        WellInjectionProperties p = getInjectionPropertiesCopy(timeStep);
-
-        p.BHPLimit = 0;
-        p.dropInjectionControl( Opm::WellInjector::BHP );
+        WellInjectionProperties p;
         setInjectionProperties( timeStep , p );
     }
 
 
     void Well::switchToInjector( size_t timeStep) {
-        WellProductionProperties p = getProductionPropertiesCopy(timeStep);
-
-        p.BHPLimit = 0;
-        p.dropProductionControl( Opm::WellProducer::BHP );
+        WellProductionProperties p;
         setProductionProperties( timeStep , p );
     }
 

--- a/lib/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
+++ b/lib/eclipse/EclipseState/Schedule/WellInjectionProperties.cpp
@@ -38,6 +38,7 @@ namespace Opm {
         THPH=0.0;
         VFPTableNumber=0;
         predictionMode=true;
+        BHPLimitFromWelltag = false;
         injectionControls=0;
         injectorType = WellInjector::WATER;
         controlMode = WellInjector::CMODE_UNDEFINED;

--- a/lib/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/lib/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -78,7 +78,8 @@ namespace Opm {
                 p.addProductionControl( cmode );
                 p.controlMode = cmode;
             } else {
-                const std::string msg = "unsupported control mode " + cmode_string + " for WCONHIST";
+                const std::string well_name = record.getItem("WELL").getTrimmedString(0);
+                const std::string msg = "unsupported control mode " + cmode_string + " for WCONHIST of Well " + well_name;
                 throw std::invalid_argument(msg);
             }
 

--- a/lib/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/lib/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include <opm/parser/eclipse/Units/Units.hpp>
 #include <opm/parser/eclipse/Deck/DeckItem.hpp>
 #include <opm/parser/eclipse/Deck/DeckRecord.hpp>
 #include <opm/parser/eclipse/EclipseState/Schedule/ScheduleEnums.hpp>
@@ -41,49 +42,66 @@ namespace Opm {
     {}
 
 
-    WellProductionProperties WellProductionProperties::history(double BHPLimit, const DeckRecord& record, const Phases &phases)
+    WellProductionProperties WellProductionProperties::history(const WellProductionProperties& prevProperties, const DeckRecord& record)
     {
-        // Modes supported in WCONHIST just from {O,W,G}RAT values
-        //
-        // Note: The default value of observed {O,W,G}RAT is zero
-        // (numerically) whence the following control modes are
-        // unconditionally supported.
         WellProductionProperties p(record);
         p.predictionMode = false;
 
-        namespace wp = WellProducer;
-        if(phases.active(Phase::OIL))
-            p.addProductionControl( wp::ORAT );
-
-        if(phases.active(Phase::WATER))
-            p.addProductionControl( wp::WRAT );
-
-        if(phases.active(Phase::GAS))
-            p.addProductionControl( wp::GRAT );
-
-        for( auto cmode : { wp::LRAT, wp::RESV, wp::GRUP } ) {
-            p.addProductionControl( cmode );
-        }
-
         /*
-          We do not update the BHPLIMIT based on the BHP value given
-          in WCONHIST, that is purely a historical value; instead we
-          copy the old value of the BHP limit from the previous
-          timestep.
+          There are a few ways to specify the BHPLimit in historical mode.
+          If the well is the under BHP control mode, then the observed BHP value will
+          serve as the BHP limit.
 
-          To actually set the BHPLIMIT in historical mode you must
-          use the WELTARG keyword.
+          If the control mode is not BHP, then by default the BHP limit is 1 atm. when declared
+          as history matching well for the first time with WCONHIST.
+
+          You can reset the BHP limit to a specific value with keyword WELTARG.
+
+          When the BHP limit is reset by WELTARG, the BHP limit will not be changed by the subsequent
+          WCONHIST keyword if not under BHP control.
+
+          FBHPDEF can be used to set the default BHP limit.
+
+          WHISTCTL can be used to stop the simulation if a history matching well switches to BHP control.
         */
-        p.BHPLimit = BHPLimit;
 
         const auto& cmodeItem = record.getItem("CMODE");
+        // to make the following work correctly, we need to make the correct limit value in place
         if (!cmodeItem.defaultApplied(0)) {
-            const auto cmode = WellProducer::ControlModeFromString( cmodeItem.getTrimmedString( 0 ) );
+            const std::string cmode_string = cmodeItem.getTrimmedString( 0 );
+            const auto cmode = WellProducer::ControlModeFromString(cmode_string);
 
-            if (p.hasProductionControl( cmode ))
+            namespace wp = WellProducer;
+
+            if (cmode == wp::LRAT || cmode == wp::RESV || cmode == wp::ORAT ||
+                cmode == wp::WRAT || cmode == wp::GRAT || cmode == wp::BHP) {
+                p.addProductionControl( cmode );
                 p.controlMode = cmode;
-            else
-                throw std::invalid_argument("Setting CMODE to unspecified control");
+            } else {
+                const std::string msg = "unsupported control mode " + cmode_string + " for WCONHIST";
+                throw std::invalid_argument(msg);
+            }
+
+            // always have a BHP control/limit, while the limit value needs to be determined
+            p.addProductionControl( wp::BHP );
+
+            if (cmode == wp::BHP) {
+                // \Note, this value can be reset by WELTARG later.
+                p.BHPLimit = record.getItem( "BHP" ).getSIDouble( 0 );
+                p.BHPLimitFromWelltag = false;
+            } else {
+                // Not sure if a well switch to prediction mode and switch back to historical mode,
+                // how the WELTAG value works here, we treat the switching from prediction model to
+                // historical mode as the first time declaring WCONHIST here
+                if (!prevProperties.predictionMode && prevProperties.BHPLimitFromWelltag) {
+                    p.BHPLimit = prevProperties.BHPLimit;
+                    p.BHPLimitFromWelltag = true;
+                } else {
+                    // The 1 atm default value can be changed by keyword FBHPDEF
+                    p.BHPLimit = 1. * unit::atm;
+                    p.BHPLimitFromWelltag = false;
+                }
+            }
         }
 
         if ( record.getItem( "BHP" ).hasValue(0) )

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -35,6 +35,7 @@ namespace Opm {
         double  BHPH;
         double  THPH;
         int     VFPTableNumber;
+        // whether the BHP limit is obtained through WELTARG
         bool BHPLimitFromWelltag;
         bool    predictionMode;
         int     injectionControls;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellInjectionProperties.hpp
@@ -35,6 +35,7 @@ namespace Opm {
         double  BHPH;
         double  THPH;
         int     VFPTableNumber;
+        bool BHPLimitFromWelltag;
         bool    predictionMode;
         int     injectionControls;
         WellInjector::TypeEnum injectorType;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -56,7 +56,9 @@ namespace Opm {
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
 
-        static WellProductionProperties history(const WellProductionProperties& prevProperties, const DeckRecord& record);
+        static WellProductionProperties history(const WellProductionProperties& prevProperties, const DeckRecord& record,
+                                                const WellProducer::ControlModeEnum controlModeWHISTCL,
+                                                const WellCommon::StatusEnum status);
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {
@@ -71,6 +73,14 @@ namespace Opm {
         void addProductionControl(WellProducer::ControlModeEnum controlModeArg) {
             if (! hasProductionControl(controlModeArg))
                 m_productionControls += controlModeArg;
+        }
+
+        // this is used to check whether the specified control mode is an effective history matching production mode
+        static bool effectiveHistoryProductionControl(WellProducer::ControlModeEnum cmode) {
+            // Note, not handling CRAT for now
+            namespace wp = WellProducer;
+            return ( (cmode == wp::LRAT || cmode == wp::RESV || cmode == wp::ORAT ||
+                      cmode == wp::WRAT || cmode == wp::GRAT || cmode == wp::BHP) );
         }
 
     private:

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -32,17 +32,22 @@ namespace Opm {
 
     class WellProductionProperties {
     public:
+        // the rates serve as limits under prediction mode
+        // while they are observed rates under historical mode
         double  OilRate     = 0.0;
         double  WaterRate   = 0.0;
         double  GasRate     = 0.0;
         double  LiquidRate  = 0.0;
         double  ResVRate    = 0.0;
+        // BHP and THP limit
         double  BHPLimit    = 0.0;
         double  THPLimit    = 0.0;
+        // historical BHP and THP under historical mode
         double  BHPH        = 0.0;
         double  THPH        = 0.0;
         int     VFPTableNumber = 0;
         double  ALQValue    = 0.0;
+        bool BHPLimitFromWelltag = false;
         bool    predictionMode = false;
 
         WellProducer::ControlModeEnum controlMode = WellProducer::CMODE_UNDEFINED;
@@ -51,7 +56,7 @@ namespace Opm {
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
 
-        static WellProductionProperties history(double BHPLimit, const DeckRecord& record, const Phases &phases = Phases(true, true, true) );
+        static WellProductionProperties history(const WellProductionProperties& prevProperties, const DeckRecord& record);
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -47,6 +47,7 @@ namespace Opm {
         double  THPH        = 0.0;
         int     VFPTableNumber = 0;
         double  ALQValue    = 0.0;
+        // whether the BHP limit is obtained through WELTARG
         bool BHPLimitFromWelltag = false;
         bool    predictionMode = false;
 

--- a/lib/eclipse/tests/ScheduleTests.cpp
+++ b/lib/eclipse/tests/ScheduleTests.cpp
@@ -1171,12 +1171,14 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
             " 18  OKT 2008 / \n"
             "/\n"
             "WCONHIST\n"
-            "   'P' 'OPEN' 'RESV' 6*  /\n/\n"
-            "DATES             -- 3\n"
+            "   'I' 'OPEN' 'RESV' 6*  /\n/\n"
+            "DATES             -- 4\n"
             " 20  OKT 2008 / \n"
             "/\n"
             "WCONINJH\n"
-            " 'I' 'WATER' 1* 100 250 / \n"
+            " 'I' 'WATER' 1* 100 250 /\n /\n"
+            "DATES             -- 5\n"
+            " 22  OKT 2008 / \n"
             "/\n"
             ;
 
@@ -1198,10 +1200,14 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(0).BHPLimit, 0); //start
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(1).BHPLimit, 600 * 1e5); // 1
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(2).BHPLimit, 600 * 1e5); // 2
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 600 * 1e5); // 3
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 0); // 3
+    const double large_default_bhp = std::numeric_limits<double>::max();
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, large_default_bhp); // 5
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(5).BHPLimit, large_default_bhp); // 5
 
     BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
-    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
+    // there should be no any production control here
+    BOOST_CHECK_EQUAL( false , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
 }
 
 BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {

--- a/lib/eclipse/tests/ScheduleTests.cpp
+++ b/lib/eclipse/tests/ScheduleTests.cpp
@@ -1171,7 +1171,7 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
             " 18  OKT 2008 / \n"
             "/\n"
             "WCONHIST\n"
-            "   'I' 'OPEN' 'RESV' 6*  /\n/\n"
+            "   'P' 'OPEN' 'RESV' 6*  /\n/\n"
             "DATES             -- 3\n"
             " 20  OKT 2008 / \n"
             "/\n"
@@ -1198,14 +1198,10 @@ BOOST_AUTO_TEST_CASE(changeBhpLimitInHistoryModeWithWeltarg) {
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(0).BHPLimit, 0); //start
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(1).BHPLimit, 600 * 1e5); // 1
     BOOST_CHECK_EQUAL(well_i->getInjectionProperties(2).BHPLimit, 600 * 1e5); // 2
+    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 600 * 1e5); // 3
 
-    // Check that the BHP limit is reset when changing between injector and producer.
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(3).BHPLimit, 0); // 3
-    BOOST_CHECK_EQUAL(well_i->getInjectionProperties(4).BHPLimit, 0); // 4
-
-    BOOST_CHECK_EQUAL( true  , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
-    BOOST_CHECK_EQUAL( false , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
-    BOOST_CHECK_EQUAL( false , well_i->getInjectionProperties(4).hasInjectionControl(Opm::WellInjector::BHP) );
+    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(2).hasInjectionControl(Opm::WellInjector::BHP) );
+    BOOST_CHECK_EQUAL( true , well_i->getInjectionProperties(3).hasInjectionControl(Opm::WellInjector::BHP) );
 }
 
 BOOST_AUTO_TEST_CASE(changeModeWithWHISTCTL) {

--- a/lib/eclipse/tests/WellTests.cpp
+++ b/lib/eclipse/tests/WellTests.cpp
@@ -864,7 +864,9 @@ namespace {
 
             auto deck = parser.parseString(input, Opm::ParseContext());
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
-            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history( 100 , record);;
+            // TODO: need to fix here
+            const Opm::WellProductionProperties prev_properties;
+            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_properties, record);;
 
             return hist;
         }

--- a/lib/eclipse/tests/WellTests.cpp
+++ b/lib/eclipse/tests/WellTests.cpp
@@ -808,10 +808,10 @@ BOOST_AUTO_TEST_CASE(testWellNameInWellNamePattern) {
 
 namespace {
     namespace WCONHIST {
-        std::string all_specified_CMODE_BHP() {
+        std::string all_specified_CMODE_THP() {
             const std::string input =
                 "WCONHIST\n"
-                "'P' 'OPEN' 'BHP' 1 2 3/\n/\n";
+                "'P' 'OPEN' 'THP' 1 2 3/\n/\n";
 
             return input;
         }
@@ -864,7 +864,6 @@ namespace {
 
             auto deck = parser.parseString(input, Opm::ParseContext());
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
-            // TODO: need to fix here
             const Opm::WellProductionProperties prev_properties;
             Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_properties, record);;
 
@@ -905,18 +904,16 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_specified());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
 
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::ORAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    // BHP is always there
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
@@ -924,17 +921,15 @@ BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::orat_defaulted());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::WRAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    // BHP is always there
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
@@ -942,17 +937,14 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::owrat_defaulted());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::GRAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
@@ -960,17 +952,14 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::LRAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
@@ -978,27 +967,22 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted_with_bhp());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
 
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::RESV);
 
-    /*
-      BHP in WCONHIST is not an available control; just information
-      about the historical BHP.
-    */
-    BOOST_CHECK_EQUAL(false , p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 
 BOOST_AUTO_TEST_CASE(BHP_CMODE)
 {
-    BOOST_CHECK_THROW( WCONHIST::properties(WCONHIST::all_specified_CMODE_BHP()) , std::invalid_argument);
+    // THP control is not supported by WCONHIST
+    BOOST_CHECK_THROW( WCONHIST::properties(WCONHIST::all_specified_CMODE_THP()) , std::invalid_argument);
     BOOST_CHECK_THROW( WCONPROD::properties(WCONPROD::all_specified_CMODE_BHP()) , std::invalid_argument);
 }
 

--- a/lib/eclipse/tests/WellTests.cpp
+++ b/lib/eclipse/tests/WellTests.cpp
@@ -865,7 +865,8 @@ namespace {
             auto deck = parser.parseString(input, Opm::ParseContext());
             const auto& record = deck.getKeyword("WCONHIST").getRecord(0);
             const Opm::WellProductionProperties prev_properties;
-            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_properties, record);;
+            Opm::WellProductionProperties hist = Opm::WellProductionProperties::history(prev_properties, record,
+                                                 WellProducer::CMODE_UNDEFINED, WellCommon::OPEN);;
 
             return hist;
         }

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -199,8 +199,8 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
             const WellProductionProperties& prop3 = well2->getProductionProperties(3);
             BOOST_CHECK_EQUAL( WellProducer::ORAT , prop3.controlMode);
             BOOST_CHECK(  prop3.hasProductionControl(WellProducer::ORAT));
-            BOOST_CHECK(  prop3.hasProductionControl(WellProducer::GRAT));
-            BOOST_CHECK(  prop3.hasProductionControl(WellProducer::WRAT));
+            BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::GRAT));
+            BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::WRAT));
         }
 
         // BOOST_CHECK( !well2->getProductionProperties(8).hasProductionControl(WellProducer::GRAT));

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -196,9 +196,10 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
         BOOST_CHECK( well2->getRFTActive( 4 ) );
         BOOST_CHECK( !well2->getRFTActive( 5 ) );
         {
+            // W_2 is SHUT
             const WellProductionProperties& prop3 = well2->getProductionProperties(3);
-            BOOST_CHECK_EQUAL( WellProducer::ORAT , prop3.controlMode);
-            BOOST_CHECK(  prop3.hasProductionControl(WellProducer::ORAT));
+            BOOST_CHECK_EQUAL( WellProducer::CMODE_UNDEFINED, prop3.controlMode);
+            BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::ORAT));
             BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::GRAT));
             BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::WRAT));
         }


### PR DESCRIPTION
Following the discussion of #1032 .

The observed rates not under control from keyword will not become control/limit.

For both WCONHIST and WCONINJH, the bhp control will always be there. For WCONHIST, the default BHP limit will be 1 atm. For WCONINJH, it is a large value (It can be the 8925 bar as WCONINJE, while has not found proof).

WELTARG can be used to set the BHP limit for both keywords. For WCONHIST, the BHP limit set by WELTARG can be changed by WCONHIST under BHP control mode.

For WCONINJH, the BHP limit set by WELARG will not be affected by information specified by WCONINJH keyword.

FBHPDEF can be used to set the default BHP limits, while the keyword has not been implemented yet.

This PR still use same variables to represent the rate limits and observed rates (depending whether prediction mode and historical mode), not sure whether it is desired. Please suggest. It looks like to me compatible with the opm-output.

The related PR in opm-simulators is OPM/opm-simulators#1362 . 

I tried to fix the tests, while I still have problem in understanding some tests. And also, to incorporate the new implementation in this PR, some tests need to be adjusted and maybe something new needs to be added. Anyway, I will continue updating this PR tomorrow so some discussion can begin.
