### PR TITLE
respect the fact that non-SI temperature may be offset from zero

### DIFF
--- a/lib/eclipse/include/opm/parser/eclipse/Units/UnitSystem.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Units/UnitSystem.hpp
@@ -104,6 +104,7 @@ namespace Opm {
         std::string m_name;
         UnitType m_unittype;
         std::map< std::string , Dimension > m_dimensions;
+        const double* measure_table_to_si_offset;
         const double* measure_table_from_si;
         const double* measure_table_to_si;
         const char* const*  unit_name_table;

--- a/lib/eclipse/include/opm/parser/eclipse/Units/Units.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Units/Units.hpp
@@ -166,8 +166,8 @@ namespace Opm {
         constexpr const double degCelsius = 1.0; // scaling factor °C -> K
         constexpr const double degCelsiusOffset = 273.15; // offset for the °C -> K conversion
 
-        constexpr const double degFahrenheit = 5.0/9; // scaling factor °F -> K
-        constexpr const double degFahrenheitOffset = 459.67*5.0/9.0; // °F -> K offset (i.e. what's 0 °F?)
+        constexpr const double degFahrenheit = 5.0/9.0; // factor to convert a difference in °F to a difference in K
+        constexpr const double degFahrenheitOffset = 459.67*degFahrenheit; // °F -> K offset (i.e. how many K is 0 °F?)
         /// @}
 
         /// \name Viscosity

--- a/lib/eclipse/include/opm/parser/eclipse/Units/Units.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Units/Units.hpp
@@ -167,7 +167,7 @@ namespace Opm {
         constexpr const double degCelsiusOffset = 273.15; // offset for the °C -> K conversion
 
         constexpr const double degFahrenheit = 5.0/9; // scaling factor °F -> K
-        constexpr const double degFahrenheitOffset = 255.37; // offset for the °C -> K conversion
+        constexpr const double degFahrenheitOffset = 459.67*5.0/9.0; // °F -> K offset (i.e. what's 0 °F?)
         /// @}
 
         /// \name Viscosity

--- a/lib/eclipse/tests/UnitTests.cpp
+++ b/lib/eclipse/tests/UnitTests.cpp
@@ -301,7 +301,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::density , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::pressure , 1.0 ) , 101325.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::temperature_absolute , 1.0 ) , 1.0 , 1.0e-10 );
-    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::temperature , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::temperature , 1.0 ) , 274.15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::viscosity , 1.0 ) , 1.0e-3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::permeability , 1.0 ) , 9.869232667160129e-16 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.to_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
@@ -330,7 +330,7 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::density , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::pressure , 1.0 ) , 9.869232667160129e-06 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::temperature_absolute , 1.0 ) , 1.0 , 1.0e-10 );
-    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::temperature , 1.0 ) , 1.0 , 1.0e-10 );
+    BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::temperature , 274.15 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::viscosity , 1.0 ) , 1.0e+3 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::permeability , 1.0 ) , 1.01325e+15 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::liquid_surface_volume , 1.0 ) , 1.0 , 1.0e-10 );
@@ -350,4 +350,35 @@ BOOST_AUTO_TEST_CASE(PVT_M_UNITS)
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::gas_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::oil_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
     BOOST_CHECK_CLOSE( pvt_m.from_si( Meas::water_inverse_formation_volume_factor , 1.0 ) , 1.0 , 1.0e-10 );
+}
+
+BOOST_AUTO_TEST_CASE(TemperatureConversions)
+{
+    using Meas = UnitSystem::measure;
+
+    // note that "metric" units are not SI units!
+    auto metric = UnitSystem::newMETRIC();
+    auto pvt_m = UnitSystem::newPVT_M();
+    auto lab = UnitSystem::newLAB();
+    auto field = UnitSystem::newFIELD();
+
+    // check absolute temperature, i.e. °R for field, K for the rest
+    BOOST_CHECK_CLOSE(metric.to_si(Meas::temperature_absolute , 1.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(metric.from_si(Meas::temperature_absolute , 1.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvt_m.to_si(Meas::temperature_absolute , 1.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvt_m.from_si(Meas::temperature_absolute , 1.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(lab.to_si(Meas::temperature_absolute , 1.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(lab.from_si(Meas::temperature_absolute , 1.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(field.to_si(Meas::temperature_absolute , 9.0/5.0), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(field.from_si(Meas::temperature_absolute , 1.0), 9.0/5.0, 1.0e-10);
+
+    // check temperature, i.e. °F for field, °C for the rest
+    BOOST_CHECK_CLOSE(metric.to_si(Meas::temperature , 1.0), 274.15, 1.0e-10);
+    BOOST_CHECK_CLOSE(metric.from_si(Meas::temperature , 274.15), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvt_m.to_si(Meas::temperature , 1.0), 274.15, 1.0e-10);
+    BOOST_CHECK_CLOSE(pvt_m.from_si(Meas::temperature , 274.15), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(lab.to_si(Meas::temperature , 1.0), 274.15, 1.0e-10);
+    BOOST_CHECK_CLOSE(lab.from_si(Meas::temperature , 274.15), 1.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(field.to_si(Meas::temperature , 1.0), (459.67 + 1.0)*5.0/9.0, 1.0e-10);
+    BOOST_CHECK_CLOSE(field.from_si(Meas::temperature , (459.67 + 1.0)*5.0/9.0), 1.0, 1.0e-10);
 }


### PR DESCRIPTION
this is another attempt for fixing the "measure" temperature conversion stuff after #1203 without causing a trainwreck.

I did not find any substantial mistakes in #1203, so maybe some downstream code tries to work around the missing offset and thus creates a wrong result (then the downstream code needs to be fixed), maybe the reference data needs to be updated, or both. Anyway, temperature conversion is now much more thoroughly tested...