### PR TITLE
Fixing history matching wells part 1

### DIFF
--- a/lib/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -455,33 +455,16 @@ namespace Opm {
                     properties = WellProductionProperties::prediction( record, addGrupProductionControl );
                 } else {
                     const WellProductionProperties& prev_properties = well->getProductionProperties(currentStep);
-                    double BHPLimit = prev_properties.BHPLimit;
-                    properties = WellProductionProperties::history( BHPLimit , record, m_phases);
+                    const double BHPLimit = prev_properties.BHPLimit;
+                    properties = WellProductionProperties::history( BHPLimit , record);
                 }
 
                 if (status != WellCommon::SHUT) {
-                        std::string cmodeString =
-                        record.getItem("CMODE").getTrimmedString(0);
-
-                    WellProducer::ControlModeEnum control =
-                        WellProducer::ControlModeFromString(cmodeString);
-
-
                     if ( m_controlModeWHISTCTL != WellProducer::CMODE_UNDEFINED &&
                          m_controlModeWHISTCTL != WellProducer::NONE && !isPredictionMode){
-                        control = m_controlModeWHISTCTL; // overwrite given control
-                        cmodeString = WellProducer::ControlMode2String(control); // update the string
-                    }
-
-                    if (properties.hasProductionControl(control)) {
-                        properties.controlMode = control;
-                    }
-                    else {
-                        std::string msg =
-                            "Tried to set invalid control: " +
-                            cmodeString + " for well: " + well->name();
-                        m_messages.error(keyword.getFileName(), msg, keyword.getLineNumber());
-                        throw std::invalid_argument(msg);
+                        if ( !properties.hasProductionControl(m_controlModeWHISTCTL) )
+                            properties.addProductionControl(m_controlModeWHISTCTL);
+                        properties.controlMode = m_controlModeWHISTCTL;
                     }
                 }
                 updateWellStatus( *well , currentStep , status );

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Schedule/WellProductionProperties.hpp
@@ -32,13 +32,17 @@ namespace Opm {
 
     class WellProductionProperties {
     public:
+        // the rates serve as limits under prediction mode
+        // while they are observed rates under historical mode
         double  OilRate     = 0.0;
         double  WaterRate   = 0.0;
         double  GasRate     = 0.0;
         double  LiquidRate  = 0.0;
         double  ResVRate    = 0.0;
+        // BHP and THP limit
         double  BHPLimit    = 0.0;
         double  THPLimit    = 0.0;
+        // historical BHP and THP under historical mode
         double  BHPH        = 0.0;
         double  THPH        = 0.0;
         int     VFPTableNumber = 0;
@@ -51,7 +55,7 @@ namespace Opm {
         bool operator!=(const WellProductionProperties& other) const;
         WellProductionProperties();
 
-        static WellProductionProperties history(double BHPLimit, const DeckRecord& record, const Phases &phases = Phases(true, true, true) );
+        static WellProductionProperties history(double BHPLimit, const DeckRecord& record);
         static WellProductionProperties prediction( const DeckRecord& record, bool addGroupProductionControl );
 
         bool hasProductionControl(WellProducer::ControlModeEnum controlModeArg) const {

--- a/lib/eclipse/tests/WellTests.cpp
+++ b/lib/eclipse/tests/WellTests.cpp
@@ -808,10 +808,10 @@ BOOST_AUTO_TEST_CASE(testWellNameInWellNamePattern) {
 
 namespace {
     namespace WCONHIST {
-        std::string all_specified_CMODE_BHP() {
+        std::string all_specified_CMODE_THP() {
             const std::string input =
                 "WCONHIST\n"
-                "'P' 'OPEN' 'BHP' 1 2 3/\n/\n";
+                "'P' 'OPEN' 'THP' 1 2 3/\n/\n";
 
             return input;
         }
@@ -903,18 +903,15 @@ BOOST_AUTO_TEST_CASE(WCH_All_Specified_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_specified());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
 
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::ORAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
@@ -922,17 +919,14 @@ BOOST_AUTO_TEST_CASE(WCH_ORAT_Defaulted_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::orat_defaulted());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::WRAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
@@ -940,17 +934,14 @@ BOOST_AUTO_TEST_CASE(WCH_OWRAT_Defaulted_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::owrat_defaulted());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::GRAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
@@ -958,17 +949,14 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Defaulted)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::RESV));
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::LRAT);
 
-    // BHP must be explicitly provided/specified
-    BOOST_CHECK(! p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
@@ -976,27 +964,21 @@ BOOST_AUTO_TEST_CASE(WCH_Rates_Defaulted_BHP_Specified)
     const Opm::WellProductionProperties& p =
         WCONHIST::properties(WCONHIST::all_defaulted_with_bhp());
 
-    // WCONHIST always supports {O,W,G}RAT, LRAT, and
-    // RESV--irrespective of actual specification.
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::ORAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::WRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::GRAT));
-    BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::LRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::ORAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::WRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::GRAT));
+    BOOST_CHECK( !p.hasProductionControl(Opm::WellProducer::LRAT));
     BOOST_CHECK(p.hasProductionControl(Opm::WellProducer::RESV));
 
     BOOST_CHECK_EQUAL(p.controlMode , Opm::WellProducer::RESV);
 
-    /*
-      BHP in WCONHIST is not an available control; just information
-      about the historical BHP.
-    */
-    BOOST_CHECK_EQUAL(false , p.hasProductionControl(Opm::WellProducer::BHP));
+    BOOST_CHECK_EQUAL(true, p.hasProductionControl(Opm::WellProducer::BHP));
 }
 
 
 BOOST_AUTO_TEST_CASE(BHP_CMODE)
 {
-    BOOST_CHECK_THROW( WCONHIST::properties(WCONHIST::all_specified_CMODE_BHP()) , std::invalid_argument);
+    BOOST_CHECK_THROW( WCONHIST::properties(WCONHIST::all_specified_CMODE_THP()) , std::invalid_argument);
     BOOST_CHECK_THROW( WCONPROD::properties(WCONPROD::all_specified_CMODE_BHP()) , std::invalid_argument);
 }
 

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -199,8 +199,8 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
             const WellProductionProperties& prop3 = well2->getProductionProperties(3);
             BOOST_CHECK_EQUAL( WellProducer::ORAT , prop3.controlMode);
             BOOST_CHECK(  prop3.hasProductionControl(WellProducer::ORAT));
-            BOOST_CHECK(  prop3.hasProductionControl(WellProducer::GRAT));
-            BOOST_CHECK(  prop3.hasProductionControl(WellProducer::WRAT));
+            BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::GRAT));
+            BOOST_CHECK(  !prop3.hasProductionControl(WellProducer::WRAT));
         }
 
         // BOOST_CHECK( !well2->getProductionProperties(8).hasProductionControl(WellProducer::GRAT));


### PR DESCRIPTION
This is the first part split from  https://github.com/OPM/opm-parser/pull/1168
We agreed to split that PR to make it easier to let it in, this is the first part. 

The major part is that for WCONHIST control production wells, they always have a BHP limit, and they can have another RATE limit instead of always having all the phase rate limits. 