### PR TITLE
Remove json library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,20 +99,6 @@ macro (prereqs_hook)
 endmacro (prereqs_hook)
 
 macro (sources_hook)
-  # Add json library
-  set(opmjson_SOURCES lib/json/JsonObject.cpp)
-  if(NOT cjson_FOUND)
-    list(APPEND opmjson_SOURCES ${PROJECT_SOURCE_DIR}/external/cjson/cJSON.c)
-  endif()
-  add_library(opmjson ${opmjson_SOURCES})
-  target_link_libraries(opmjson PUBLIC ${Boost_FILESYSTEM_LIBRARY})
-  if(cjson_FOUND)
-    target_link_libraries(opmjson PUBLIC ${CJSON_LIBRARIES})
-  else()
-    target_include_directories(opmjson PRIVATE ${PROJECT_SOURCE_DIR}/external/cjson)
-  endif()
-  list(APPEND opm-parser_LIBRARIES opmjson ecl)
-
   # Keyword generation
   include(GenerateKeywords.cmake)
 
@@ -137,7 +123,6 @@ macro (install_hook)
           PATTERN *.hpp
   )
   install(DIRECTORY lib/json/include/ DESTINATION include)
-  set(opm-parser_EXTRA_TARGETS opmjson)
 endmacro (install_hook)
 
 include (OpmLibMain)

--- a/CMakeLists_files.cmake
+++ b/CMakeLists_files.cmake
@@ -2,6 +2,7 @@
 # vim: set filetype=cmake autoindent tabstop=2 shiftwidth=2 noexpandtab softtabstop=2 nowrap:
 
 list(APPEND MAIN_SOURCE_FILES
+  lib/json/JsonObject.cpp
   lib/eclipse/Deck/Deck.cpp
   lib/eclipse/Deck/DeckItem.cpp
   lib/eclipse/Deck/DeckKeyword.cpp
@@ -86,6 +87,10 @@ list(APPEND MAIN_SOURCE_FILES
   lib/eclipse/Utility/Functional.cpp
   lib/eclipse/Utility/Stringview.cpp
 )
+
+if(NOT cjson_FOUND)
+  list(APPEND MAIN_SOURCE_FILES external/cjson/cJSON.c)
+endif()
 
 # For now, we use full directory installs from install_hook
 list (APPEND PUBLIC_HEADER_FILES

--- a/ExtraTests.cmake
+++ b/ExtraTests.cmake
@@ -103,6 +103,6 @@ endif()
 # JSON tests
 opm_add_test(jsonTests
              SOURCES lib/json/tests/jsonTests.cpp
-             LIBRARIES ${TEST_LIBS} opmjson
+             LIBRARIES ${TEST_LIBS}
              TEST_ARGS ${PROJECT_SOURCE_DIR}/lib/json/tests/example1.json)
 list(APPEND EXTRA_TESTS jsonTests)

--- a/GenerateKeywords.cmake
+++ b/GenerateKeywords.cmake
@@ -1,4 +1,5 @@
-set(genkw_SOURCES lib/eclipse/Parser/createDefaultKeywordList.cpp
+set(genkw_SOURCES lib/json/JsonObject.cpp
+                  lib/eclipse/Parser/createDefaultKeywordList.cpp
                   lib/eclipse/Deck/Deck.cpp
                   lib/eclipse/Deck/DeckItem.cpp
                   lib/eclipse/Deck/DeckKeyword.cpp
@@ -19,9 +20,12 @@ set(genkw_SOURCES lib/eclipse/Parser/createDefaultKeywordList.cpp
                   lib/eclipse/Units/UnitSystem.cpp
                   lib/eclipse/Utility/Stringview.cpp
 )
+if(NOT cjson_FOUND)
+  list(APPEND genkw_SOURCES external/cjson/cJSON.c)
+endif()
 add_executable(genkw ${genkw_SOURCES})
 
-target_link_libraries(genkw opmjson ecl Boost::regex Boost::filesystem Boost::system)
+target_link_libraries(genkw ecl Boost::regex Boost::filesystem Boost::system)
 target_include_directories(genkw PRIVATE lib/eclipse/include
                                          lib/json/include)
 

--- a/debian/control
+++ b/debian/control
@@ -6,7 +6,7 @@ Build-Depends: build-essential, debhelper (>= 9), pkg-config, libopm-common-dev,
                libecl-dev, git, libtool, doxygen, libboost-date-time-dev,
                texlive-latex-extra, texlive-latex-recommended, ghostscript,
                libboost-system-dev, libboost-test-dev, libboost-regex-dev,
-               libblas-dev, liblapack-dev
+               libblas-dev, liblapack-dev, libopm-common-dev
 Standards-Version: 3.9.2
 Section: libs
 Homepage: http://opm-project.org

--- a/debian/libopm-parser1-dev.install
+++ b/debian/libopm-parser1-dev.install
@@ -1,6 +1,5 @@
 usr/include/*
-usr/share/opm-parser/*
 usr/lib/*/libopm*.so
 usr/lib/dunecontrol/*
-usr/lib/*/cmake/opm-parser/*
-usr/lib/pkgconfig/*
+usr/share/cmake/opm-parser/*
+usr/lib/*/pkgconfig/*


### PR DESCRIPTION
This removes the opmjson library, instead opting for compiling the sources twice (one for generator, one for main library). less hassle.

the second commit fixes debian packaging and thus restores nightly builds.