### PR TITLE
Prevent linker errors with shared boost unit test libs.

### DIFF
--- a/lib/eclipse/Generator/KeywordGenerator.cpp
+++ b/lib/eclipse/Generator/KeywordGenerator.cpp
@@ -35,6 +35,10 @@
 namespace {
 
 const std::string testHeader =
+    "#include <config.h>\n"
+    "#if HAVE_DYNAMIC_BOOST_TEST\n"
+    "#define BOOST_TEST_DYN_LINK\n"
+    "#endif\n"
     "#define BOOST_TEST_MODULE ParserRecordTests\n"
     "#include <boost/filesystem.hpp>\n"
     "#include <boost/test/unit_test.hpp>\n"

--- a/lib/eclipse/tests/ADDREGTests.cpp
+++ b/lib/eclipse/tests/ADDREGTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 #include <cstdio>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EqualRegTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/AquanconTests.cpp
+++ b/lib/eclipse/tests/AquanconTests.cpp
@@ -17,6 +17,10 @@ You should have received a copy of the GNU General Public License
 along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE AquanconTest
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/AqudimsTests.cpp
+++ b/lib/eclipse/tests/AqudimsTests.cpp
@@ -16,6 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE AQUDIMS_TESTS
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/BoxTests.cpp
+++ b/lib/eclipse/tests/BoxTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <memory>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE BoxManagereTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/COMPSEGUnits.cpp
+++ b/lib/eclipse/tests/COMPSEGUnits.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE COMPSEGUNITS
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/ColumnSchemaTests.cpp
+++ b/lib/eclipse/tests/ColumnSchemaTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ColumnSchemaTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/CompletionSetTests.cpp
+++ b/lib/eclipse/tests/CompletionSetTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE CompletionSetTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/CompletionTests.cpp
+++ b/lib/eclipse/tests/CompletionTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE CompletionTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/CopyRegTests.cpp
+++ b/lib/eclipse/tests/CopyRegTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 #include <cstdio>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE CopyRegTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/DeckTests.cpp
+++ b/lib/eclipse/tests/DeckTests.cpp
@@ -18,9 +18,13 @@
  */
 
 
+#include <config.h>
 #include <stdexcept>
 #include <sstream>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE DeckTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/DynamicStateTests.cpp
+++ b/lib/eclipse/tests/DynamicStateTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE DynamicStateTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/DynamicVectorTests.cpp
+++ b/lib/eclipse/tests/DynamicVectorTests.cpp
@@ -17,8 +17,12 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE DynamicVectorTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/Eclipse3DPropertiesTests.cpp
+++ b/lib/eclipse/tests/Eclipse3DPropertiesTests.cpp
@@ -17,10 +17,14 @@
  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE Eclipse3DPropertiesTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/EclipseGridTests.cpp
+++ b/lib/eclipse/tests/EclipseGridTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 #include <cstdio>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/EclipseStateTests.cpp
+++ b/lib/eclipse/tests/EclipseStateTests.cpp
@@ -17,10 +17,14 @@ You should have received a copy of the GNU General Public License
 along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EclipseStateTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/EqualRegTests.cpp
+++ b/lib/eclipse/tests/EqualRegTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 #include <cstdio>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EqualRegTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/EventTests.cpp
+++ b/lib/eclipse/tests/EventTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EventTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/FaceDirTests.cpp
+++ b/lib/eclipse/tests/FaceDirTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <memory>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE FaceDirTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/FaultTests.cpp
+++ b/lib/eclipse/tests/FaultTests.cpp
@@ -17,9 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE FaultTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/FaultsTests.cpp
+++ b/lib/eclipse/tests/FaultsTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE FaultsTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/FunctionalTests.cpp
+++ b/lib/eclipse/tests/FunctionalTests.cpp
@@ -16,6 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE FunctionalTests
 
 #include <iostream>

--- a/lib/eclipse/tests/GeomodifierTests.cpp
+++ b/lib/eclipse/tests/GeomodifierTests.cpp
@@ -17,9 +17,13 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE GeoModifiersTests
 #include <boost/test/unit_test.hpp>
 

--- a/lib/eclipse/tests/GridPropertyTests.cpp
+++ b/lib/eclipse/tests/GridPropertyTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <memory>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EclipseGridTests
 
 #include <boost/filesystem.hpp>

--- a/lib/eclipse/tests/GroupTests.cpp
+++ b/lib/eclipse/tests/GroupTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE GroupTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/IOConfigTests.cpp
+++ b/lib/eclipse/tests/IOConfigTests.cpp
@@ -19,6 +19,10 @@
 
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE IOConfigTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/InitConfigTest.cpp
+++ b/lib/eclipse/tests/InitConfigTest.cpp
@@ -19,6 +19,10 @@
 
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE InitConfigTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/KeywordLoaderTests.cpp
+++ b/lib/eclipse/tests/KeywordLoaderTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <cstdio>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE InputKeywordTests
 
 #include <boost/filesystem.hpp>

--- a/lib/eclipse/tests/MULTREGTScannerTests.cpp
+++ b/lib/eclipse/tests/MULTREGTScannerTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE MULTREGTScannerTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/MessageContainerTest.cpp
+++ b/lib/eclipse/tests/MessageContainerTest.cpp
@@ -18,6 +18,10 @@
 */
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE MessageContainerTest
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/MessageLimitTests.cpp
+++ b/lib/eclipse/tests/MessageLimitTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE MessageLimitTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/MultiRegTests.cpp
+++ b/lib/eclipse/tests/MultiRegTests.cpp
@@ -17,11 +17,15 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 #include <cstdio>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE MultiRegTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/MultisegmentWellTests.cpp
+++ b/lib/eclipse/tests/MultisegmentWellTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE CompletionSetTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/OrderedMapTests.cpp
+++ b/lib/eclipse/tests/OrderedMapTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ScheduleTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/PORVTests.cpp
+++ b/lib/eclipse/tests/PORVTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE PORVTESTS
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <stdlib.h>
 #include <iostream>
 #include <boost/filesystem.hpp>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParseContextTests
 #include <boost/test/unit_test.hpp>
 

--- a/lib/eclipse/tests/ParserIncludeTests.cpp
+++ b/lib/eclipse/tests/ParserIncludeTests.cpp
@@ -18,6 +18,10 @@
  */
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserTests
 #include <boost/filesystem/path.hpp>
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/ParserTests.cpp
+++ b/lib/eclipse/tests/ParserTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserTests
 #include <boost/test/unit_test.hpp>
 

--- a/lib/eclipse/tests/PvtxTableTests.cpp
+++ b/lib/eclipse/tests/PvtxTableTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE PvtxTableTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/RawKeywordTests.cpp
+++ b/lib/eclipse/tests/RawKeywordTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE RawKeywordTests
 #include <cstring>
 #include <stdexcept>

--- a/lib/eclipse/tests/RestartConfigTests.cpp
+++ b/lib/eclipse/tests/RestartConfigTests.cpp
@@ -19,6 +19,10 @@
 
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE RestartConfigTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/RunspecTests.cpp
+++ b/lib/eclipse/tests/RunspecTests.cpp
@@ -17,6 +17,10 @@ You should have received a copy of the GNU General Public License
 along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE RunspecTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/SatfuncPropertyInitializersTests.cpp
+++ b/lib/eclipse/tests/SatfuncPropertyInitializersTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE SatfuncPropertyInitializersTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/ScheduleTests.cpp
+++ b/lib/eclipse/tests/ScheduleTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ScheduleTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/SectionTests.cpp
+++ b/lib/eclipse/tests/SectionTests.cpp
@@ -18,6 +18,10 @@
  */
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE SectionTests
 
 #include <stdexcept>

--- a/lib/eclipse/tests/SimpleTableTests.cpp
+++ b/lib/eclipse/tests/SimpleTableTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE SimpleTableTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/SimulationConfigTest.cpp
+++ b/lib/eclipse/tests/SimulationConfigTest.cpp
@@ -19,6 +19,10 @@
 
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE SimulationConfigTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/StarTokenTests.cpp
+++ b/lib/eclipse/tests/StarTokenTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserTests
 #include <stdexcept>
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/StringTests.cpp
+++ b/lib/eclipse/tests/StringTests.cpp
@@ -1,3 +1,7 @@
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE StringTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/SummaryConfigTests.cpp
+++ b/lib/eclipse/tests/SummaryConfigTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE SummaryConfigTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/TabdimsTests.cpp
+++ b/lib/eclipse/tests/TabdimsTests.cpp
@@ -16,6 +16,10 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TABDIMS_TESTS
 #include <boost/test/unit_test.hpp>
 

--- a/lib/eclipse/tests/TableColumnTests.cpp
+++ b/lib/eclipse/tests/TableColumnTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TableColumnTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/TableContainerTests.cpp
+++ b/lib/eclipse/tests/TableContainerTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TableContainerTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/TableManagerTests.cpp
+++ b/lib/eclipse/tests/TableManagerTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE SimpleTableTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/TableSchemaTests.cpp
+++ b/lib/eclipse/tests/TableSchemaTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TableSchemaTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/ThresholdPressureTest.cpp
+++ b/lib/eclipse/tests/ThresholdPressureTest.cpp
@@ -19,8 +19,12 @@
 
 
 
+#include <config.h>
 #include <algorithm>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ThresholdPressureTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/TimeMapTest.cpp
+++ b/lib/eclipse/tests/TimeMapTest.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TimeMapTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/TransMultTests.cpp
+++ b/lib/eclipse/tests/TransMultTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE EclipseGridTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/TuningTests.cpp
+++ b/lib/eclipse/tests/TuningTests.cpp
@@ -18,6 +18,10 @@
  */
 
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TuningTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/UnitTests.cpp
+++ b/lib/eclipse/tests/UnitTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE UnitTests
 
 #include <opm/parser/eclipse/Units/UnitSystem.hpp>

--- a/lib/eclipse/tests/ValueTests.cpp
+++ b/lib/eclipse/tests/ValueTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE VALUETESTS
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/WellSolventTests.cpp
+++ b/lib/eclipse/tests/WellSolventTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE WellSolventTests
 
 #include <boost/filesystem.hpp>

--- a/lib/eclipse/tests/WellTests.cpp
+++ b/lib/eclipse/tests/WellTests.cpp
@@ -17,10 +17,14 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
 #include <stdexcept>
 #include <iostream>
 #include <boost/filesystem.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE WellTest
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/integration/BoxTest.cpp
+++ b/lib/eclipse/tests/integration/BoxTest.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE BoxTest
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/integration/CheckDeckValidity.cpp
+++ b/lib/eclipse/tests/integration/CheckDeckValidity.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/lib/eclipse/tests/integration/CompletionsFromDeck.cpp
+++ b/lib/eclipse/tests/integration/CompletionsFromDeck.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE CompletionIntegrationTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/integration/EclipseGridCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/EclipseGridCreateFromDeck.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ScheduleIntegrationTests
 #include <math.h>
 

--- a/lib/eclipse/tests/integration/IOConfigIntegrationTest.cpp
+++ b/lib/eclipse/tests/integration/IOConfigIntegrationTest.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE IOCONFIG_INTEGRATION_TEST
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/lib/eclipse/tests/integration/IncludeTest.cpp
+++ b/lib/eclipse/tests/integration/IncludeTest.cpp
@@ -17,6 +17,10 @@
  along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/lib/eclipse/tests/integration/IntegrationTests.cpp
+++ b/lib/eclipse/tests/integration/IntegrationTests.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>

--- a/lib/eclipse/tests/integration/NNCTests.cpp
+++ b/lib/eclipse/tests/integration/NNCTests.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 #include <opm/parser/eclipse/EclipseState/Grid/NNC.hpp>
 #include <opm/parser/eclipse/Parser/Parser.hpp>
 #include <opm/parser/eclipse/Parser/ParseContext.hpp>
@@ -25,6 +26,9 @@
 #include <opm/parser/eclipse/EclipseState/EclipseState.hpp>
 #include <opm/parser/eclipse/Units/Units.hpp>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE NNCTests
 
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/integration/ParseDATAWithDefault.cpp
+++ b/lib/eclipse/tests/integration/ParseDATAWithDefault.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <math.h>
 

--- a/lib/eclipse/tests/integration/ParseKEYWORD.cpp
+++ b/lib/eclipse/tests/integration/ParseKEYWORD.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserKeywordsIntegrationTests
 #include <boost/algorithm/string/join.hpp>
 #include <boost/test/unit_test.hpp>

--- a/lib/eclipse/tests/integration/Polymer.cpp
+++ b/lib/eclipse/tests/integration/Polymer.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ParserIntegrationTests
 #include <boost/test/unit_test.hpp>
 

--- a/lib/eclipse/tests/integration/ResinsightTest.cpp
+++ b/lib/eclipse/tests/integration/ResinsightTest.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ResinsightIntegrationTests
 #include <boost/test/unit_test.hpp>
 

--- a/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
+++ b/lib/eclipse/tests/integration/ScheduleCreateFromDeck.cpp
@@ -17,6 +17,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE ScheduleIntegrationTests
 #include <math.h>
 

--- a/lib/eclipse/tests/integration/TransMultIntegrationTests.cpp
+++ b/lib/eclipse/tests/integration/TransMultIntegrationTests.cpp
@@ -16,6 +16,10 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE TransMultTests
 #include <boost/test/unit_test.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>

--- a/lib/eclipse/tests/integration/parse_write.cpp
+++ b/lib/eclipse/tests/integration/parse_write.cpp
@@ -17,6 +17,7 @@
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+#include <config.h>
 #include <sstream>
 
 #include <opm/parser/eclipse/Parser/Parser.hpp>

--- a/lib/json/tests/jsonTests.cpp
+++ b/lib/json/tests/jsonTests.cpp
@@ -16,10 +16,14 @@
   You should have received a copy of the GNU General Public License
   along with OPM.  If not, see <http://www.gnu.org/licenses/>.
  */
+#include <config.h>
 #include <stdexcept>
 #include <math.h>
 #include <iostream>
 
+#if HAVE_DYNAMIC_BOOST_TEST
+#define BOOST_TEST_DYN_LINK
+#endif
 #define BOOST_TEST_MODULE jsonParserTests
 #include <boost/test/unit_test.hpp>
 #include <boost/test/test_tools.hpp>


### PR DESCRIPTION
If we are using a shared boost unit test library we need
to define BOOST_TEST_DYN_LINK or we will get linker error
like:
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status

With this commit we do this in the source files of all the tests like in
other modules by checking HAVE_DYNAMIC_BOOST_TEST and if it is defined
setting BOOST_TEST_DYN_LINK.

An alternative approach would be to add BOOST_TEST_DYN_LINK to the compile definitions but
that would be inconsistent with the other modules. (They could do the same of course...)
Closes #1213.