### PR TITLE
[NO MERGE] small fixes of the pvtables.

### DIFF
--- a/lib/eclipse/EclipseState/Tables/Tables.cpp
+++ b/lib/eclipse/EclipseState/Tables/Tables.cpp
@@ -92,14 +92,14 @@ PvtgTable::PvtgTable( const DeckKeyword& keyword, size_t tableIdx ) :
     }
 
 PvtoTable::PvtoTable( const DeckKeyword& keyword, size_t tableIdx) :
-    PvtxTable("P") {
+    PvtxTable("RS") {
         m_underSaturatedSchema.addColumn( ColumnSchema( "P"  , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ));
-        m_underSaturatedSchema.addColumn( ColumnSchema( "BO" , Table::RANDOM , Table::DEFAULT_LINEAR ));
+        m_underSaturatedSchema.addColumn( ColumnSchema( "BO" , Table::STRICTLY_DECREASING, Table::DEFAULT_LINEAR ));
         m_underSaturatedSchema.addColumn( ColumnSchema( "MU" , Table::RANDOM , Table::DEFAULT_LINEAR ));
 
         m_saturatedSchema.addColumn( ColumnSchema( "RS" , Table::STRICTLY_INCREASING , Table::DEFAULT_NONE ));
         m_saturatedSchema.addColumn( ColumnSchema( "P"  , Table::RANDOM , Table::DEFAULT_NONE ));
-        m_saturatedSchema.addColumn( ColumnSchema( "BO" , Table::RANDOM , Table::DEFAULT_LINEAR ));
+        m_saturatedSchema.addColumn( ColumnSchema( "BO" , Table::STRICTLY_INCREASING, Table::DEFAULT_LINEAR ));
         m_saturatedSchema.addColumn( ColumnSchema( "MU" , Table::RANDOM , Table::DEFAULT_LINEAR ));
 
         PvtxTable::init(keyword , tableIdx);

--- a/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
+++ b/lib/eclipse/include/opm/parser/eclipse/EclipseState/Tables/SimpleTable.hpp
@@ -64,8 +64,6 @@ namespace Opm {
         void assertJFuncPressure(const bool jf) const;
 
     protected:
-        std::map<std::string, size_t> m_columnNames;
-        std::vector<std::vector<bool> > m_valueDefaulted;
         TableSchema m_schema;
         OrderedMap<TableColumn> m_columns;
         bool m_jfunc = false;

--- a/lib/eclipse/tests/integration/ParseKEYWORD.cpp
+++ b/lib/eclipse/tests/integration/ParseKEYWORD.cpp
@@ -839,19 +839,19 @@ TABDIMS
 
 PVTO
 --   Rs       PO           BO           MUO
-     1e-3     1            1.01         1.02
+     1e-3     1            1.20        1.02
               250          1.15         0.95
-              500          1.20         0.93 /
-     1e-2     14.8         1.05         1.03
+              500          1.01        0.93 /
+     1e-2     14.8         1.30        1.03
               251          1.25         0.98
-              502          1.30         0.95 /
+              502          1.05         0.95 /
 /
-     1e-1     1.1          1.02         1.03
+     1e-1     1.1          1.21         1.03
               253          1.16         0.96
-              504          1.21         0.97 /
-     1e00     15           1.06         1.04
+              504          1.02         0.97 /
+     1e00     15           1.31         1.04
               255          1.26         0.99
-              506          1.31         0.96 /
+              506          1.06         0.96 /
 /
 )";
 
@@ -905,8 +905,8 @@ PVTO
 
     BOOST_CHECK_EQUAL( 3, table0.numRows());
     BOOST_CHECK_EQUAL( 3, table0.numColumns());
-    BOOST_CHECK_EQUAL( BO.front( ) , 1.01 );
-    BOOST_CHECK_EQUAL( BO.back( ) , 1.20 );
+    BOOST_CHECK_EQUAL( BO.front( ) , 1.20 );
+    BOOST_CHECK_EQUAL( BO.back( ) , 1.01 );
 
     BOOST_CHECK_CLOSE(1.15 , table0.evaluate( "BO" , 250*1e5 ) , 1e-6);
 


### PR DESCRIPTION
some rules are from testing output. 

I removed 
```
-        std::map<std::string, size_t> m_columnNames;
-        std::vector<std::vector<bool> > m_valueDefaulted;
```
from `SimpleTable`, potentially to reduce some confusion, since they are not used. 

This PR is created for testing purpose, please do not merge. 