### PR TITLE
add more thermal keywords and the associated infrastructure

### DIFF
--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -424,6 +424,12 @@ namespace Opm {
         // saturation dependence of thermal conductivity, E300 only
         supportedDoubleKeywords.emplace_back( "THCONSF", 0.0, "1");
 
+        // the THC* family of keywords to specify heat contuctivity, E300 only
+        supportedDoubleKeywords.emplace_back( "THCROCK", 0.0, "Energy/AbsoluteTemperature*Length*Time");
+        supportedDoubleKeywords.emplace_back( "THCOIL", 0.0, "Energy/AbsoluteTemperature*Length*Time");
+        supportedDoubleKeywords.emplace_back( "THCGAS", 0.0, "Energy/AbsoluteTemperature*Length*Time");
+        supportedDoubleKeywords.emplace_back( "THCWATER", 0.0, "Energy/AbsoluteTemperature*Length*Time");
+
         return supportedDoubleKeywords;
     }
 

--- a/lib/eclipse/share/keywords/001_Eclipse300/T/THCGAS
+++ b/lib/eclipse/share/keywords/001_Eclipse300/T/THCGAS
@@ -1,0 +1,8 @@
+{
+  "name": "THCGAS",
+  "sections": ["GRID"],
+  "data": {
+    "value_type": "DOUBLE",
+    "dimension": "Energy/AbsoluteTemperature*Length*Time"
+   }
+}

--- a/lib/eclipse/share/keywords/001_Eclipse300/T/THCOIL
+++ b/lib/eclipse/share/keywords/001_Eclipse300/T/THCOIL
@@ -1,0 +1,8 @@
+{
+  "name": "THCOIL",
+  "sections": ["GRID"],
+  "data": {
+    "value_type": "DOUBLE",
+    "dimension": "Energy/AbsoluteTemperature*Length*Time"
+   }
+}

--- a/lib/eclipse/share/keywords/001_Eclipse300/T/THCROCK
+++ b/lib/eclipse/share/keywords/001_Eclipse300/T/THCROCK
@@ -1,0 +1,8 @@
+{
+  "name": "THCROCK",
+  "sections": ["GRID"],
+  "data": {
+    "value_type": "DOUBLE",
+    "dimension": "Energy/AbsoluteTemperature*Length*Time"
+   }
+}

--- a/lib/eclipse/share/keywords/001_Eclipse300/T/THCWATER
+++ b/lib/eclipse/share/keywords/001_Eclipse300/T/THCWATER
@@ -1,0 +1,8 @@
+{
+  "name": "THCWATER",
+  "sections": ["GRID"],
+  "data": {
+    "value_type": "DOUBLE",
+    "dimension": "Energy/AbsoluteTemperature*Length*Time"
+   }
+}

--- a/lib/eclipse/share/keywords/keyword_list.cmake
+++ b/lib/eclipse/share/keywords/keyword_list.cmake
@@ -405,7 +405,11 @@ set( keywords
      001_Eclipse300/S/STCOND
      001_Eclipse300/T/TEMPI
      001_Eclipse300/T/TEMPVD
+     001_Eclipse300/T/THCGAS
+     001_Eclipse300/T/THCOIL
      001_Eclipse300/T/THCONSF
+     001_Eclipse300/T/THCROCK
+     001_Eclipse300/T/THCWATER
      001_Eclipse300/T/THERMAL
      001_Eclipse300/T/THERMEX1
      001_Eclipse300/T/TREF


### PR DESCRIPTION
this is a small follow-up to #1158. It just adds the THC* keyword family to specify thermal conductivity. BTW: the approach of this keyword family is just a much too complicated way to set constant conductivity. That's because the final heat conductivity does not depend on the current solution at all, i.e. instead of just computing the arithmetic average of all fluid phases, it would be better to weight each phase conductivity with the phase's saturation.