### PR TITLE
Silence warning.

### DIFF
--- a/lib/eclipse/EclipseState/AquiferCT.cpp
+++ b/lib/eclipse/EclipseState/AquiferCT.cpp
@@ -66,12 +66,12 @@ namespace Opm {
         return m_aquct;
     }
 
-    const int AquiferCT::getAqInflTabID(size_t aquiferIndex)
+    int AquiferCT::getAqInflTabID(size_t aquiferIndex)
     {
         return m_aquct.at(aquiferIndex).inftableID;
     }
 
-    const int AquiferCT::getAqPvtTabID(size_t aquiferIndex)
+    int AquiferCT::getAqPvtTabID(size_t aquiferIndex)
     {
         return m_aquct.at(aquiferIndex).pvttableID;
     }

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/AquiferCT.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/AquiferCT.hpp
@@ -66,8 +66,8 @@ namespace Opm {
             AquiferCT(const EclipseState& eclState, const Deck& deck);
 
             const std::vector<AquiferCT::AQUCT_data>& getAquifers() const;
-            const int getAqInflTabID(size_t aquiferIndex);
-            const int getAqPvtTabID(size_t aquiferIndex);
+            int getAqInflTabID(size_t aquiferIndex);
+            int getAqPvtTabID(size_t aquiferIndex);
     
         private:
   


### PR DESCRIPTION
Another minor warning squashing: unlike returning const references, returning const values is no different from returning a non-const value.