### PR TITLE
Default box

### DIFF
--- a/lib/eclipse/CMakeLists.txt
+++ b/lib/eclipse/CMakeLists.txt
@@ -67,6 +67,7 @@ set(opmparser_SOURCES Deck/Deck.cpp
                       EclipseState/Grid/NNC.cpp
                       EclipseState/Grid/PinchMode.cpp
                       EclipseState/Grid/SatfuncPropertyInitializers.cpp
+                      EclipseState/Grid/setKeywordBox.cpp
                       EclipseState/Grid/TransMult.cpp
                       EclipseState/InitConfig/Equil.cpp
                       EclipseState/InitConfig/InitConfig.cpp

--- a/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
+++ b/lib/eclipse/EclipseState/Eclipse3DProperties.cpp
@@ -33,6 +33,8 @@
 #include <opm/parser/eclipse/EclipseState/Tables/TableManager.hpp>
 #include <opm/parser/eclipse/Utility/String.hpp>
 
+#include "Grid/setKeywordBox.hpp"
+
 namespace Opm {
 
     namespace {
@@ -931,48 +933,4 @@ namespace Opm {
         return messages;
     }
 
-
-    void Eclipse3DProperties::setKeywordBox( const DeckKeyword& deckKeyword,
-                                           const DeckRecord& deckRecord,
-                                           BoxManager& boxManager) {
-        const auto& I1Item = deckRecord.getItem("I1");
-        const auto& I2Item = deckRecord.getItem("I2");
-        const auto& J1Item = deckRecord.getItem("J1");
-        const auto& J2Item = deckRecord.getItem("J2");
-        const auto& K1Item = deckRecord.getItem("K1");
-        const auto& K2Item = deckRecord.getItem("K2");
-
-        size_t setCount = 0;
-
-        if (!I1Item.defaultApplied(0))
-            setCount++;
-
-        if (!I2Item.defaultApplied(0))
-            setCount++;
-
-        if (!J1Item.defaultApplied(0))
-            setCount++;
-
-        if (!J2Item.defaultApplied(0))
-            setCount++;
-
-        if (!K1Item.defaultApplied(0))
-            setCount++;
-
-        if (!K2Item.defaultApplied(0))
-            setCount++;
-
-        if (setCount == 6) {
-            boxManager.setKeywordBox( I1Item.get< int >(0) - 1,
-                                      I2Item.get< int >(0) - 1,
-                                      J1Item.get< int >(0) - 1,
-                                      J2Item.get< int >(0) - 1,
-                                      K1Item.get< int >(0) - 1,
-                                      K2Item.get< int >(0) - 1);
-        } else if (setCount != 0) {
-            std::string msg = "BOX modifiers on keywords must be either "
-                "specified completely or not at all. Ignoring.";
-            m_intGridProperties.getMessageContainer().error(deckKeyword.getFileName() + std::to_string(deckKeyword.getLineNumber()) + msg);
-        }
-    }
 }

--- a/lib/eclipse/EclipseState/Grid/Box.cpp
+++ b/lib/eclipse/EclipseState/Grid/Box.cpp
@@ -21,6 +21,22 @@
 
 #include <opm/parser/eclipse/EclipseState/Grid/Box.hpp>
 
+namespace {
+
+    void assert_dims(int len,  int l1 , int l2) {
+        if (len <= 0)
+            throw std::invalid_argument("Box must have finite size in all directions");
+
+        if ((l1 < 0) || (l2 < 0) || (l1 > l2))
+            throw std::invalid_argument("Invalid index values for sub box");
+
+        if (l2 >= len)
+            throw std::invalid_argument("Invalid index values for sub box");
+    }
+
+
+}
+
 namespace Opm {
 
     Box::Box(int nx , int ny , int nz) {
@@ -50,10 +66,10 @@ namespace Opm {
     }
 
 
-    Box::Box(const Box& globalBox , int i1 , int i2 , int j1 , int j2 , int k1 , int k2) {
-        assertDims(globalBox , 0 , i1 , i2);
-        assertDims(globalBox , 1 , j1 , j2);
-        assertDims(globalBox , 2 , k1 , k2);
+    Box::Box(int nx, int ny, int nz, int i1 , int i2 , int j1 , int j2 , int k1 , int k2) {
+        assert_dims(nx , i1 , i2);
+        assert_dims(ny , j1 , j2);
+        assert_dims(nz , k1 , k2);
 
         m_dims[0] = (size_t) (i2 - i1 + 1);
         m_dims[1] = (size_t) (j2 - j1 + 1);
@@ -64,10 +80,10 @@ namespace Opm {
         m_offset[2] = (size_t) k1;
 
         m_stride[0] = 1;
-        m_stride[1] = globalBox.getDim(0);
-        m_stride[2] = globalBox.getDim(0) * globalBox.getDim(1);
+        m_stride[1] = nx;
+        m_stride[2] = nx*ny;
 
-        if (size() == globalBox.size())
+        if (size() == nx*ny*nz) 
             m_isGlobal = true;
         else
             m_isGlobal = false;
@@ -76,13 +92,10 @@ namespace Opm {
     }
 
 
-    void Box::assertDims(const Box& globalBox, size_t idim , int l1 , int l2) {
-        if ((l1 < 0) || (l2 < 0) || (l1 > l2))
-            throw std::invalid_argument("Invalid index values for sub box");
+    Box::Box(const Box& globalBox , int i1 , int i2 , int j1 , int j2 , int k1 , int k2) :
+        Box(globalBox.getDim(0), globalBox.getDim(1), globalBox.getDim(2), i1,i2,j1,j2,k1,k2)
+    { }
 
-        if ((size_t) l2 >= globalBox.getDim(idim))
-            throw std::invalid_argument("Invalid index values for sub box");
-    }
 
 
     size_t Box::size() const {

--- a/lib/eclipse/EclipseState/Grid/Box.cpp
+++ b/lib/eclipse/EclipseState/Grid/Box.cpp
@@ -177,5 +177,37 @@ namespace Opm {
         return this->size() != 0;
     }
 
-}
 
+    int Box::lower(int dim) const {
+        return m_offset[dim];
+    }
+
+    int Box::upper(int dim) const {
+        return m_offset[dim] + m_dims[dim] - 1;
+    }
+
+    int Box::I1() const {
+        return lower(0);
+    }
+
+    int Box::I2() const {
+        return upper(0);
+    }
+
+    int Box::J1() const {
+        return lower(1);
+    }
+
+    int Box::J2() const {
+        return upper(1);
+    }
+
+    int Box::K1() const {
+        return lower(2);
+    }
+
+    int Box::K2() const {
+        return upper(2);
+    }
+
+}

--- a/lib/eclipse/EclipseState/Grid/GridProperties.cpp
+++ b/lib/eclipse/EclipseState/Grid/GridProperties.cpp
@@ -112,49 +112,6 @@ namespace Opm {
 
 
 
-    void setKeywordBox( const DeckRecord& deckRecord,
-                        BoxManager& boxManager) {
-        const auto& I1Item = deckRecord.getItem("I1");
-        const auto& I2Item = deckRecord.getItem("I2");
-        const auto& J1Item = deckRecord.getItem("J1");
-        const auto& J2Item = deckRecord.getItem("J2");
-        const auto& K1Item = deckRecord.getItem("K1");
-        const auto& K2Item = deckRecord.getItem("K2");
-
-        size_t setCount = 0;
-
-        if (!I1Item.defaultApplied(0))
-            setCount++;
-
-        if (!I2Item.defaultApplied(0))
-            setCount++;
-
-        if (!J1Item.defaultApplied(0))
-            setCount++;
-
-        if (!J2Item.defaultApplied(0))
-            setCount++;
-
-        if (!K1Item.defaultApplied(0))
-            setCount++;
-
-        if (!K2Item.defaultApplied(0))
-            setCount++;
-
-        if (setCount == 6) {
-            boxManager.setKeywordBox( I1Item.get< int >(0) - 1,
-                                      I2Item.get< int >(0) - 1,
-                                      J1Item.get< int >(0) - 1,
-                                      J2Item.get< int >(0) - 1,
-                                      K1Item.get< int >(0) - 1,
-                                      K2Item.get< int >(0) - 1);
-        } else if (setCount != 0) {
-            std::string msg = "BOX modifiers on keywords must be either "
-                "specified completely or not at all. Ignoring.";
-            throw std::invalid_argument( msg );
-        }
-    }
-
     template< typename T >
     const MessageContainer& GridProperties<T>::getMessageContainer() const {
         return m_messages;

--- a/lib/eclipse/EclipseState/Grid/setKeywordBox.cpp
+++ b/lib/eclipse/EclipseState/Grid/setKeywordBox.cpp
@@ -1,0 +1,43 @@
+/*
+   Copyright 2016 Statoil ASA.
+
+   This file is part of the Open Porous Media project (OPM).
+
+   OPM is free software: you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation, either version 3 of the License, or
+   (at your option) any later version.
+
+   OPM is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "setKeywordBox.hpp"
+namespace Opm {
+
+    void setKeywordBox( const DeckRecord& deckRecord,
+                        BoxManager& boxManager) {
+        const auto& I1Item = deckRecord.getItem("I1");
+        const auto& I2Item = deckRecord.getItem("I2");
+        const auto& J1Item = deckRecord.getItem("J1");
+        const auto& J2Item = deckRecord.getItem("J2");
+        const auto& K1Item = deckRecord.getItem("K1");
+        const auto& K2Item = deckRecord.getItem("K2");
+
+        const auto& active_box = boxManager.getActiveBox();
+
+        const int i1 = I1Item.hasValue(0) ? I1Item.get<int>(0) - 1 : active_box.I1();
+        const int i2 = I2Item.hasValue(0) ? I2Item.get<int>(0) - 1 : active_box.I2();
+        const int j1 = J1Item.hasValue(0) ? J1Item.get<int>(0) - 1 : active_box.J1();
+        const int j2 = J2Item.hasValue(0) ? J2Item.get<int>(0) - 1 : active_box.J2();
+        const int k1 = K1Item.hasValue(0) ? K1Item.get<int>(0) - 1 : active_box.K1();
+        const int k2 = K2Item.hasValue(0) ? K2Item.get<int>(0) - 1 : active_box.K2();
+
+        boxManager.setKeywordBox( i1,i2,j1,j2,k1,k2 );
+    }
+}

--- a/lib/eclipse/EclipseState/Grid/setKeywordBox.hpp
+++ b/lib/eclipse/EclipseState/Grid/setKeywordBox.hpp
@@ -1,0 +1,31 @@
+/*
+  Copyright 2016 Statoil ASA.
+
+  This file is part of the Open Porous Media project (OPM).
+
+  OPM is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  OPM is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef SET_KEYWORDBOX_HPP
+#define SET_KEYWORDBOX_HPP
+
+#include <opm/parser/eclipse/Deck/DeckRecord.hpp>
+#include <opm/parser/eclipse/EclipseState/Grid/BoxManager.hpp>
+
+namespace Opm {
+
+void setKeywordBox( const DeckRecord& deckRecord,BoxManager& boxManager);
+
+}
+#endif

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Eclipse3DProperties.hpp
@@ -92,8 +92,6 @@ namespace Opm {
         void loadGridPropertyFromDeckKeyword(const Box& inputBox,
                                              const DeckKeyword& deckKeyword);
 
-        void setKeywordBox(const DeckKeyword& deckKeyword, const DeckRecord&, BoxManager& boxManager);
-
         std::string            m_defaultRegion;
         UnitSystem             m_deckUnitSystem;
         GridProperties<int>    m_intGridProperties;

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/Box.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/Box.hpp
@@ -31,6 +31,7 @@ namespace Opm {
         Box() = default;
         Box(int nx , int ny , int nz);
         Box(const Box& globalBox , int i1 , int i2 , int j1 , int j2 , int k1 , int k2); // Zero offset coordinates.
+        Box(int nx, int ny, int nz, int i1 , int i2 , int j1 , int j2 , int k1 , int k2);
         size_t size() const;
         bool   isGlobal() const;
         size_t getDim(size_t idim) const;
@@ -43,7 +44,6 @@ namespace Opm {
 
     private:
         void initIndexList();
-        static void assertDims(const Box& globalBox, size_t idim , int l1 , int l2);
         size_t m_dims[3] = { 0, 0, 0 };
         size_t m_offset[3];
         size_t m_stride[3];

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/Box.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Grid/Box.hpp
@@ -42,6 +42,14 @@ namespace Opm {
         std::vector<size_t>::const_iterator begin() const;
         std::vector<size_t>::const_iterator end() const;
 
+
+        int I1() const;
+        int I2() const;
+        int J1() const;
+        int J2() const;
+        int K1() const;
+        int K2() const;
+
     private:
         void initIndexList();
         size_t m_dims[3] = { 0, 0, 0 };
@@ -50,6 +58,9 @@ namespace Opm {
 
         bool   m_isGlobal;
         std::vector<size_t> m_indexList;
+
+        int lower(int dim) const;
+        int upper(int dim) const;
     };
 }
 

--- a/lib/eclipse/tests/BoxTests.cpp
+++ b/lib/eclipse/tests/BoxTests.cpp
@@ -172,3 +172,20 @@ BOOST_AUTO_TEST_CASE(TestKeywordBox) {
     BOOST_CHECK( !boxManager.getInputBox() );
     BOOST_CHECK( boxManager.getActiveBox().equal( boxManager.getGlobalBox()));
 }
+
+
+BOOST_AUTO_TEST_CASE(BoxNineArg) {
+    const size_t nx = 10;
+    const size_t ny = 7;
+    const size_t nz = 6;
+    BOOST_CHECK_NO_THROW( Opm::Box(nx,ny,nz,0,7,0,5,1,2) );
+
+    // Invalid x dimension
+    BOOST_CHECK_THROW( Opm::Box(0,ny,nz,0,0,1,1,2,2), std::invalid_argument);
+
+    // J2 < J1
+    BOOST_CHECK_THROW( Opm::Box(nx,ny,nz,1,1,4,3,2,2), std::invalid_argument);
+
+    // K2 >= Nz
+    BOOST_CHECK_THROW( Opm::Box(nx,ny,nz,1,1,2,2,3,nz), std::invalid_argument);
+}

--- a/lib/eclipse/tests/Eclipse3DPropertiesTests.cpp
+++ b/lib/eclipse/tests/Eclipse3DPropertiesTests.cpp
@@ -476,3 +476,86 @@ BOOST_AUTO_TEST_CASE(TEMPI_TEST) {
     Setup s(createDeck());
     BOOST_CHECK_NO_THROW( s.props.getDoubleGridProperty("TEMPI") );
 }
+
+
+static Opm::Deck createMultiplyDeck() {
+    const auto* input = R"(
+RUNSPEC
+
+TITLE
+ 'TITTEL'
+
+DIMENS
+  100 21 20 /
+
+METRIC
+
+OIL
+WATER
+
+TABDIMS
+/
+
+START
+  19 JUN 2017
+/
+
+WELLDIMS
+  3 20 1
+/
+
+EQLDIMS
+    2* 100 2* /
+
+GRID
+
+
+DXV
+  5.0D0 10.0D0 2*20.0D0 45.0D0 95*50.0D0
+/
+
+DYV
+  21*4.285714D0
+/
+
+DZV
+  20*0.5D0
+/
+
+TOPS
+  2100*1000.0D0
+/
+
+
+PERMX
+  42000*100.0D0
+/
+
+
+COPY
+  'PERMX' 'PERMZ' /
+  'PERMX' 'PERMY' /
+/
+
+MULTIPLY
+  'PERMZ' 0.1D0 /
+  'PERMX' 0.1D0 *  *  1  21  *  1 / -- This is a weird way to specify the top layer! 
+/
+)";
+
+    Opm::Parser parser;
+    return parser.parseString(input, Opm::ParseContext() );
+}
+
+
+
+
+BOOST_AUTO_TEST_CASE(DefaultedBox) {
+  const Setup s(createMultiplyDeck());
+
+  const auto& permx   = s.props.getDoubleGridProperty("PERMX");
+  const auto& permz   = s.props.getDoubleGridProperty("PERMZ");
+
+  BOOST_CHECK_EQUAL( permx.iget(0,0,0)        , permz.iget(0,0,0));
+  BOOST_CHECK_EQUAL( permx.iget(0,0,1) * 0.10 , permz.iget(0,0,1));
+}


### PR DESCRIPTION
Allow the use use of defaults in the operational keywords like `ADD` and `MULTIPLY`:

This now works:

```
MULTIPLY
   'PERMX' 0.25 * * * * 4 4 /
/
```
to multiply `PERMX`in layer 4 - previously '*' could not be used.