### PR TITLE
adding keyword WSEGSICD

### DIFF
--- a/lib/eclipse/share/keywords/000_Eclipse100/W/WSEGSICD
+++ b/lib/eclipse/share/keywords/000_Eclipse100/W/WSEGSICD
@@ -1,0 +1,15 @@
+{"name" : "WSEGSICD" , "sections" : ["SCHEDULE"] , "items" : [
+   {"name" : "WELL" , "value_type" : "STRING"},
+   {"name" : "SEG1", "value_type" : "INT"},
+   {"name" : "SEG2", "value_type" : "INT"},
+   {"name" : "STRENGTH", "value_type" : "DOUBLE", "dimension" : "Pressure*Time*Time/Length*Length*Length*Length*Length*Length"},
+   {"name" : "LENGTH", "value_type" : "DOUBLE", "dimension" : "Length", "default" : 12.0},
+   {"name" : "DENSITY_CALI", "value_type" : "DOUBLE", "dimension" : "Density", "default" : 1000.25},
+   {"name" : "VISCOSITY_CALI", "value_type" : "DOUBLE", "dimension" : "Viscosity", "default" : 1.45},
+   {"name" : "CRITICAL_VALUE", "value_type" : "DOUBLE", "dimension" : "1", "default" : 0.5},
+   {"name" : "WIDTH_TRANS", "value_type" : "DOUBLE", "dimension" : "1", "default" : 0.05},
+   {"name" : "MAX_VISC_RATIO", "value_type" : "DOUBLE", "dimension" : "1", "default" : 5.0},
+   {"name" : "METHOD_SCALING_FACTOR", "value_type" : "INT", "default" : -1},
+   {"name" : "MAX_ABS_RATE", "value_type" : "DOUBLE", "dimension" : "Length*Length*Length/Time"},
+   {"name" : "STATUS", "value_type" : "STRING", "default" : "OPEN"}]}
+

--- a/lib/eclipse/share/keywords/keyword_list.cmake
+++ b/lib/eclipse/share/keywords/keyword_list.cmake
@@ -355,6 +355,7 @@ set( keywords
      000_Eclipse100/W/WELOPEN
      000_Eclipse100/W/WELPI
      000_Eclipse100/W/WELSEGS
+     000_Eclipse100/W/WSEGSICD
      000_Eclipse100/W/WELSPECS
      000_Eclipse100/W/WELTARG
      000_Eclipse100/W/WGASPROD


### PR DESCRIPTION
Adding the keywor WSEGSICD. 

The unit for the item 4 by definition is bar/(rm^3/day)^2 (METRIC), psi/(rft^3/day)^2 (FIELD)....

Since the `rft^3` is used for the FIELD unit system instead of `rb`, I use `Volume` for the `rm^3` and `rft^3` instead of `ReservoirVolume`. 

And also I have question about how to write this unit for the item 4. 

The confusion is from the definition of the keywords `COMPDAT`, the transmissibility factor unit is defined as `cP.rm^3 /day/bars` and the definition of the keyword is `Viscosity*ReservoirVolume/Time*Pressure`  instead of `Viscosity*ReservoirVolume/Time/Pressure`. It is something we have been using for almost all the cases and it has been working well, while some explanation is required here about the unit rule of the keyword definition. 
