### PR TITLE
Summary missing wells

### DIFF
--- a/lib/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
+++ b/lib/eclipse/EclipseState/SummaryConfig/SummaryConfig.cpp
@@ -170,25 +170,23 @@ inline void keywordW( std::vector< ERT::smspec_node >& list,
                       const Schedule& schedule ) {
 
     const auto type = ECL_SMSPEC_WELL_VAR;
-    static const std::vector< std::string > wildcard = { "*" };
-
     const auto hasValue = []( const DeckKeyword& kw ) {
         return kw.getDataRecord().getDataItem().hasValue( 0 );
     };
 
-    const auto& patterns = keyword.size() > 0 && hasValue( keyword )
-                         ? keyword.getStringData()
-                         : wildcard;
+    if (keyword.size() && hasValue(keyword)) {
+        for( const std::string& pattern : keyword.getStringData()) {
+            auto wells = schedule.getWellsMatching( pattern );
 
-    for( const std::string& pattern : patterns ) {
-        auto wells = schedule.getWellsMatching( pattern );
+            if( wells.empty() )
+                handleMissingWell( parseContext, keyword.name(), pattern );
 
-        if( wells.empty() )
-            handleMissingWell( parseContext, keyword.name(), pattern );
-
-        for( const auto* well : wells )
-            list.emplace_back( type, well->name(), keyword.name() );
-    }
+            for( const auto* well : wells )
+                list.emplace_back( type, well->name(), keyword.name() );
+        }
+    } else
+        for (const auto* well : schedule.getWells())
+            list.emplace_back(type, well->name(), keyword.name());
 }
 
 inline void keywordG( std::vector< ERT::smspec_node >& list,

--- a/lib/eclipse/Parser/ParseContext.cpp
+++ b/lib/eclipse/Parser/ParseContext.cpp
@@ -68,23 +68,23 @@ namespace Opm {
     }
 
     void ParseContext::initDefault() {
-        addKey(PARSE_EXTRA_RECORDS);
-        addKey(PARSE_UNKNOWN_KEYWORD);
-        addKey(PARSE_RANDOM_TEXT);
-        addKey(PARSE_RANDOM_SLASH);
-        addKey(PARSE_MISSING_DIMS_KEYWORD);
-        addKey(PARSE_EXTRA_DATA);
-        addKey(PARSE_MISSING_INCLUDE);
+        addKey(PARSE_EXTRA_RECORDS, InputError::THROW_EXCEPTION);
+        addKey(PARSE_UNKNOWN_KEYWORD, InputError::THROW_EXCEPTION);
+        addKey(PARSE_RANDOM_TEXT, InputError::THROW_EXCEPTION);
+        addKey(PARSE_RANDOM_SLASH, InputError::THROW_EXCEPTION);
+        addKey(PARSE_MISSING_DIMS_KEYWORD, InputError::THROW_EXCEPTION);
+        addKey(PARSE_EXTRA_DATA, InputError::THROW_EXCEPTION);
+        addKey(PARSE_MISSING_INCLUDE, InputError::THROW_EXCEPTION);
 
-        addKey(UNSUPPORTED_SCHEDULE_GEO_MODIFIER);
-        addKey(UNSUPPORTED_COMPORD_TYPE);
-        addKey(UNSUPPORTED_INITIAL_THPRES);
-        addKey(UNSUPPORTED_TERMINATE_IF_BHP);
+        addKey(UNSUPPORTED_SCHEDULE_GEO_MODIFIER, InputError::THROW_EXCEPTION);
+        addKey(UNSUPPORTED_COMPORD_TYPE, InputError::THROW_EXCEPTION);
+        addKey(UNSUPPORTED_INITIAL_THPRES, InputError::THROW_EXCEPTION);
+        addKey(UNSUPPORTED_TERMINATE_IF_BHP, InputError::THROW_EXCEPTION);
 
-        addKey(INTERNAL_ERROR_UNINITIALIZED_THPRES);
+        addKey(INTERNAL_ERROR_UNINITIALIZED_THPRES, InputError::THROW_EXCEPTION);
 
-        addKey(SUMMARY_UNKNOWN_WELL);
-        addKey(SUMMARY_UNKNOWN_GROUP);
+        addKey(SUMMARY_UNKNOWN_WELL, InputError::THROW_EXCEPTION);
+        addKey(SUMMARY_UNKNOWN_GROUP, InputError::THROW_EXCEPTION);
     }
 
     void ParseContext::initEnv() {
@@ -126,14 +126,12 @@ namespace Opm {
 
     ParseContext ParseContext::withKey(const std::string& key, InputError::Action action) const {
         ParseContext pc(*this);
-        pc.addKey(key);
-        pc.updateKey(key, action);
+        pc.addKey(key, action);
         return pc;
     }
 
     ParseContext& ParseContext::withKey(const std::string& key, InputError::Action action) {
-        this->addKey(key);
-        this->updateKey(key, action);
+        this->addKey(key, action);
         return *this;
     }
 
@@ -145,12 +143,12 @@ namespace Opm {
     }
 
 
-    void ParseContext::addKey(const std::string& key) {
+    void ParseContext::addKey(const std::string& key, InputError::Action default_action) {
         if (key.find_first_of("|:*") != std::string::npos)
             throw std::invalid_argument("The ParseContext keys can not contain '|', '*' or ':'");
 
         if (!hasKey(key))
-            m_errorContexts.insert( std::pair<std::string , InputError::Action>( key , InputError::THROW_EXCEPTION ));
+            m_errorContexts.insert( std::pair<std::string , InputError::Action>( key , default_action));
     }
 
 

--- a/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/Parser/ParseContext.hpp
@@ -98,7 +98,7 @@ namespace Opm {
           want a different value you must subsequently call the update
           method.
         */
-        void addKey(const std::string& key);
+      void addKey(const std::string& key, InputError::Action default_action);
         /*
           The PARSE_EXTRA_RECORDS field regulates how the parser 
           responds to keywords whose size has been defined in the 

--- a/lib/eclipse/tests/ParseContextTests.cpp
+++ b/lib/eclipse/tests/ParseContextTests.cpp
@@ -390,8 +390,8 @@ BOOST_AUTO_TEST_CASE(TestCOMPORD) {
 
 BOOST_AUTO_TEST_CASE(TestInvalidKey) {
     ParseContext parseContext;
-    BOOST_CHECK_THROW( parseContext.addKey("KEY*") , std::invalid_argument );
-    BOOST_CHECK_THROW( parseContext.addKey("KEY:") , std::invalid_argument );
+    BOOST_CHECK_THROW( parseContext.addKey("KEY*", InputError::THROW_EXCEPTION) , std::invalid_argument );
+    BOOST_CHECK_THROW( parseContext.addKey("KEY:", InputError::THROW_EXCEPTION) , std::invalid_argument );
 }
 
 
@@ -399,11 +399,11 @@ BOOST_AUTO_TEST_CASE(TestNew) {
     ParseContext parseContext;
 
     BOOST_CHECK_EQUAL( false , parseContext.hasKey("NO"));
-    parseContext.addKey("NEW_KEY");
+    parseContext.addKey("NEW_KEY", InputError::THROW_EXCEPTION);
     BOOST_CHECK_EQUAL( true , parseContext.hasKey("NEW_KEY"));
     BOOST_CHECK_THROW( parseContext.get("NO") , std::invalid_argument );
     BOOST_CHECK_EQUAL( parseContext.get("NEW_KEY") , InputError::THROW_EXCEPTION );
-    parseContext.addKey("KEY2");
+    parseContext.addKey("KEY2", InputError::THROW_EXCEPTION);
     BOOST_CHECK_EQUAL( parseContext.get("NEW_KEY") , InputError::THROW_EXCEPTION );
 
     BOOST_CHECK_THROW( parseContext.updateKey("NO" , InputError::IGNORE) , std::invalid_argument);
@@ -416,9 +416,9 @@ BOOST_AUTO_TEST_CASE(TestNew) {
     BOOST_CHECK_EQUAL( parseContext.get("NEW_KEY") , InputError::IGNORE );
     BOOST_CHECK_EQUAL( parseContext.get("KEY2") , InputError::IGNORE );
 
-    parseContext.addKey("SECRET_KEY");
-    parseContext.addKey("NEW_KEY2");
-    parseContext.addKey("NEW_KEY3");
+    parseContext.addKey("SECRET_KEY", InputError::THROW_EXCEPTION);
+    parseContext.addKey("NEW_KEY2", InputError::THROW_EXCEPTION);
+    parseContext.addKey("NEW_KEY3", InputError::THROW_EXCEPTION);
     parseContext.update("NEW_KEY*" , InputError::WARN);
     BOOST_CHECK_EQUAL( parseContext.get("NEW_KEY") , InputError::WARN );
     BOOST_CHECK_EQUAL( parseContext.get("NEW_KEY2") , InputError::WARN );


### PR DESCRIPTION
Will handle keywords like:
```
WWCT
/
```
in the summary section without complaining - even for decks without wells.

Observe that the second commit implies policy change, now the default behaviour for error condition `SUMMARY_UNKNOWN_WELL`is to completely ignore it. This is a policy change, the behaviour with respect to the
```
WWCT
/
``` 
configuration does *not* require this change of policy.

