### PR TITLE
[WIP] VFP number is always read for WCONINJE

### DIFF
--- a/lib/eclipse/EclipseState/Schedule/Schedule.cpp
+++ b/lib/eclipse/EclipseState/Schedule/Schedule.cpp
@@ -601,10 +601,11 @@ namespace Opm {
 
                 if (!record.getItem("THP").defaultApplied(0)) {
                     properties.THPLimit       = record.getItem("THP").getSIDouble(0);
-                    properties.VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
                     properties.addInjectionControl(WellInjector::THP);
                 } else
                     properties.dropInjectionControl(WellInjector::THP);
+
+                properties.VFPTableNumber = record.getItem("VFP_TABLE").get< int >(0);
 
                 /*
                   There is a sensible default BHP limit defined, so the BHPLimit can be

--- a/lib/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
+++ b/lib/eclipse/EclipseState/Schedule/WellProductionProperties.cpp
@@ -103,8 +103,14 @@ namespace Opm {
         };
 
         for( const auto& cmode : modes ) {
-            if( !record.getItem( cmode.first ).defaultApplied( 0 ) )
-                 p.addProductionControl( cmode.second );
+            if( !record.getItem( cmode.first ).defaultApplied( 0 ) ) {
+
+                // a zero value THP limit will not be handled as a THP limit
+                if (cmode.first == "THP" && p.THPLimit == 0.)
+                    continue;
+
+                p.addProductionControl( cmode.second );
+            }
         }
 
         // There is always a BHP constraint, when not specified, will use the default value


### PR DESCRIPTION
and a zero-value THP limit for WCONPROD will not be treated as a THP limit.

The history matching part is slightly more tricky, was not handled by this PR yet. 