### PR TITLE
WIP: Added ParseContext::IGNORE_EXTRA_RECORDS

### DIFF
--- a/lib/eclipse/Parser/ParseContext.cpp
+++ b/lib/eclipse/Parser/ParseContext.cpp
@@ -68,7 +68,7 @@ namespace Opm {
     }
 
     void ParseContext::initDefault() {
-        addKey(IGNORE_EXTRA_RECORDS);
+        addKey(PARSE_EXTRA_RECORDS);
         addKey(PARSE_UNKNOWN_KEYWORD);
         addKey(PARSE_RANDOM_TEXT);
         addKey(PARSE_RANDOM_SLASH);
@@ -244,7 +244,7 @@ namespace Opm {
         }
     }
 
-    const std::string ParseContext::IGNORE_EXTRA_RECORDS = "IGNORE_EXTRA_RECORDS";
+    const std::string ParseContext::PARSE_EXTRA_RECORDS = "PARSE_EXTRA_RECORDS";
     const std::string ParseContext::PARSE_UNKNOWN_KEYWORD = "PARSE_UNKNOWN_KEYWORD";
     const std::string ParseContext::PARSE_RANDOM_TEXT = "PARSE_RANDOM_TEXT";
     const std::string ParseContext::PARSE_RANDOM_SLASH = "PARSE_RANDOM_SLASH";

--- a/lib/eclipse/Parser/ParseContext.cpp
+++ b/lib/eclipse/Parser/ParseContext.cpp
@@ -68,6 +68,7 @@ namespace Opm {
     }
 
     void ParseContext::initDefault() {
+        addKey(IGNORE_EXTRA_RECORDS);
         addKey(PARSE_UNKNOWN_KEYWORD);
         addKey(PARSE_RANDOM_TEXT);
         addKey(PARSE_RANDOM_SLASH);
@@ -243,6 +244,7 @@ namespace Opm {
         }
     }
 
+    const std::string ParseContext::IGNORE_EXTRA_RECORDS = "IGNORE_EXTRA_RECORDS";
     const std::string ParseContext::PARSE_UNKNOWN_KEYWORD = "PARSE_UNKNOWN_KEYWORD";
     const std::string ParseContext::PARSE_RANDOM_TEXT = "PARSE_RANDOM_TEXT";
     const std::string ParseContext::PARSE_RANDOM_SLASH = "PARSE_RANDOM_SLASH";

--- a/lib/eclipse/Parser/Parser.cpp
+++ b/lib/eclipse/Parser/Parser.cpp
@@ -495,6 +495,7 @@ bool tryParseKeyword( ParserState& parserState, const Parser& parser ) {
         if( parserState.rawKeyword == NULL ) {
             if( RawKeyword::isKeywordPrefix( line, keywordString ) ) {
                 parserState.rawKeyword = createRawKeyword( keywordString, parserState, parser );
+                parserState.lastSizeType = SLASH_TERMINATED;
                 if ( parser.isRecognizedKeyword(line) ) {
                    const auto* parserKeyword = parser.getParserKeywordFromDeckName( line );
                    parserState.lastSizeType = parserKeyword->getSizeType();

--- a/lib/eclipse/Parser/Parser.cpp
+++ b/lib/eclipse/Parser/Parser.cpp
@@ -340,18 +340,20 @@ void ParserState::handleRandomText(const string_view& keywordString ) const {
     std::stringstream msg;
     std::string trimmedCopy = keywordString.string();
 
-    if (lastSizeType == OTHER_KEYWORD_IN_DECK) {
+
+    if (trimmedCopy == "/") {
+        errorKey = ParseContext::PARSE_RANDOM_SLASH;
+        msg << "Extra '/' detected at: "
+            << this->current_path()
+            << ":" << this->line();
+    }
+    else if (lastSizeType == OTHER_KEYWORD_IN_DECK) {
       errorKey = ParseContext::PARSE_EXTRA_RECORDS;
       msg << "Too many records in keyword: " 
           << lastKeyWord
           << ".\n";
     }
-    else if (trimmedCopy == "/") {
-        errorKey = ParseContext::PARSE_RANDOM_SLASH;
-        msg << "Extra '/' detected at: "
-            << this->current_path()
-            << ":" << this->line();
-    } else {
+    else {
         errorKey = ParseContext::PARSE_RANDOM_TEXT;
         msg << "String \'" << keywordString
             << "\' not formatted/recognized as valid keyword at: "

--- a/lib/eclipse/Parser/Parser.cpp
+++ b/lib/eclipse/Parser/Parser.cpp
@@ -229,7 +229,7 @@ class ParserState {
 
     public:
         std::shared_ptr< RawKeyword > rawKeyword;
-        ParserKeywordSizeEnum lastSizeType;
+        ParserKeywordSizeEnum lastSizeType = SLASH_TERMINATED;
         std::string lastKeyWord;
         
         string_view nextKeyword = emptystr;
@@ -495,7 +495,6 @@ bool tryParseKeyword( ParserState& parserState, const Parser& parser ) {
         if( parserState.rawKeyword == NULL ) {
             if( RawKeyword::isKeywordPrefix( line, keywordString ) ) {
                 parserState.rawKeyword = createRawKeyword( keywordString, parserState, parser );
-                parserState.lastSizeType = SLASH_TERMINATED;
                 if ( parser.isRecognizedKeyword(line) ) {
                    const auto* parserKeyword = parser.getParserKeywordFromDeckName( line );
                    parserState.lastSizeType = parserKeyword->getSizeType();

--- a/lib/eclipse/Parser/Parser.cpp
+++ b/lib/eclipse/Parser/Parser.cpp
@@ -230,6 +230,7 @@ class ParserState {
     public:
         std::shared_ptr< RawKeyword > rawKeyword;
         ParserKeywordSizeEnum lastSizeType;
+        std::string lastKeyWord;
         
         string_view nextKeyword = emptystr;
         Deck deck;
@@ -339,8 +340,12 @@ void ParserState::handleRandomText(const string_view& keywordString ) const {
     std::stringstream msg;
     std::string trimmedCopy = keywordString.string();
 
-    if (lastSizeType == OTHER_KEYWORD_IN_DECK)
-      errorKey = ParseContext::IGNORE_EXTRA_RECORDS;
+    if (lastSizeType == OTHER_KEYWORD_IN_DECK) {
+      errorKey = ParseContext::PARSE_EXTRA_RECORDS;
+      msg << "Too many records in keyword: " 
+          << lastKeyWord
+          << ".\n";
+    }
     else if (trimmedCopy == "/") {
         errorKey = ParseContext::PARSE_RANDOM_SLASH;
         msg << "Extra '/' detected at: "
@@ -491,6 +496,7 @@ bool tryParseKeyword( ParserState& parserState, const Parser& parser ) {
                 if ( parser.isRecognizedKeyword(line) ) {
                    const auto* parserKeyword = parser.getParserKeywordFromDeckName( line );
                    parserState.lastSizeType = parserKeyword->getSizeType();
+                   parserState.lastKeyWord = parserState.rawKeyword->getKeywordName();
                 }
             } else {
                 /* We are looking at some random gibberish?! */

--- a/lib/eclipse/Parser/Parser.cpp
+++ b/lib/eclipse/Parser/Parser.cpp
@@ -349,8 +349,13 @@ void ParserState::handleRandomText(const string_view& keywordString ) const {
     }
     else if (lastSizeType == OTHER_KEYWORD_IN_DECK) {
       errorKey = ParseContext::PARSE_EXTRA_RECORDS;
-      msg << "Too many records in keyword: " 
+      msg << "String: \'" 
+          << keywordString
+          << "\' invalid."
+          << "Too many records in keyword: " 
           << lastKeyWord
+          << " at: "
+          << this->line()
           << ".\n";
     }
     else {

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -100,6 +100,10 @@ namespace Opm {
         */
         void addKey(const std::string& key);
         /*
+          Add comment here.
+        */
+        const static std::string IGNORE_EXTRA_RECORDS;
+        /*
           The unknownKeyword field regulates how the parser should
           react when it encounters an unknwon keyword. Observe that
           'keyword' in this context means:

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -100,9 +100,23 @@ namespace Opm {
         */
         void addKey(const std::string& key);
         /*
-          Add comment here.
+          The PARSE_EXTRA_RECORDS field regulates how the parser 
+          responds to keywords whose size has been defined in the 
+          previous keyword. 
+          Example:
+          EQLDIMS
+            2  100  20  1  1  /
+          EQUIL\n
+           2469   382.4   1705.0  0.0    500    0.0     1     1      20 /
+           2469   382.4   1705.0  0.0    500    0.0     1     1      20 /
+           2470   382.4   1705.0  0.0    500    0.0     1     1      20 /
+          EQLDIMS's first entry is 2 and defines the record size of the 
+          EQUIL keyword. Since there are 3 records in EQUIL, this results 
+          in an error that needs to be handled by the parser. By default, 
+          an exception is thrown, or it may be specified in the 
+          PARSE_EXTRA_RECORDS field that this error is to be ignored. 
         */
-        const static std::string IGNORE_EXTRA_RECORDS;
+        const static std::string PARSE_EXTRA_RECORDS;
         /*
           The unknownKeyword field regulates how the parser should
           react when it encounters an unknwon keyword. Observe that

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -114,6 +114,33 @@ BOOST_AUTO_TEST_CASE(Handle_extra_records) {
 }
 
 
+BOOST_AUTO_TEST_CASE(Handle_extra_records_2) {
+    const char * deck_string = 
+         "EQLDIMS\n"
+         "  2  100  20  1  1  /\n"
+         "\n"
+         "EQUIL\n"
+         "  2469   382.4   1705.0  0.0    500    0.0     1     1      20 /\n"
+         "  2469   382.4   1705.0  0.0    500    0.0     1     1      20 /\n"
+         "GRID\n"
+         "DIMENS\n"
+          " 10 10 3 /\n"
+          " 5 3 2 /\n";
+
+    ParseContext parseContext;
+    Parser parser(false);
+    
+    parser.addKeyword<ParserKeywords::EQLDIMS>();
+    parser.addKeyword<ParserKeywords::EQUIL>();
+    parser.addKeyword<ParserKeywords::GRID>();
+    parser.addKeyword<ParserKeywords::DIMENS>();
+
+    parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::IGNORE );
+    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ), std::invalid_argument );
+    
+}
+
+
 BOOST_AUTO_TEST_CASE(TestUnkownKeyword_DATA) {
     const char * deck_string1 =
         "RUNSPEC\n"

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -105,11 +105,11 @@ BOOST_AUTO_TEST_CASE(Handle_extra_records) {
     parser.addKeyword<ParserKeywords::GRID>();
     BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ) , std::invalid_argument );
 
-    parseContext.update(ParseContext::IGNORE_EXTRA_RECORDS , InputError::IGNORE );
+    parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::IGNORE );
     parser.parseString( deck_string , parseContext );
     BOOST_CHECK( parser.hasKeyword( "GRID" ) );
 
-    parseContext.update(ParseContext::IGNORE_EXTRA_RECORDS , InputError::THROW_EXCEPTION );
+    parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::THROW_EXCEPTION );
     BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ) , std::invalid_argument);
 }
 

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -28,6 +28,7 @@
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/D.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/E.hpp>
+#include <opm/parser/eclipse/Parser/ParserKeywords/G.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/O.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/R.hpp>
 #include <opm/parser/eclipse/Parser/ParserKeywords/S.hpp>
@@ -82,6 +83,34 @@ BOOST_AUTO_TEST_CASE(TestUnkownKeyword) {
     parseContext.update(ParseContext::PARSE_UNKNOWN_KEYWORD , InputError::IGNORE );
     parseContext.update(ParseContext::PARSE_RANDOM_TEXT , InputError::IGNORE );
     BOOST_CHECK_NO_THROW( parser.parseString( deck2 , parseContext ) );
+}
+
+
+BOOST_AUTO_TEST_CASE(Handle_extra_records) {
+    const char * deck_string = 
+         "EQLDIMS\n"
+         "  2  100  20  1  1  /\n"
+         "\n"
+         "EQUIL\n"
+         "  2469   382.4   1705.0  0.0    500    0.0     1     1      20 /\n"
+         "  2469   382.4   1705.0  0.0    500    0.0     1     1      20 /\n"
+         "  2470   382.4   1705.0  0.0    500    0.0     1     1      20 /\n"
+         "GRID\n";
+
+    ParseContext parseContext;
+    Parser parser(false);
+    
+    parser.addKeyword<ParserKeywords::EQLDIMS>();
+    parser.addKeyword<ParserKeywords::EQUIL>();
+    parser.addKeyword<ParserKeywords::GRID>();
+    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ) , std::invalid_argument );
+
+    parseContext.update(ParseContext::IGNORE_EXTRA_RECORDS , InputError::IGNORE );
+    parser.parseString( deck_string , parseContext );
+    BOOST_CHECK( parser.hasKeyword( "GRID" ) );
+
+    parseContext.update(ParseContext::IGNORE_EXTRA_RECORDS , InputError::THROW_EXCEPTION );
+    BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ) , std::invalid_argument);
 }
 
 

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -137,7 +137,6 @@ BOOST_AUTO_TEST_CASE(Handle_extra_records_2) {
 
     parseContext.update(ParseContext::PARSE_EXTRA_RECORDS , InputError::IGNORE );
     BOOST_CHECK_THROW( parser.parseString( deck_string , parseContext ), std::invalid_argument );
-    
 }
 
 


### PR DESCRIPTION
Adding a new keyword for handling reading of eclipse .DATA files. 
When reading a keyword whose length was specified in the previous keyword, an exception is thrown if there are more records than expected. 

With the new PARSE_EXTRA_RECORDS field, these extra records can be ignored. 