### PR TITLE
rename c_p to c_v in specrock and specheat table classes

### DIFF
--- a/lib/eclipse/EclipseState/Tables/Tables.cpp
+++ b/lib/eclipse/EclipseState/Tables/Tables.cpp
@@ -108,9 +108,9 @@ PvtoTable::PvtoTable( const DeckKeyword& keyword, size_t tableIdx) :
 SpecheatTable::SpecheatTable(const DeckItem& item)
 {
     m_schema.addColumn(ColumnSchema("TEMPERATURE", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
-    m_schema.addColumn(ColumnSchema("CP_OIL", Table::RANDOM, Table::DEFAULT_LINEAR));
-    m_schema.addColumn(ColumnSchema("CP_WATER", Table::RANDOM, Table::DEFAULT_LINEAR));
-    m_schema.addColumn(ColumnSchema("CP_GAS", Table::RANDOM, Table::DEFAULT_LINEAR));
+    m_schema.addColumn(ColumnSchema("CV_OIL", Table::RANDOM, Table::DEFAULT_LINEAR));
+    m_schema.addColumn(ColumnSchema("CV_WATER", Table::RANDOM, Table::DEFAULT_LINEAR));
+    m_schema.addColumn(ColumnSchema("CV_GAS", Table::RANDOM, Table::DEFAULT_LINEAR));
 
     SimpleTable::init(item);
 }
@@ -118,19 +118,19 @@ SpecheatTable::SpecheatTable(const DeckItem& item)
 const TableColumn& SpecheatTable::getTemperatureColumn() const
 { return SimpleTable::getColumn(0); }
 
-const TableColumn& SpecheatTable::getCpOilColumn() const
+const TableColumn& SpecheatTable::getCvOilColumn() const
 { return SimpleTable::getColumn(1); }
 
-const TableColumn& SpecheatTable::getCpWaterColumn() const
+const TableColumn& SpecheatTable::getCvWaterColumn() const
 { return SimpleTable::getColumn(2); }
 
-const TableColumn& SpecheatTable::getCpGasColumn() const
+const TableColumn& SpecheatTable::getCvGasColumn() const
 { return SimpleTable::getColumn(3); }
 
 SpecrockTable::SpecrockTable(const DeckItem& item)
 {
     m_schema.addColumn(ColumnSchema("TEMPERATURE", Table::STRICTLY_INCREASING, Table::DEFAULT_NONE));
-    m_schema.addColumn(ColumnSchema("CP_ROCK", Table::RANDOM, Table::DEFAULT_LINEAR));
+    m_schema.addColumn(ColumnSchema("CV_ROCK", Table::RANDOM, Table::DEFAULT_LINEAR));
 
     SimpleTable::init(item);
 }
@@ -138,7 +138,7 @@ SpecrockTable::SpecrockTable(const DeckItem& item)
 const TableColumn& SpecrockTable::getTemperatureColumn() const
 { return SimpleTable::getColumn(0); }
 
-const TableColumn& SpecrockTable::getCpRockColumn() const
+const TableColumn& SpecrockTable::getCvRockColumn() const
 { return SimpleTable::getColumn(1); }
 
 SwofTable::SwofTable( const DeckItem& item , const bool jfunc) {

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SpecheatTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SpecheatTable.hpp
@@ -31,9 +31,9 @@ namespace Opm {
         SpecheatTable(const DeckItem& item);
 
         const TableColumn& getTemperatureColumn() const;
-        const TableColumn& getCpOilColumn() const;
-        const TableColumn& getCpWaterColumn() const;
-        const TableColumn& getCpGasColumn() const;
+        const TableColumn& getCvOilColumn() const;
+        const TableColumn& getCvWaterColumn() const;
+        const TableColumn& getCvGasColumn() const;
     };
 }
 

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SpecrockTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SpecrockTable.hpp
@@ -30,7 +30,7 @@ namespace Opm {
         SpecrockTable(const DeckItem& item);
 
         const TableColumn& getTemperatureColumn() const;
-        const TableColumn& getCpRockColumn() const;
+        const TableColumn& getCvRockColumn() const;
     };
 }
 


### PR DESCRIPTION
even though the official documentation does not seem to specify whether the specified heat capacities of the SPECROCK and SPECHEAT keywords are for constant pressure or for constant volume, the implicitly seem to be for the latter: pressure dependent heat capacites cannot be specified, yet the enthalpy for an incompressible fluid *is* pressure dependent, so the specified heat capacities must be for constant volume and they specify the internal energy instead of the enthalpy.

this requires some downstream mop-up in opm-material. permission to merge the downstream PR with this one is hereby granted.