### PR TITLE
not turning off injector because of defaulted rates.

### DIFF
--- a/lib/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -634,7 +634,11 @@ namespace Opm {
                 if (well->setInjectionProperties(currentStep, properties))
                     m_events.addEvent( ScheduleEvents::INJECTION_UPDATE , currentStep );
 
-                if ( ! well->getAllowCrossFlow() && (properties.surfaceInjectionRate == 0) ) {
+                // if the well has zero surface rate limit or reservior rate limit, while does not allow crossflow,
+                // it should be turned off.
+                if ( ! well->getAllowCrossFlow()
+                     && ( (properties.hasInjectionControl(WellInjector::RATE) && properties.surfaceInjectionRate == 0)
+                       || (properties.hasInjectionControl(WellInjector::RESV) && properties.reservoirInjectionRate == 0) ) ) {
                     std::string msg =
                             "Well " + well->name() + " is an injector with zero rate where crossflow is banned. " +
                             "This well will be closed at " + std::to_string ( m_timeMap.getTimePassedUntil(currentStep) / (60*60*24) ) + " days";

--- a/lib/eclipse/tests/data/integration_tests/SCHEDULE/SCHEDULE_WELLS2
+++ b/lib/eclipse/tests/data/integration_tests/SCHEDULE/SCHEDULE_WELLS2
@@ -1,16 +1,20 @@
 SCHEDULE
 
-DATES             -- 1
+-- 0
+DATES
   10  'JUN'  2007 /
 /
 
 
-DATES             -- 2,3
+-- 1
+DATES
    10  JLY 2007 /
+-- 2
    10  AUG 2007 /
-/      
+/
 
-WELSPECS 
+-- 3
+WELSPECS
      'W_1'        'OP'   30   37  1*       'OIL'  3*  'NO'/   Crap1
 -- the spaces around the phase name are intentional!
      'W_2'        'OP'   20   51  100       ' OIL '  7* /   Crap2   Crap3
@@ -24,8 +28,8 @@ WRFTPLT
    'W_2'       'REPT'        'NO'        'NO' /
 /
 
-COMPDAT 
--- WELL        I    J    K1  K2            Sat.        CF       DIAM        KH SKIN ND        DIR   Ro 
+COMPDAT
+-- WELL        I    J    K1  K2            Sat.        CF       DIAM        KH SKIN ND        DIR   Ro
      'W_1'   30   37    1    3      'OPEN'  1*     32.948      0.311   3047.839  2*         'X'     22.100 /
 -- the spaces around the direction indicator are intentional!
      'W_1'   31   37   14   14      'OPEN'  1*     19.731      0.311   1831.202  3.3 1*         '  X    '     22.463 /
@@ -40,7 +44,7 @@ COMPDAT
 
 
 
-WCONHIST 
+WCONHIST
 -- the spaces around the names indicator are intentional!
 -- they test that even padded quoted literals as arguments to WCONHIST and
 -- friends are stripped correctly
@@ -50,105 +54,113 @@ WCONHIST
 /
 
 
-TSTEP             -- 4
+TSTEP
   10   /
 
-TSTEP             -- 5
+-- 4
+TSTEP
   10   /
 
+-- 5
 WRFTPLT
    'W_2'       'NO'        'NO'        'NO' /
 /
 
-
-TSTEP             -- 6
+TSTEP
   10   /
 
 
 
- 
-
-WCONHIST 
+-- 6
+WCONHIST
      'W_1'      'OPEN'      'ORAT'   14000.000      4.000 1.46402E+006  5* /
      'W_2'      'OPEN'      'ORAT'   17998.000      2.000 1461075.000  5* /
      'W_3'      'OPEN'      'ORAT'   17999.000      1.000 1471824.000  5* /
 /
 
 
-TSTEP             - 7 
+TSTEP
   3  /
 
 
+-- 7
 COMPDAT
      'W_1'   31   37   14   14      'SHUT'  1*     19.731      0.311   1831.202  2*         'X'     22.463 /
 /
 
 
-WCONPROD 
+WCONPROD
      'W_1'      'OPEN'      'ORAT'   11000.000      44.000 188  5* /
      'W_2'      'OPEN'      'RESV'   17998.000      2.000 1461075.000   *  777 3* /
      'W_3'      'OPEN'      'RESV'   17999.000      1.000 1471824.000  999 999 4* /
 /
 
-TSTEP              -- 8
+TSTEP
  4 /
 
-WCONHIST 
+-- 8
+WCONHIST
      'W_1'      'OPEN'      'ORAT'   13000.000      4.000 1.46402E+006  5* /
      'W_2'      'OPEN'      'ORAT'   17998.000      2.000 6* /
      'W_3'      'OPEN'      'ORAT'   17999.000      1.000 1471824.000   5* /
 /
 
-DATES              -- 9
+DATES
    10  JLY 2008 /
-/      
+/
 
-WCONINJE 
+-- 9
+WCONINJE
      'W_1'     'WATER'  1*      'RESV'  20000.000  200000.000 5* /
 /
 
-DATES              -- 10
+DATES
    10  AUG 2008 /
-/      
+/
 
-WCONINJE 
+-- 10
+WCONINJE
      'W_1'     'WATER'  1*      'RATE'  20000.000  200000.000 123 678 4* /
 /
 
-DATES              -- 11
+DATES
    15  AUG 2008 /
-/      
+/
 
 
+-- 11
 WCONINJH
      'W_1'     'WATER'  1*      5000.000   50000.000 /
 /
 
 
-DATES              -- 12
+DATES
    10  SEP 2008 /
-/      
+/
 
-WCONINJE 
+-- 12
+WCONINJE
      'W_1'     'WATER'  'OPEN'      'RATE'  20000.000  * 123 678 4* /
 /
 
-DATES              -- 13
+DATES
    10  OCT 2008 /
 /
 
+-- 13
 WCONINJE
      'W_1'     'WATER'  'OPEN'      'RATE'  0.000  * 123 678 4* /
 /
 
-DATES              -- 14
+DATES
    10  NOV 2008 /
 /
 
+-- 14
 WCONINJE
      'W_1'     'WATER'  'OPEN'      'BHP'  2*  100 /
 /
 
-DATES              -- 15
+DATES
    10  DEC 2008 /
 /

--- a/lib/eclipse/tests/data/integration_tests/SCHEDULE/SCHEDULE_WELLS2
+++ b/lib/eclipse/tests/data/integration_tests/SCHEDULE/SCHEDULE_WELLS2
@@ -11,7 +11,7 @@ DATES             -- 2,3
 /      
 
 WELSPECS 
-     'W_1'        'OP'   30   37  1*       'OIL'  7* /   Crap1
+     'W_1'        'OP'   30   37  1*       'OIL'  3*  'NO'/   Crap1
 -- the spaces around the phase name are intentional!
      'W_2'        'OP'   20   51  100       ' OIL '  7* /   Crap2   Crap3
 -- Note defaulted reference depth for W_3
@@ -130,5 +130,25 @@ DATES              -- 12
 /      
 
 WCONINJE 
-     'W_1'     'WATER'  'SHUT'      'RATE'  20000.000  * 123 678 4* /
+     'W_1'     'WATER'  'OPEN'      'RATE'  20000.000  * 123 678 4* /
+/
+
+DATES              -- 13
+   10  OCT 2008 /
+/
+
+WCONINJE
+     'W_1'     'WATER'  'OPEN'      'RATE'  0.000  * 123 678 4* /
+/
+
+DATES              -- 14
+   10  NOV 2008 /
+/
+
+WCONINJE
+     'W_1'     'WATER'  'OPEN'      'BHP'  2*  100 /
+/
+
+DATES              -- 15
+   10  DEC 2008 /
 /

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -142,6 +142,11 @@ BOOST_AUTO_TEST_CASE(WellTestOpen) {
     auto well3 = sched.getWell( "W_3" );
 
     {
+        auto wells = sched.getOpenWells( 0 );
+        BOOST_CHECK_EQUAL( 0U , wells.size() );
+    }
+
+    {
         auto wells = sched.getOpenWells( 3 );
         BOOST_CHECK_EQUAL( 1U , wells.size() );
         BOOST_CHECK_EQUAL( well1 , wells[0] );

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -158,10 +158,26 @@ BOOST_AUTO_TEST_CASE(WellTestOpen) {
 
     {
         auto wells = sched.getOpenWells(12);
+        BOOST_CHECK_EQUAL( 3U , wells.size() );
+
+        BOOST_CHECK_EQUAL( well2 , wells[1] );
+        BOOST_CHECK_EQUAL( well3 , wells[2] );
+    }
+
+    {
+        auto wells = sched.getOpenWells(13);
         BOOST_CHECK_EQUAL( 2U , wells.size() );
 
         BOOST_CHECK_EQUAL( well2 , wells[0] );
         BOOST_CHECK_EQUAL( well3 , wells[1] );
+    }
+
+    {
+        auto wells = sched.getOpenWells(14);
+        BOOST_CHECK_EQUAL( 3U , wells.size() );
+
+        BOOST_CHECK_EQUAL( well2 , wells[1] );
+        BOOST_CHECK_EQUAL( well3 , wells[2] );
     }
 }
 
@@ -282,12 +298,14 @@ BOOST_AUTO_TEST_CASE(WellTesting) {
         }
 
 
-        BOOST_CHECK_EQUAL( WellCommon::SHUT , well1->getStatus( 12 ));
+        BOOST_CHECK_EQUAL( WellCommon::OPEN , well1->getStatus( 12 ));
         BOOST_CHECK(  well1->getInjectionPropertiesCopy(12).hasInjectionControl(WellInjector::RATE ));
         BOOST_CHECK( !well1->getInjectionPropertiesCopy(12).hasInjectionControl(WellInjector::RESV));
         BOOST_CHECK(  well1->getInjectionPropertiesCopy(12).hasInjectionControl(WellInjector::THP ));
         BOOST_CHECK(  well1->getInjectionPropertiesCopy(12).hasInjectionControl(WellInjector::BHP ));
 
+        BOOST_CHECK_EQUAL( WellCommon::SHUT , well1->getStatus( 13 ));
+        BOOST_CHECK_EQUAL( WellCommon::OPEN , well1->getStatus( 14 ));
     }
 }
 


### PR DESCRIPTION
it must be a limit to turn it off. The old implementation make it impossible to have a injector with only bhp control.

And also, in my understanding, for well control, it always is the time or TSTEP after the `WCON*` keywords. Please correct me if I am wrong. I saw things very differently test cases many times and I always got confused. 