### PR TITLE
Addde keyword SKINPRES

### DIFF
--- a/lib/eclipse/share/keywords/000_Eclipse100/S/SKINPRES
+++ b/lib/eclipse/share/keywords/000_Eclipse100/S/SKINPRES
@@ -1,0 +1,11 @@
+{"name" : "PVTG" , "sections" : ["PROPS"], "num_tables" : {"keyword":"TABDIMS" , "item":"NTPVT"},
+"records" : [
+    [
+       {"name" : "REF_COND", "value_type" : "DOUBLE"}
+    ],
+    [
+       {"name":"GAS_PRESSURE", "value_type" : "DOUBLE", "dimension":"Pressure" },
+       {"name":"DATA", "size_type" : "ALL" , "value_type":"DOUBLE" , "dimension" : ["OilDissolutionFactor","OilDissolutionFactor","Viscosity"]}
+    ]
+  ]
+}

--- a/lib/eclipse/share/keywords/keyword_list.cmake
+++ b/lib/eclipse/share/keywords/keyword_list.cmake
@@ -280,6 +280,7 @@ set( keywords
      000_Eclipse100/S/SGU
      000_Eclipse100/S/SGWFN
      000_Eclipse100/S/SHRATE
+     000_Eclipse100/S/SKINPRES
      000_Eclipse100/S/SKIP
      000_Eclipse100/S/SKIP100
      000_Eclipse100/S/SKIP300


### PR DESCRIPTION
This PR introduces a highty experimental keyword `SKINPRES` which is quite non-standard in *two ways*:

1.  It uses multi record item description. This feature was introduced for the `VFPPROD` and `VFPINJE` keywords, and it works there.

2. It uses the `num_tables` functionality to determine the number of records in keyword, this is only used for the two quite non-triivial keywords `PVTO` and `PVTG`.

The current keyword compiles; but if it is usable for anything I am not certain. I fear that the reference condition record for each item will not be correctly recycled.